### PR TITLE
Enhance documentation and deployment configurations for Open AD Kit

### DIFF
--- a/.github/workflows/build-all-images.yaml
+++ b/.github/workflows/build-all-images.yaml
@@ -3,6 +3,17 @@ name: build-all-images
 on:
   push:
     branches: [main]
+    paths:
+      - 'components/docker-bake.hcl'
+      - 'components/common/**'
+      - 'components/sensing-perception/**'
+      - 'components/localization-mapping/**'
+      - 'components/planning-control/**'
+      - 'components/vehicle-system/**'
+      - 'components/api/**'
+      - 'components/visualizer/**'
+      - 'components/simulator/**'
+      - 'components/universe/**'
   workflow_dispatch:
 
 env:

--- a/README.md
+++ b/README.md
@@ -20,9 +20,15 @@ Open AD Kit aims to democratize autonomous drive (AD) systems by bringing the cl
 
 The Autoware Foundation is a voting member of the [SOAFEE (Scalable Open Architecture For the Embedded Edge)](https://soafee.io/) initiative, as the Autoware Open AD Kit is the first SOAFEE blueprint for the software defined vehicle ecosystem.
 
+### Quick Links
+
+- **[Getting Started](https://autowarefoundation.github.io/openadkit/getting-started/)**
+- **[Documentation](https://autowarefoundation.github.io/openadkit/)**
+- **[Contributing](https://autowarefoundation.github.io/openadkit/contributing/)**
+
 ## Key Features
 
-### Granular Components
+### Modular Components
 
 Open AD Kit is a micro-service based project, which means that it is designed to be deployed on a variety of platforms with microservices architecture. Each component is designed to be independent and can be deployed on a variety of platforms.
 
@@ -61,31 +67,3 @@ Open AD Kit envisions an always connected, complete autonomous driving developme
 - **Continuous testing** in containerized environments
 
 ![Connected and Continuous](docs/assets/images/connected-continuous.png)
-
-## Roadmap
-
-```mermaid
-graph LR
-    A[Q2/2025<br/>Open AD Kit components and tools definition]
-    B[Q3/2025<br/>Modular Autoware components]
-    C[Q4/2025<br/>Configurable components for use cases]
-    D[Q1/2026<br/>Component orchestration support]
-
-    A --> B --> C --> D;
-
-    classDef p1 fill:#0d2c54,stroke:#333,stroke-width:2px,color:#fff,font-weight:bold;
-    classDef p2 fill:#2d6a8b,stroke:#333,stroke-width:2px,color:#fff,font-weight:bold;
-    classDef p3 fill:#3690c0,stroke:#333,stroke-width:2px,color:#fff,font-weight:bold;
-    classDef p4 fill:#673ab7,stroke:#333,stroke-width:2px,color:#fff,font-weight:bold;
-
-    class A p1;
-    class B p2;
-    class C p3;
-    class D p4;
-```
-
-## Getting Started
-
-- **[Getting Started](https://autowarefoundation.github.io/openadkit/getting-started/)**
-- **[Documentation](https://autowarefoundation.github.io/openadkit/)**
-- **[Contributing](https://autowarefoundation.github.io/openadkit/contributing/)**

--- a/components/visualizer/etc/visualizer_entrypoint.sh
+++ b/components/visualizer/etc/visualizer_entrypoint.sh
@@ -4,8 +4,8 @@
 
 # Check if RVIZ_CONFIG is provided
 if [ -z "$RVIZ_CONFIG" ]; then
-    echo -e "\e[31mRVIZ_CONFIG is not set defaulting to /autoware/rviz/autoware.rviz\e[0m"
-    RVIZ_CONFIG="/autoware/rviz/autoware.rviz"
+    echo -e "\e[31mRVIZ_CONFIG is not set defaulting to /opt/autoware/share/autoware_launch/rviz/autoware.rviz\e[0m"
+    RVIZ_CONFIG="/opt/autoware/share/autoware_launch/rviz/autoware.rviz"
     export RVIZ_CONFIG
 fi
 
@@ -90,9 +90,11 @@ source "/opt/autoware/setup.bash"
 
 # Execute passed command if provided, otherwise launch rviz2
 if [ "$REMOTE_DISPLAY" == "false" ]; then
+    echo "Launching local rviz2 display"
     [ $# -eq 0 ] && rviz2 -d "$RVIZ_CONFIG" --ros-args -p use_sim_time:="$USE_SIM_TIME"
     exec "$@"
 else
+    echo "Launching remote rviz2 display"
     configure_vnc
     [ $# -eq 0 ] && sleep infinity
     exec "$@"

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -2,5 +2,8 @@
 
 This directory contains deployment configurations for **Open AD Kit**. Each folder contains a README file with detailed instructions on how to deploy the deployment configuration.
 
-- [Samples](./samples): Sample deployment configurations for development and testing.
-- [Demos](./demos): Demo deployment configurations with specific use case scenarios.
+- **Sample deployment** configurations for development and testing.
+  - [Planning Simulation](./samples/planning-simulation): Simple Open AD Kit deployment that demonstrates the autoware **planning features** with planning simulation.
+  - [Logging Simulation](./samples/logging-simulation): Simple Open AD Kit deployment that demonstrates the autoware **end-to-end functionality** with sensor simulation using rosbag.
+- **Demo deployment** configurations with specific use case scenarios.
+  - [Zenoh Bridge](./demos/zenoh-bridge): A demo of remote visualization with Zenoh bridge. See [Zenoh Bridge Document](openadkit-dev/docs/deployments/zenoh-bridge/index.md) for more details.

--- a/deployments/demos/README.md
+++ b/deployments/demos/README.md
@@ -1,5 +1,0 @@
-# Demo Deployments
-
-This directory contains demo deployment configurations for Open AD Kit that are specific to certain use cases.
-
-* [zenoh-bridge](./zenoh-bridge/README.md): A demo of remote visualization with Zenoh bridge. See [Zenoh Bridge Document](openadkit-dev/docs/deployments/zenoh-bridge/index.md) for more details.

--- a/deployments/samples/README.md
+++ b/deployments/samples/README.md
@@ -1,7 +1,0 @@
-# Sample Deployments
-
-This directory contains sample **Open AD Kit** deployment configurations to help you get started. Each folder contains a README file with detailed instructions on how to deploy the deployment configuration.
-
-- [Planning Simulation](./planning-simulation/README.md): Simple Open AD Kit deployment that demonstrates the autoware **planning features** with planning simulation.
-
-- [Logging Simulation](./logging-simulation/README.md): Simple Open AD Kit deployment that demonstrates the autoware **end-to-end functionality** with sensor simulation using rosbag.

--- a/deployments/samples/logging-simulation/README.md
+++ b/deployments/samples/logging-simulation/README.md
@@ -1,10 +1,6 @@
-# Autoware Logging Simulation
+# Autoware Open AD Kit Logging Simulation
 
-This sample deployment shows how to run autoware **logging simulation**.
-
-- **autoware**: Autoware monolithic container for development and deployment.
-- **rosbag**: Rosbag container for Autoware sensor simulation with rosbag data.
-- **visualizer**: RViz-based remote operation and visualization container for Autoware.
+This sample deployment shows how to run Autoware Open AD Kit **logging simulation**.
 
 ## Requirements
 
@@ -41,7 +37,7 @@ unzip -d ~/autoware_map/ ~/autoware_map/sample-rosbag.zip
 1. Start the deployment by running the following command:
 
     ```bash
-    docker compose up -d
+    docker compose --env-file logging-simulation.env up -d
     ```
 
 2. Open a browser to visualize the simulation and navigate to:
@@ -61,7 +57,7 @@ unzip -d ~/autoware_map/ ~/autoware_map/sample-rosbag.zip
 3. To start the logging simulation, you should run the following command to play the rosbag:
 
     ```bash
-    docker compose up rosbag -d
+    docker compose --env-file logging-simulation.env up rosbag -d
     ```
 
 ## Stop the Deployment

--- a/deployments/samples/logging-simulation/docker-compose.yaml
+++ b/deployments/samples/logging-simulation/docker-compose.yaml
@@ -24,8 +24,8 @@ services:
     container_name: autoware-planning
     network_mode: host
     init: true
-    ipc: host
     pid: service:map
+    ipc: host
     environment:
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
@@ -47,8 +47,8 @@ services:
     container_name: autoware-vehicle
     network_mode: host
     init: true
-    ipc: host
     pid: service:map
+    ipc: host
     environment:
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
@@ -69,8 +69,8 @@ services:
     container_name: autoware-system
     network_mode: host
     init: true
-    ipc: host
     pid: service:map
+    ipc: host
     environment:
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
@@ -81,6 +81,81 @@ services:
       launch_system_monitor:=${LAUNCH_SYSTEM_MONITOR}
       launch_dummy_diag_publisher:=${LAUNCH_DUMMY_DIAG_PUBLISHER}
       sensor_model:=${SENSOR_MODEL}
+      system_run_mode:=${SYSTEM_RUN_MODE}
+      use_sim_time:=${USE_SIM_TIME}
+      vehicle_model:=${VEHICLE_MODEL}
+    restart: on-failure
+
+  sensing:
+    image: ${SENSING_PERCEPTION_IMAGE}
+    container_name: autoware-sensing
+    network_mode: host
+    init: true
+    pid: service:map
+    ipc: host
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+    volumes:
+      - ${DATA_PATH}:/autoware_data:rw
+    depends_on:
+      - map
+      - system
+    command: >
+      ros2 launch autoware_launch tier4_sensing_component.launch.xml
+      launch_pointcloud_container:=${LAUNCH_POINTCLOUD_CONTAINER_SENSING}
+      launch_sensing_driver:=${LAUNCH_SENSING_DRIVER}
+      pointcloud_container_name:=${POINTCLOUD_CONTAINER_NAME}
+      sensor_model:=${SENSOR_MODEL}
+      use_sim_time:=${USE_SIM_TIME}
+      vehicle_model:=${VEHICLE_MODEL}
+    restart: on-failure
+  
+  perception:
+    image: ${SENSING_PERCEPTION_IMAGE}
+    container_name: autoware-perception
+    network_mode: host
+    init: true
+    pid: service:map
+    ipc: host
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+    volumes:
+      - ${DATA_PATH}:/autoware_data:rw
+    depends_on:
+      - map
+      - system
+      - sensing
+    command: >
+      ros2 launch autoware_launch tier4_perception_component.launch.xml
+      data_path:=/autoware_data
+      launch_pointcloud_container:=${LAUNCH_POINTCLOUD_CONTAINER_PERCEPTION}
+      lidar_detection_model:=${LIDAR_DETECTION_MODEL}
+      occupancy_grid_map_method:=${OCCUPANCY_GRID_MAP_METHOD}
+      perception_mode:=${PERCEPTION_MODE}
+      pointcloud_container_name:=${POINTCLOUD_CONTAINER_NAME}
+      use_sim_time:=${USE_SIM_TIME}
+      vehicle_model:=${VEHICLE_MODEL}
+    restart: on-failure
+    
+  localization:
+    image: ghcr.io/autowarefoundation/openadkit:localization-mapping
+    container_name: autoware-localization
+    network_mode: host
+    init: true
+    pid: service:map
+    ipc: host
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+    depends_on:
+      - map
+      - system
+      - sensing
+      - perception
+    command: >
+      ros2 launch autoware_launch tier4_localization_component.launch.xml
       system_run_mode:=${SYSTEM_RUN_MODE}
       use_sim_time:=${USE_SIM_TIME}
       vehicle_model:=${VEHICLE_MODEL}
@@ -117,8 +192,8 @@ services:
     container_name: autoware-simulator
     network_mode: host
     init: true
-    ipc: host
     pid: service:map
+    ipc: host
     environment:
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
@@ -152,8 +227,8 @@ services:
     container_name: autoware-api
     network_mode: host
     init: true
-    ipc: host
     pid: service:map
+    ipc: host
     environment:
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
@@ -171,8 +246,8 @@ services:
     image: ghcr.io/autowarefoundation/openadkit:visualizer
     network_mode: host
     init: true
-    ipc: host
     pid: service:map
+    ipc: host
     ports:
       - 6080:6080
     environment:
@@ -180,3 +255,22 @@ services:
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
       - RVIZ_CONFIG=${RVIZ_CONFIG}
       - USE_SIM_TIME=${USE_SIM_TIME}
+  
+  rosbag:
+    image: ghcr.io/autowarefoundation/openadkit:universe
+    container_name: autoware-rosbag
+    network_mode: host
+    init: true
+    pid: service:map
+    ipc: host
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+    volumes:
+      - ${ROSBAG_PATH}:/autoware_map/rosbag:ro
+    command: >
+      bash -c "ros2 bag info /autoware_map/rosbag -s ${ROSBAG_FORMAT} &&
+      ros2 bag play /autoware_map/rosbag -r ${ROSBAG_RATE} -s ${ROSBAG_FORMAT}"
+    restart: "no"
+    profiles:
+      - rosbag

--- a/deployments/samples/planning-simulation/README.md
+++ b/deployments/samples/planning-simulation/README.md
@@ -1,9 +1,6 @@
-# Autoware Planning Simulation
+# Autoware Open AD Kit Planning Simulation
 
-This sample deployment shows how to run autoware **planning simulation**.
-
-- **autoware**: Autoware monolithic container for development and deployment.
-- **visualizer**: RViz-based remote operation and visualization container for Autoware.
+This sample deployment shows how to run Autoware Open AD Kit **planning simulation**.
 
 ## Requirements
 
@@ -27,7 +24,7 @@ unzip -d ~/autoware_map ~/autoware_map/sample-map-planning.zip
 1. Start the deployment by running the following command:
 
     ```bash
-    docker compose up -d
+    docker compose --env-file planning-simulation.env up -d
     ```
 
 2. Open a browser to visualize the simulation and navigate to:


### PR DESCRIPTION
- Updated README.md to include quick links for Getting Started, Documentation, and Contributing.
- Changed "Granular Components" to "Modular Components" in the Key Features section.
- Improved deployment README files to clarify sample and demo configurations.
- Added detailed instructions for running logging and planning simulations.
- Updated build-all-images workflow to trigger on changes in specific component directories.
- Refined visualizer entrypoint script to provide clearer default RVIZ_CONFIG paths and display messages.

## Description

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
