### PR TITLE
fix(ci): stabilize build-all-images workflow

### DIFF
--- a/.github/actions/combine-multi-arch-images/action.yaml
+++ b/.github/actions/combine-multi-arch-images/action.yaml
@@ -5,8 +5,8 @@ inputs:
   ros-distro:
     description: ROS distribution name
     required: true
-  date:
-    description: Build date stamp (YYYYMMDD)
+  build-tag:
+    description: Immutable build tag for this workflow run
     required: true
   registry:
     description: Container registry
@@ -40,7 +40,7 @@ runs:
 
         IMAGE="${{ inputs.image-prefix-common }}"
         DISTRO="${{ inputs.ros-distro }}"
-        DATE="${{ inputs.date }}"
+        BUILD_TAG="${{ inputs.build-tag }}"
 
         # Known common image variants
         MULTI_ARCH_VARIANTS="base devel"
@@ -48,20 +48,20 @@ runs:
 
         # Create multi-arch manifests (amd64 + arm64)
         for variant in ${MULTI_ARCH_VARIANTS}; do
-          base_tag="${variant}-${DISTRO}-${DATE}"
+          base_tag="${variant}-${DISTRO}-${BUILD_TAG}"
           echo "Creating multi-arch manifest for ${IMAGE}:${base_tag}"
           docker buildx imagetools create -t "${IMAGE}:${base_tag}" \
-            "${IMAGE}:${variant}-amd64-${DISTRO}-${DATE}" \
-            "${IMAGE}:${variant}-arm64-${DISTRO}-${DATE}"
+            "${IMAGE}:${variant}-amd64-${DISTRO}-${BUILD_TAG}" \
+            "${IMAGE}:${variant}-arm64-${DISTRO}-${BUILD_TAG}"
           echo "Created ${IMAGE}:${base_tag}"
         done
 
         # Create single-arch aliases for CUDA (amd64-only)
         for variant in ${CUDA_VARIANTS}; do
-          base_tag="${variant}-${DISTRO}-${DATE}"
+          base_tag="${variant}-${DISTRO}-${BUILD_TAG}"
           echo "Creating single-arch manifest for ${IMAGE}:${base_tag}"
           docker buildx imagetools create -t "${IMAGE}:${base_tag}" \
-            "${IMAGE}:${variant}-amd64-${DISTRO}-${DATE}"
+            "${IMAGE}:${variant}-amd64-${DISTRO}-${BUILD_TAG}"
           echo "Created ${IMAGE}:${base_tag}"
         done
       shell: bash
@@ -72,24 +72,24 @@ runs:
 
         IMAGE="${{ inputs.image-prefix-component }}"
         DISTRO="${{ inputs.ros-distro }}"
-        DATE="${{ inputs.date }}"
+        BUILD_TAG="${{ inputs.build-tag }}"
         TARGETS="${{ inputs.component-targets }}"
 
         for target in ${TARGETS}; do
-          base_tag="${target}-${DISTRO}-${DATE}"
+          base_tag="${target}-${DISTRO}-${BUILD_TAG}"
 
           if [[ "${target}" == *cuda* ]]; then
             # CUDA: single-arch alias (amd64-only)
             echo "Creating single-arch manifest for ${IMAGE}:${base_tag}"
             docker buildx imagetools create -t "${IMAGE}:${base_tag}" \
-              "${IMAGE}:${target}-amd64-${DISTRO}-${DATE}"
+              "${IMAGE}:${target}-amd64-${DISTRO}-${BUILD_TAG}"
             echo "Created ${IMAGE}:${base_tag}"
           else
             # Multi-arch manifest (amd64 + arm64)
             echo "Creating multi-arch manifest for ${IMAGE}:${base_tag}"
             docker buildx imagetools create -t "${IMAGE}:${base_tag}" \
-              "${IMAGE}:${target}-amd64-${DISTRO}-${DATE}" \
-              "${IMAGE}:${target}-arm64-${DISTRO}-${DATE}"
+              "${IMAGE}:${target}-amd64-${DISTRO}-${BUILD_TAG}" \
+              "${IMAGE}:${target}-arm64-${DISTRO}-${BUILD_TAG}"
             echo "Created ${IMAGE}:${base_tag}"
           fi
         done

