### PR TITLE
fix: use correct paths to Dockerfiles

### DIFF
--- a/tools/docker-bake.hcl
+++ b/tools/docker-bake.hcl
@@ -7,8 +7,14 @@ group "default" {
 // For docker/metadata-action
 target "docker-metadata-action-scenario-simulator" {}
 
+target "visualizer" {
+  inherits = ["docker-metadata-action-visualizer"]
+  dockerfile = "tools/visualizer/Dockerfile"
+  target = "visualizer"
+}
+
 target "scenario-simulator" {
   inherits = ["docker-metadata-action-scenario-simulator"]
-  dockerfile = "docker/tools/scenario-simulator/Dockerfile"
+  dockerfile = "tools/scenario-simulator/Dockerfile"
   target = "scenario-simulator"
 }


### PR DESCRIPTION
## Description

The paths in the `docker-bake.hcl` point to `Dockerfile`s that do not exist. The changes here match the pattern of other bake files in the repo.

## How was this PR tested?

## Notes for reviewers

Depends on #34 

## Effects on system behavior

None.
