### PR TITLE
fix(ci): correct build-all-images workflow triggers

### DIFF
--- a/.github/workflows/build-all-images.yaml
+++ b/.github/workflows/build-all-images.yaml
@@ -2,9 +2,6 @@ name: build-all-images
 
 on:
   push:
-on:
-  schedule:
-    - cron: '0 0 1 * *'
     paths:
       - 'components/docker-bake.hcl'
       - 'components/common/**'
@@ -16,6 +13,8 @@ on:
       - 'components/visualizer/**'
       - 'components/simulator/**'
       - 'components/universe/**'
+  schedule:
+    - cron: '0 0 1 * *'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
- fix the invalid trigger declaration in `build-all-images.yaml` by removing the duplicate top-level `on` key
- move component path filters under `push`, where GitHub Actions supports `paths`
- preserve the scheduled and manual triggers so push runs stop failing at workflow validation time