--- a/.github/actions/free-disk-space/action.yaml
+++ b/.github/actions/free-disk-space/action.yaml
@@ -13,7 +13,7 @@ runs:
       shell: bash
 
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
+      uses: jlumbroso/free-disk-space@v1.3.1
       with:
         # this might remove tools that are actually needed,
         # if set to "true" but frees about 6 GB

--- a/.github/workflows/build-all-images.yaml
+++ b/.github/workflows/build-all-images.yaml
@@ -2,9 +2,6 @@ name: build-all-images
 
 on:
   push:
-on:
-  schedule:
-    - cron: '0 0 1 * *'
     paths:
       - 'components/docker-bake.hcl'
       - 'components/common/**'
@@ -16,6 +13,8 @@ on:
       - 'components/visualizer/**'
       - 'components/simulator/**'
       - 'components/universe/**'
+  schedule:
+    - cron: '0 0 1 * *'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build-all-images.yaml
+++ b/.github/workflows/build-all-images.yaml
@@ -17,6 +17,10 @@ on:
     - cron: '0 0 1 * *'
   workflow_dispatch:
 
+concurrency:
+  group: build-all-images-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX_COMMON: ghcr.io/${{ github.repository_owner }}/openadkit-common
@@ -24,16 +28,33 @@ env:
   BAKE_FILE: components/docker-bake.hcl
 
 jobs:
+  prepare:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    outputs:
+      autoware_ref: ${{ steps.prepare.outputs.autoware_ref }}
+      build_tag: ${{ steps.prepare.outputs.build_tag }}
+    steps:
+      - name: Resolve shared build inputs
+        id: prepare
+        run: |
+          set -euo pipefail
+          autoware_ref=$(git ls-remote https://github.com/autowarefoundation/autoware refs/heads/main | cut -f1)
+          build_tag="$(date -u +'%Y%m%d')-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "autoware_ref=${autoware_ref}" >> "$GITHUB_OUTPUT"
+          echo "build_tag=${build_tag}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
   # =============================================================================
   # Stage 1: Build common images
   # =============================================================================
   build-common:
+    needs: prepare
     runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-22.04' || 'ubuntu-22.04-arm' }}
     permissions:
       contents: read
       packages: write
-    outputs:
-      date: ${{ steps.date.outputs.date }}
     strategy:
       fail-fast: false
       max-parallel: 8
@@ -55,7 +76,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: autowarefoundation/autoware
-          ref: main
+          ref: ${{ needs.prepare.outputs.autoware_ref }}
           path: autoware
           fetch-depth: 1
 
@@ -75,11 +96,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-        shell: bash
-
       - name: Extract metadata for openadkit-common:base
         id: meta-common-base
         uses: docker/metadata-action@v5
@@ -88,7 +104,7 @@ jobs:
           bake-target: docker-metadata-action-common-base
           tags: |
             type=raw,value=base-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }},enable={{is_default_branch}}
-            type=raw,value=base-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ steps.date.outputs.date }}
+            type=raw,value=base-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
           flavor: |
             latest=false
 
@@ -100,7 +116,7 @@ jobs:
           bake-target: docker-metadata-action-common-base-cuda
           tags: |
             type=raw,value=base-cuda-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }},enable={{is_default_branch}}
-            type=raw,value=base-cuda-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ steps.date.outputs.date }}
+            type=raw,value=base-cuda-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
           flavor: |
             latest=false
 
@@ -112,7 +128,7 @@ jobs:
           bake-target: docker-metadata-action-common-devel
           tags: |
             type=raw,value=devel-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }},enable={{is_default_branch}}
-            type=raw,value=devel-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ steps.date.outputs.date }}
+            type=raw,value=devel-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
           flavor: |
             latest=false
 
@@ -124,7 +140,7 @@ jobs:
           bake-target: docker-metadata-action-common-devel-cuda
           tags: |
             type=raw,value=devel-cuda-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }},enable={{is_default_branch}}
