### PR TITLE
fix(zenoh-bridge): align demo defaults and docs

### DIFF
--- a/deployments/demos/zenoh-bridge/README.md
+++ b/deployments/demos/zenoh-bridge/README.md
@@ -27,10 +27,9 @@ The project provides different deployment strategies to suit various testing nee
 
 ## Quick Start
 
-We recommend using the Split Topology mode in the `local` directory:
+We recommend using the Split Topology mode from this directory:
 
 ```bash
-cd local
 ./edge.sh up -d
 ./cloud.sh up -d
 ```

--- a/deployments/demos/zenoh-bridge/docker-compose.yaml
+++ b/deployments/demos/zenoh-bridge/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
     environment:
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - ROS_DOMAIN_ID=1
-      - REMOTE_PASSWORD=o
+      - REMOTE_PASSWORD=openadkit
       - USE_SIM_TIME=true
     ports:
       - "0.0.0.0:6081:6080"

--- a/docs/deployments/demos/zenoh-bridge/index.md
+++ b/docs/deployments/demos/zenoh-bridge/index.md
@@ -1,8 +1,8 @@
-# OpenADKit Remote Visualization with Zenoh Bridge: Implementation Report and User Manual
+# Open AD Kit Remote Visualization with Zenoh Bridge: Implementation Report and User Manual
 
 ## 1. Introduction
 
-This document provides a comprehensive implementation guide and technical overview for the distributed architecture of the OpenADKit project. The core objective is to separate compute-intensive and lightweight components of an autonomous driving system, enabling deployment across different hardware. For example, the core Autoware software stack runs on the edge side (e.g., vehicle, or a powerful simulation server). Users can remotely visualize and manage Autoware from their laptops or a cloud-based management system.
+This document provides a comprehensive implementation guide and technical overview for the distributed architecture of the Open AD Kit project. The core objective is to separate compute-intensive and lightweight components of an autonomous driving system, enabling deployment across different hardware. For example, the core Autoware software stack runs on the edge side (e.g., vehicle, or a powerful simulation server). Users can remotely visualize and manage Autoware from their laptops or a cloud-based management system.
 
 To achieve this, we utilize [Zenoh](https://zenoh.io/) as a high-performance, low-latency communication protocol, paired with the [`zenoh-bridge-ros2dds`](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds) tool to seamlessly connect two ROS 2 (Robot Operating System 2) environments isolated by Docker virtual networks. This manual covers architecture design, setup steps, system startup, and troubleshooting, providing complete operational guidance.
 
@@ -85,7 +85,7 @@ graph TD
     end
 
     %% === External & Cross-Network Connections ===
-    user[fa:fa-user User] -->|"HTTP (Port 6080)"| visualizer
+    user[fa:fa-user User] -->|"HTTP (Port 6081)"| visualizer
     edge_bridge -->|"<b>Zenoh Protocol over zenoh_net</b><br>Connects to tcp/cloud_zenoh_bridge:7448"| cloud_bridge
 ```
 


### PR DESCRIPTION
## Summary
- Fix zenoh-bridge demo compose default password to match documented defaults.
- Align zenoh-bridge docs wording and port reference with the actual reachable host-mapped endpoint.
- Keep this PR scoped to zenoh-bridge correctness/documentation alignment only.

## Split context
- Extracted from the broader docs consistency work in https://github.com/autowarefoundation/openadkit/pull/64.