-            type=raw,value=devel-cuda-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ steps.date.outputs.date }}
+            type=raw,value=devel-cuda-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
           flavor: |
             latest=false
 
@@ -170,7 +186,7 @@ jobs:
   # =============================================================================
   build-components:
     runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-22.04' || 'ubuntu-22.04-arm' }}
-    needs: build-common
+    needs: [prepare, build-common]
     permissions:
       contents: read
       packages: write
@@ -211,7 +227,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: autowarefoundation/autoware
-          ref: main
+          ref: ${{ needs.prepare.outputs.autoware_ref }}
           path: autoware
           fetch-depth: 1
 
@@ -239,7 +255,7 @@ jobs:
           bake-target: docker-metadata-action-${{ matrix.target }}
           tags: |
             type=raw,value=${{ matrix.target }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }},enable={{is_default_branch}}
-            type=raw,value=${{ matrix.target }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
+            type=raw,value=${{ matrix.target }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
           flavor: |
             latest=false
 
@@ -254,10 +270,10 @@ jobs:
           set: |
             *.platform=${{ matrix.platform }}
             *.args.ROS_DISTRO=${{ matrix.ros-distro }}
-            *.args.COMMON_BASE_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:base-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
-            *.args.COMMON_BASE_CUDA_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:base-cuda-amd64-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
-            *.args.COMMON_DEVEL_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:devel-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
-            *.args.COMMON_DEVEL_CUDA_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:devel-cuda-amd64-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
+            *.args.COMMON_BASE_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:base-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
+            *.args.COMMON_BASE_CUDA_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:base-cuda-amd64-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
+            *.args.COMMON_DEVEL_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:devel-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
+            *.args.COMMON_DEVEL_CUDA_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:devel-cuda-amd64-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/openadkit-buildcache:${{ matrix.target }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-main
             *.cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/openadkit-buildcache:${{ matrix.target }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-main,mode=max
 
@@ -266,7 +282,7 @@ jobs:
   # =============================================================================
   build-universe:
     runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-22.04' || 'ubuntu-22.04-arm' }}
-    needs: [build-common, build-components]
+    needs: [prepare, build-common, build-components]
     permissions:
       contents: read
       packages: write
@@ -286,8 +302,11 @@ jobs:
             ros-distro: jazzy
             target: universe-cuda
     steps:
+      - name: Checkout OpenADKit repository
+        uses: actions/checkout@v6
+
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: ./.github/actions/free-disk-space
 
       - name: Install jq and vcs2l
         run: |
@@ -296,14 +315,11 @@ jobs:
           pipx install vcs2l
         shell: bash
 
-      - name: Checkout OpenADKit repository
-        uses: actions/checkout@v6
-
       - name: Checkout Autoware repository
         uses: actions/checkout@v6
         with:
           repository: autowarefoundation/autoware
-          ref: main
+          ref: ${{ needs.prepare.outputs.autoware_ref }}
           path: autoware
           fetch-depth: 1
 
@@ -331,7 +347,7 @@ jobs:
           bake-target: docker-metadata-action-${{ matrix.target }}
           tags: |
             type=raw,value=${{ matrix.target }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }},enable={{is_default_branch}}
-            type=raw,value=${{ matrix.target }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
+            type=raw,value=${{ matrix.target }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
           flavor: |
             latest=false
 
@@ -346,18 +362,18 @@ jobs:
           set: |
             *.platform=${{ matrix.platform }}
             *.args.ROS_DISTRO=${{ matrix.ros-distro }}
-            *.args.COMMON_BASE_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:base-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
-            *.args.COMMON_BASE_CUDA_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:base-cuda-amd64-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
-            *.args.COMMON_DEVEL_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:devel-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
-            *.args.COMMON_DEVEL_CUDA_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:devel-cuda-amd64-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
-            *.args.SENSING_PERCEPTION_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:sensing-perception-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
-            *.args.SENSING_PERCEPTION_CUDA_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:sensing-perception-cuda-amd64-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
-            *.args.LOCALIZATION_MAPPING_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:localization-mapping-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
-            *.args.PLANNING_CONTROL_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:planning-control-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
-            *.args.VEHICLE_SYSTEM_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:vehicle-system-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
-            *.args.API_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:api-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
-            *.args.VISUALIZER_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:visualizer-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
-            *.args.SIMULATOR_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:simulator-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.build-common.outputs.date }}
+            *.args.COMMON_BASE_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:base-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
+            *.args.COMMON_BASE_CUDA_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:base-cuda-amd64-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
+            *.args.COMMON_DEVEL_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:devel-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
+            *.args.COMMON_DEVEL_CUDA_IMAGE=${{ env.IMAGE_PREFIX_COMMON }}:devel-cuda-amd64-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
+            *.args.SENSING_PERCEPTION_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:sensing-perception-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
+            *.args.SENSING_PERCEPTION_CUDA_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:sensing-perception-cuda-amd64-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
+            *.args.LOCALIZATION_MAPPING_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:localization-mapping-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
+            *.args.PLANNING_CONTROL_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:planning-control-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
+            *.args.VEHICLE_SYSTEM_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:vehicle-system-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
+            *.args.API_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:api-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
+            *.args.VISUALIZER_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:visualizer-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
+            *.args.SIMULATOR_IMAGE=${{ env.IMAGE_PREFIX_COMPONENT }}:simulator-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-${{ needs.prepare.outputs.build_tag }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/openadkit-buildcache:${{ matrix.target }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-main
             *.cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/openadkit-buildcache:${{ matrix.target }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-main,mode=max
 
@@ -366,7 +382,7 @@ jobs:
   # =============================================================================
   create-manifests:
     runs-on: ubuntu-22.04
-    needs: [build-common, build-components, build-universe]
+    needs: [prepare, build-common, build-components, build-universe]
     permissions:
       contents: read
       packages: write
@@ -385,7 +401,7 @@ jobs:
         uses: ./.github/actions/combine-multi-arch-images
         with:
           ros-distro: ${{ matrix.ros-distro }}
-          date: ${{ needs.build-common.outputs.date }}
+          build-tag: ${{ needs.prepare.outputs.build_tag }}
           registry: ${{ env.REGISTRY }}
           image-prefix-common: ${{ env.IMAGE_PREFIX_COMMON }}
           image-prefix-component: ${{ env.IMAGE_PREFIX_COMPONENT }}

--- a/components/common/Dockerfile
+++ b/components/common/Dockerfile
@@ -26,6 +26,7 @@ RUN echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/99-disable-ext
 # Install apt packages and add GitHub to known hosts for private repositories
 RUN rm -f /etc/apt/apt.conf.d/docker-clean \
   && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache
+RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/80-retries
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
   gosu \

--- a/components/common/Dockerfile
+++ b/components/common/Dockerfile
@@ -14,7 +14,7 @@ ENV CCACHE_DIR="/root/.ccache"
 WORKDIR /autoware
 
 # Copy files
-COPY autoware/setup-dev-env.sh autoware/ansible-galaxy-requirements.yaml autoware/amd64.env autoware/amd64_jazzy.env autoware/arm64.env /autoware/
+COPY autoware/setup-dev-env.sh autoware/ansible-galaxy-requirements.yaml /autoware/
 COPY autoware/ansible/ /autoware/ansible/
 COPY components/common/scripts/ /scripts/
 RUN chmod -R +x /scripts/


### PR DESCRIPTION
## Summary
- fix the invalid `build-all-images` trigger definition and restore valid push, schedule, and manual dispatch behavior
- harden the common image build against transient apt/NVIDIA download failures and stop copying upstream Autoware `.env` files that were removed
- make `build-all-images` more deterministic by resolving one Autoware SHA and one immutable build tag per run, adding workflow concurrency, and pinning the free disk space action through the local wrapper

## Validation
- `build-all-images` completed successfully on this branch after the Docker compatibility fixes: https://github.com/autowarefoundation/openadkit/actions/runs/23913754925
- a fresh validation run for the workflow hardening refactor is in progress: https://github.com/autowarefoundation/openadkit/actions/runs/23936779691