### PR TITLE
docs: apply consistency pass across guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ The Autoware Foundation is a voting member of the [SOAFEE (Scalable Open Archite
 
 Open AD Kit is a micro-service based project, which means that it is designed to be deployed on a variety of platforms with microservices architecture. Each component is designed to be independent and can be deployed on a variety of platforms.
 
-- **Independent components** for sensing, perception, mapping, localization, planning, control, and visualization
-- **Multi-platform deployment** supporting both amd64 and arm64 architectures  
-- **Service mesh integration** with configurable environment variables
+- **Independent images** for sensing, perception, mapping, localization, planning, control, APIs, simulation, and visualization
+- **Multi-platform deployment** supporting both amd64 and arm64 architectures
+- **Configurable ROS 2 container deployments** with environment-driven composition
 
 ![Granular Components](docs/assets/images/granular-components.png)
 
@@ -53,7 +53,7 @@ Open AD Kit leverages modern cloud native technologies to deliver scalable, port
 
 - **Seamless scaling** from development laptops to production edge devices
 - **Hybrid cloud support** bridging development and production environments
-- **Container orchestration** ready for Kubernetes and similar platforms
+- **Containerized runtimes** using Docker Compose, Docker Bake, and platform-specific integrations such as AutoSD
 
 ![Cloud Native](docs/assets/images/cloud-native.png)
 

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -6,4 +6,4 @@ This directory contains deployment configurations for **Open AD Kit**. Each fold
   - [Planning Simulation](./samples/planning-simulation): Simple Open AD Kit deployment that demonstrates the autoware **planning features** with planning simulation.
   - [Logging Simulation](./samples/logging-simulation): Simple Open AD Kit deployment that demonstrates the autoware **end-to-end functionality** with sensor simulation using rosbag.
 - **Demo deployment** configurations with specific use case scenarios.
-  - [Zenoh Bridge](./demos/zenoh-bridge): A demo of remote visualization with Zenoh bridge. See [Zenoh Bridge Document](openadkit-dev/docs/deployments/zenoh-bridge/index.md) for more details.
+  - [Zenoh Bridge](./demos/zenoh-bridge): A demo of remote visualization with Zenoh bridge. See the [Zenoh Bridge documentation](../docs/deployments/demos/zenoh-bridge/index.md) for more details.

--- a/deployments/samples/logging-simulation/README.md
+++ b/deployments/samples/logging-simulation/README.md
@@ -4,17 +4,25 @@ This sample deployment shows how to run Autoware Open AD Kit **logging simulatio
 
 ## Requirements
 
-In order to run the logging simulation, you need to have the logging simulation **sample map** and **rosbag**. You can download them by running the following commands:
+In order to run the logging simulation, you need the logging simulation **sample map**, **rosbag**, and the Autoware artifacts downloaded by `setup.sh --download-artifacts`.
+
+If `gdown` or `unzip` are not installed yet, install them first:
+
+```bash
+sudo apt-get install -y python3-pip unzip
+python3 -m pip install --user gdown
+```
 
 ### Sample Logging Map
 
 Download and unpack a logging simulation sample map that is used in this sample.
 
-- You can also download [the map](https://drive.google.com/file/d/1499_nsbUbIeturZaDj7jhUownh5fvXHd/view?usp=sharing) manually.
+- You can also download [the map](https://drive.google.com/file/d/1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI/view?usp=sharing) manually.
 
 ```bash
-gdown -O ~/autoware_map/ 'https://docs.google.com/uc?export=download&id=1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI'
-unzip -d ~/autoware_map/ ~/autoware_map/sample-map-rosbag.zip
+mkdir -p ~/autoware_map
+gdown -O ~/autoware_map/sample-map-rosbag.zip 'https://docs.google.com/uc?export=download&id=1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI'
+unzip -o -d ~/autoware_map ~/autoware_map/sample-map-rosbag.zip
 ```
 
 > **Note**: This sample map(Copyright 2020 TIER IV, Inc.) is only for demonstration purposes. You can use your own map by following the [How-to Guide](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-maps/).
@@ -23,14 +31,22 @@ unzip -d ~/autoware_map/ ~/autoware_map/sample-map-rosbag.zip
 
 Download and unpack a sample rosbag that is used for **sensor simulation** in this sample.
 
-- You can also download [the rosbag](https://drive.google.com/file/d/1499_nsbUbIeturZaDj7jhUownh5fvXHd/view?usp=sharing) manually.
+- You can also download [the rosbag](https://drive.google.com/file/d/1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP/view?usp=sharing) manually.
 
 ```bash
-gdown -O ~/autoware_map/ 'https://docs.google.com/uc?export=download&id=1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP'
-unzip -d ~/autoware_map/ ~/autoware_map/sample-rosbag.zip
+gdown -O ~/autoware_map/sample-rosbag.zip 'https://docs.google.com/uc?export=download&id=1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP'
+unzip -o -d ~/autoware_map ~/autoware_map/sample-rosbag.zip
 ```
 
 > **Note**: Due to privacy concerns, the rosbag(Copyright 2020 TIER IV, Inc.) does not contain image data, which will cause: Traffic light recognition functionality cannot be tested with this sample rosbag. Object detection accuracy is decreased.
+
+### Autoware Artifacts
+
+This deployment mounts `${HOME}/autoware_data` into the sensing and perception containers. Download the artifacts ahead of time by following the [Getting Started](../../../docs/getting-started/index.md) guide:
+
+```bash
+sudo ./setup.sh --download-artifacts
+```
 
 ## Run the Deployment
 
@@ -46,7 +62,7 @@ unzip -d ~/autoware_map/ ~/autoware_map/sample-rosbag.zip
     http://localhost:6080/vnc.html
     ```
 
-    Use the default password `openadkit` to access the visualizer. **It can take a few seconds to visualizer to start.**
+    Use the default password `openadkit` to access the visualizer. **It can take a few seconds for the visualizer to start.**
 
     > If your machine is on a remote server, you can access the visualizer by using its accessible IP address:
     >

--- a/deployments/samples/planning-simulation/README.md
+++ b/deployments/samples/planning-simulation/README.md
@@ -4,7 +4,14 @@ This sample deployment shows how to run Autoware Open AD Kit **planning simulati
 
 ## Requirements
 
-In order to run the planning simulation, you need to have the planning simulation **sample map**. You can download it by running the following commands:
+In order to run the planning simulation, you need the planning simulation **sample map**.
+
+If `gdown` or `unzip` are not installed yet, install them first:
+
+```bash
+sudo apt-get install -y python3-pip unzip
+python3 -m pip install --user gdown
+```
 
 ### Sample Planning Map
 
@@ -13,8 +20,9 @@ Download and unpack a planning simulation sample map that is used in this sample
 - You can also download [the map](https://drive.google.com/file/d/1499_nsbUbIeturZaDj7jhUownh5fvXHd/view?usp=sharing) manually.
 
 ```bash
-gdown -O ~/autoware_map/ 'https://docs.google.com/uc?export=download&id=1499_nsbUbIeturZaDj7jhUownh5fvXHd'
-unzip -d ~/autoware_map ~/autoware_map/sample-map-planning.zip
+mkdir -p ~/autoware_map
+gdown -O ~/autoware_map/sample-map-planning.zip 'https://docs.google.com/uc?export=download&id=1499_nsbUbIeturZaDj7jhUownh5fvXHd'
+unzip -o -d ~/autoware_map ~/autoware_map/sample-map-planning.zip
 ```
 
 > **Note**: This sample map(Copyright 2020 TIER IV, Inc.) is only for demonstration purposes. You can use your own map by following the [How-to Guide](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-maps/).
@@ -33,7 +41,7 @@ unzip -d ~/autoware_map ~/autoware_map/sample-map-planning.zip
     http://localhost:6080/vnc.html
     ```
 
-    Use the default password `openadkit` to access the visualizer. **It can take a few seconds to visualizer to start.**
+    Use the default password `openadkit` to access the visualizer. **It can take a few seconds for the visualizer to start.**
 
     > If your machine is on a remote server, you can access the visualizer by using its accessible IP address:
     >

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -1,6 +1,6 @@
 # Components
 
-Open AD Kit is a component based project, which means that it is designed to be deployed on a variety of platforms with microservices architecture. Each **Autoware component** is designed to be independent and can be configured to work together to achieve a particular task, such as a simulation or a full autonomous driving stack.
+Open AD Kit is a component-based project designed to run on a variety of platforms with containerized services. Each **Autoware function** remains independently deployable, while the published images group closely related functions together where that keeps the runtime layout simpler.
 
 ![Granular Components](../assets/images/granular-components.png)
 
@@ -30,14 +30,10 @@ The planning component is responsible for planning the vehicle's path. Planning 
 
 The control component is responsible for controlling the vehicle's actuators. Control component can be configured to use a variety of control algorithms, including **PID and MPC**. For more details, see the [Autoware control design document](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-architecture-v1/components/control/).
 
-### Vehicle
+### Vehicle and System
 
-The vehicle component is responsible for managing the vehicle's state. Vehicle component can be configured to use a variety of vehicle algorithms, including **vehicle state estimation and vehicle control**. For more details, see the [Autoware vehicle design document](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-architecture-v1/components/vehicle/).
+The `vehicle-system` image packages both the vehicle interface and system-level services used by the Open AD Kit deployments. On the functional side, the vehicle component manages vehicle-specific interfaces and state, while the system component provides health monitoring and related system services. For more details, see the [Autoware vehicle design document](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-architecture-v1/components/vehicle/).
 
 ### API
 
-The API component is responsible for providing [AD API](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-interfaces/ad-api/) interface for the vehicle's state. API component can be configured to enable/disable various interfaces. For more details, see the [Autoware Interface design document](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-architecture-v1/interfaces/).
-
-### System
-
-The system component is responsible for managing the vehicle's system. System component can be configured to use a variety of system algorithms, including **system health monitoring and system error handling**.
+The API component is responsible for providing [AD API](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-interfaces/ad-api/) interface for the vehicle's state. API component can be configured to enable or disable various interfaces. For more details, see the [Autoware Interface design document](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-architecture-v1/interfaces/).

--- a/docs/deployments/samples/index.md
+++ b/docs/deployments/samples/index.md
@@ -2,5 +2,5 @@
 
 Sample deployment configurations to help you get started. Recommended for **learning and development**.
 
-- [Planning Simulation](planning-simulation/index.md)
-- [Logging Simulation](logging-simulation/index.md)
+- [Planning Simulation](planning-simulation/index.md) - Run the Autoware planning simulation with a sample map.
+- [Logging Simulation](logging-simulation/index.md) - Run the Autoware logging simulation with a sample rosbag.

--- a/docs/deployments/samples/logging-simulation/index.md
+++ b/docs/deployments/samples/logging-simulation/index.md
@@ -1,68 +1,34 @@
 # Autoware Open AD Kit Logging Simulation
 
-This sample deployment shows how to run Autoware Open AD Kit **logging simulation**.
+This sample deployment demonstrates the Open AD Kit logging simulation workflow.
 
-## Requirements
+## Source of Truth
 
-In order to run the logging simulation, you need to have the logging simulation **sample map** and **rosbag**. You can download them by running the following commands:
+The complete operational instructions for this deployment live alongside the deployment assets in [`deployments/samples/logging-simulation/README.md`](https://github.com/autowarefoundation/openadkit/blob/main/deployments/samples/logging-simulation/README.md).
 
-### Sample Logging Map
+That README covers:
 
-Download and unpack a logging simulation sample map that is used in this sample.
+- sample map and rosbag download and extraction
+- required Autoware artifacts
+- visualizer access
+- startup and shutdown commands
 
-- You can also download [the map](https://drive.google.com/file/d/1499_nsbUbIeturZaDj7jhUownh5fvXHd/view?usp=sharing) manually.
+## Quick Start
 
-```bash
-gdown -O ~/autoware_map/ 'https://docs.google.com/uc?export=download&id=1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI'
-unzip -d ~/autoware_map/ ~/autoware_map/sample-map-rosbag.zip
-```
-
-> **Note**: This sample map(Copyright 2020 TIER IV, Inc.) is only for demonstration purposes. You can use your own map by following the [How-to Guide](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-maps/).
-
-### Sample Rosbag
-
-Download and unpack a sample rosbag that is used for **sensor simulation** in this sample.
-
-- You can also download [the rosbag](https://drive.google.com/file/d/1499_nsbUbIeturZaDj7jhUownh5fvXHd/view?usp=sharing) manually.
+From `deployments/samples/logging-simulation/`:
 
 ```bash
-gdown -O ~/autoware_map/ 'https://docs.google.com/uc?export=download&id=1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP'
-unzip -d ~/autoware_map/ ~/autoware_map/sample-rosbag.zip
+docker compose --env-file logging-simulation.env up -d
+docker compose --env-file logging-simulation.env up rosbag -d
 ```
 
-> **Note**: Due to privacy concerns, the rosbag(Copyright 2020 TIER IV, Inc.) does not contain image data, which will cause: Traffic light recognition functionality cannot be tested with this sample rosbag. Object detection accuracy is decreased.
+Open the visualizer at:
 
-## Run the Deployment
+```text
+http://localhost:6080/vnc.html
+```
 
-1. Start the deployment by running the following command:
-
-    ```bash
-    docker compose --env-file logging-simulation.env up -d
-    ```
-
-2. Wait for the deployment to start for about 5 seconds and then open a browser to visualize the simulation and navigate to:
-
-    ```bash
-    http://localhost:6080/vnc.html
-    ```
-
-    Use the default password `openadkit` to access the visualizer. **It can take a few seconds to visualizer to start.**
-
-    > If your machine is on a remote server, you can access the visualizer by using its accessible IP address:
-    >
-    > ```bash
-    > http://<your-server-ip>:6080/vnc.html
-    > ```
-
-3. To start the logging simulation, you should run the following command to play the rosbag:
-
-    ```bash
-    docker compose --env-file logging-simulation.env up rosbag -d
-    ```
-
-## Stop the Deployment
-
-Stop the deployment by running the following command:
+To stop the deployment:
 
 ```bash
 docker compose --env-file logging-simulation.env --profile rosbag down

--- a/docs/deployments/samples/planning-simulation/index.md
+++ b/docs/deployments/samples/planning-simulation/index.md
@@ -1,49 +1,32 @@
 # Autoware Open AD Kit Planning Simulation
 
-This sample deployment shows how to run Autoware Open AD Kit **planning simulation**.
+This sample deployment demonstrates the Open AD Kit planning simulation workflow.
 
-## Requirements
+## Source of Truth
 
-In order to run the planning simulation, you need to have the planning simulation **sample map**. You can download it by running the following commands:
+The complete operational instructions for this deployment live alongside the deployment assets in [`deployments/samples/planning-simulation/README.md`](https://github.com/autowarefoundation/openadkit/blob/main/deployments/samples/planning-simulation/README.md).
 
-### Sample Planning Map
+That README covers:
 
-Download and unpack a planning simulation sample map that is used in this sample.
+- sample map download and extraction
+- visualizer access
+- startup and shutdown commands
 
-- You can also download [the map](https://drive.google.com/file/d/1499_nsbUbIeturZaDj7jhUownh5fvXHd/view?usp=sharing) manually.
+## Quick Start
+
+From `deployments/samples/planning-simulation/`:
 
 ```bash
-gdown -O ~/autoware_map/ 'https://docs.google.com/uc?export=download&id=1499_nsbUbIeturZaDj7jhUownh5fvXHd'
-unzip -d ~/autoware_map ~/autoware_map/sample-map-planning.zip
+docker compose --env-file planning-simulation.env up -d
 ```
 
-> **Note**: This sample map(Copyright 2020 TIER IV, Inc.) is only for demonstration purposes. You can use your own map by following the [How-to Guide](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-maps/).
+Open the visualizer at:
 
-## Run the Deployment
+```text
+http://localhost:6080/vnc.html
+```
 
-1. Start the deployment by running the following command:
-
-    ```bash
-    docker compose --env-file planning-simulation.env up -d
-    ```
-
-2. Wait for the deployment to start for about 5 seconds and then open a browser to visualize the simulation and navigate to:
-
-    ```bash
-    http://localhost:6080/vnc.html
-    ```
-
-    Use the default password `openadkit` to access the visualizer. **It can take a few seconds to visualizer to start.**
-
-    > If your machine is on a remote server, you can access the visualizer by using its accessible IP address:
-    >
-    > ```bash
-    > http://<your-server-ip>:6080/vnc.html
-    > ```
-
-3. After you see the visualizer, you can start the autonomous driving simulation by following the [planning simulation instructions](https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/lane-driving/#2-set-an-initial-pose-for-the-ego-vehicle) in the Autoware documentation.
-
-## Stop the Deployment
+To stop the deployment:
 
 ```bash
 docker compose --env-file planning-simulation.env down

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -4,7 +4,7 @@
 
 - Docker Engine
 - NVIDIA Container Toolkit (Optional but highly recommended for sensing and perception tasks)
-- Autoware artifacts (Optional but highly recommended for sensing and perception tasks)
+- Autoware artifacts (Optional in general, but required for sensing and perception deployments such as Logging Simulation)
 
     > All the above requirements can be installed by running the **setup.sh** script.
 
@@ -31,7 +31,9 @@
     sudo ./setup.sh --download-artifacts
     ```
 
+    > This step is required for deployments that mount `${HOME}/autoware_data`, including the Logging Simulation sample.
+
 ## Next Steps
 
-- [Running a sample deployment](../deployments/)
-- [Learn more about the Open AD Kit components](../components/)
+- [Running a sample deployment](../deployments/index.md)
+- [Learn more about the Open AD Kit components](../components/index.md)

--- a/docs/hardware/index.md
+++ b/docs/hardware/index.md
@@ -13,7 +13,10 @@ The Open AD Kit supports **amd64** and **arm64** architectures with the followin
 ## Tested Hardware
 
 - [ADLink AADP-AVA](https://www.adlinktech.com/products/Computer_on_Modules/COM-HPC-Server-Carrier-and-Starter-Kit/Ampere_Altra_Developer_Platform)
-- [NVIDIA Jetson Orin](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/) (TBD)
+
+## Planned Validation
+
+- [NVIDIA Jetson Orin](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/)
 
 ## Tested Cloud Instances
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Open AD Kit adopts a modular, component-based architecture designed for flexibility, scalability, and platform independence. It leverages cloud-native principles and containerization to decompose the [Autoware Universe](https://github.com/autowarefoundation/autoware) into a collection of interoperable components. This approach allows developers to create customized autonomous driving (AD) systems by combining components to meet their specific needs.
+Open AD Kit adopts a modular, component-based architecture designed for flexibility, scalability, and platform independence. It leverages cloud-native principles and containerization to decompose [Autoware](https://github.com/autowarefoundation/autoware) into a collection of interoperable components. This approach allows developers to create customized autonomous driving (AD) systems by combining components to meet their specific needs.
 
 ## Architecture
 
@@ -16,50 +16,47 @@ Deployments are defined using container orchestration files (e.g., `docker-compo
 
 This modular structure allows users to start with a minimal deployment and incrementally add components and tools as their system evolves.
 
-For more details, see the [Deployments](./deployments/).
+For more details, see the [Deployments](./deployments/index.md).
 
 ## Components
 
-The core functional components of the Open AD Kit are derived from the main **[Autoware Universe](https://github.com/autowarefoundation/autoware_universe)** project. Each component is packaged as an independent containerized component, responsible for a specific aspect of the autonomous driving pipeline. This modular approach provides flexibility in composing different AD systems by combining different components.
+The core functional components of the Open AD Kit are derived from the main **[Autoware](https://github.com/autowarefoundation/autoware)** project. Each image packages a focused part of the autonomous driving pipeline, which makes it possible to compose different AD systems from a common container set.
 
-The primary components include:
+The primary images include:
 
-- **Sensing**: Collects data from various sensors (Cameras, Lidars, Radars).
-- **Perception**: Processes sensor data to detect and track objects in the environment.
-- **Mapping**: Creates and maintains maps of the environment.
-- **Localization**: Determines the vehicle's position within the map.
-- **Planning**: Plans the vehicle's trajectory from its current location to a destination.
-- **Control**: Sends commands to the vehicle's actuators to follow the planned trajectory.
-- **Vehicle**: Manages the vehicle's internal state and interface.
-- **System**: Provides system-level functionalities like health monitoring.
+- **Sensing and Perception**: Collects and processes sensor data.
+- **Localization and Mapping**: Manages maps and vehicle pose estimation.
+- **Planning and Control**: Produces and follows the driving trajectory.
+- **Vehicle and System**: Packages vehicle interfaces and system-level services in the `vehicle-system` image.
 - **API**: Offers an interface for external systems to interact with the vehicle.
-- **Simulator**: Allows for testing the AD stack in a virtual environment with ad-hoc simulations.
+- **Simulator**: Allows testing the AD stack in a virtual environment.
+- **Visualizer**: Provides a browser-accessible RViz environment for remote inspection.
 
-These components communicate with each other over a service mesh, allowing for flexible deployment and scaling. For more details, see the [Autoware components](./components/).
+These images communicate through ROS 2 middleware, and some deployments bridge isolated environments with Zenoh. For more details, see the [Autoware components](./components/index.md).
 
 ## Tools
 
 In addition to the **Autoware components**, Open AD Kit provides essential tools for development, simulation, and visualization. These tools are also containerized and can be integrated into deployments as needed.
 
-- **Scenario Simulator-TBD**: Allows for testing the AD stack in a virtual environment. It supports complex scenario-based simulations for validation and CI/CD.
+- **Scenario Simulator**: Runs scenario-based simulations for validation, CI, and local development.
 
-For more details, see the [Tools](./tools/).
+For more details, see the [Tools](./tools/index.md).
 
 ## Supported Platforms
 
-Open AD Kit supports a variety of platforms as **development** and **SOAFEE production** platforms.
+Open AD Kit currently documents Ubuntu as the primary development host and AutoSD as the platform-specific deployment path available in this repository. EWAOL is planned but does not yet ship runnable assets here.
 
 ### Development platforms
 
 - Ubuntu 22.04, 24.04
 
-### SOAFEE Production platforms
+### Platform-specific deployment paths
 
-- [EWAOL](https://ewaol.docs.arm.com/en/kirkstone-dev/)
 - [AutoSD](https://docs.centos.org/automotive-sig-documentation/features-and-concepts/)
+- [EWAOL](https://ewaol.docs.arm.com/en/kirkstone-dev/) (planned)
 
-For more details, see the [Supported SOAFEE Platforms](./platforms/).
+For more details, see the [Supported SOAFEE Platforms](./platforms/index.md).
 
 ## Supported Hardware
 
-For detailed information on system requirements, tested hardware, and cloud instances, please refer to the [Hardware](./hardware/) section.
+For detailed information on system requirements, tested hardware, and cloud instances, please refer to the [Hardware](./hardware/index.md) section.

--- a/docs/platforms/autosd/planning-simulator/index.md
+++ b/docs/platforms/autosd/planning-simulator/index.md
@@ -5,5 +5,5 @@ This folder shows how to run and test scenario with containers managed by System
 ## Folder Structure
 
 * `aib`: automotive-image-builder manifest files to build an AutoSD image
-* `components`: quadlet files to run Open Ad Kit inside container in an AutoSD image
+* `components`: quadlet files to run Open AD Kit inside container in an AutoSD image
 * `docs`: extra documentation files, such as architecture diagrams

--- a/docs/platforms/ewaol/index.md
+++ b/docs/platforms/ewaol/index.md
@@ -1,3 +1,9 @@
 # EWAOL
 
-Instructions on how to run Open AD Kit on EWAOL will be provided here (TBD).
+EWAOL is a planned Open AD Kit target, but this repository does not yet contain EWAOL-specific deployment assets, container orchestration files, or step-by-step runtime instructions.
+
+Current status:
+
+- AutoSD is the platform-specific workflow implemented in this repository today.
+- EWAOL support is still being scoped.
+- This page will be expanded once runnable EWAOL assets land in the tree.

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -1,6 +1,6 @@
 # Supported Platforms
 
-As the Autoware Open AD Kit is the first [SOAFEE](https://www.soafee.io/) blueprint for the software defined vehicle ecosystem, it supports a variety of platforms as core SOAFEE platforms.
+As the Autoware Open AD Kit is the first [SOAFEE](https://www.soafee.io/) blueprint for the software defined vehicle ecosystem, it tracks multiple platform directions. The repository currently contains runnable assets for AutoSD; EWAOL remains a documented target rather than an implemented one.
 
 Here is an explanatory blog post on the [benefits of open standards in automotive development](https://www.soafee.io/blog/2025/the-benefits-of-open-standards-in-automotive-development/).
 
@@ -16,4 +16,4 @@ Instructions on how to build and deploy Open AD Kit on AutoSD can be found in th
 
 The Edge Workload Abstraction and Orchestration Layer (EWAOL) is a standards-based, container-centric framework for deploying and orchestrating applications on edge platforms, delivered via the `meta-ewaol` Yocto layer to build distribution images. It organizes the stack into user-defined containerized application workloads (deployed by end users), an EWAOL Linux filesystem that provides core services such as Docker, K3s, and Xen along with validation and development tooling, and platform-specific system software (firmware, bootloader, OS, and optional Xen) integrated from `meta-arm`, `meta-arm-bsp`, and `meta-virtualization`. EWAOL is the reference implementation for SOAFEE, extending cloud-native methods to automotive with an emphasis on real-time and functional safety.
 
-Instructions on how to run Open AD Kit on EWAOL can be found in the [EWAOL folder](ewaol/index.md) (TBD).
+The [EWAOL page](ewaol/index.md) currently captures project intent and status only. Runnable deployment instructions are still planned.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -2,6 +2,8 @@
 
 Open AD Kit includes containerized third-party tools for testing, deploying, and managing autonomous driving systems. These tools complement the **Autoware components** and can be integrated into deployments as needed.
 
-## Scenario Simulator - TBD
+## Scenario Simulator
 
-The [Tier IV Scenario Simulator](https://tier4.github.io/scenario_simulator_v2-docs/) is a tool that enables users to test their autonomous driving system in a virtual environment. It uses a scenario runner to run more complex simulations based on predefined scenarios. It is often run automatically for continuous integration purposes, but can also be run on a local machine.
+The [Tier IV Scenario Simulator](https://tier4.github.io/scenario_simulator_v2-docs/) enables users to test their autonomous driving system in a virtual environment. It uses a scenario runner to execute more complex simulations based on predefined scenarios, and it can be used both in CI and on a local machine.
+
+The container entrypoint and supported environment variables are documented in the repository's [Scenario Simulator README](https://github.com/autowarefoundation/openadkit/blob/main/tools/scenario-simulator/README.md).

--- a/platforms/README.md
+++ b/platforms/README.md
@@ -3,4 +3,4 @@
 This directory contains platform specific deployment configurations for **Open AD Kit**. Each folder contains a README file with detailed instructions on how to deploy the deployment configuration for the specific platform.
 
 - [AutoSD](./autosd/README.md): How to build and deploy Open AD Kit components in AutoSD
-- EWAOL (TBD): How to run Open AD Kit components on EWAOL
+- EWAOL (planned): Target platform under discussion; runnable assets are not yet present in this repository

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,3 +1,5 @@
-# Open AD Kit Tools -TBD
+# Open AD Kit Tools
 
-This directory offers tools for Open AD Kit to make development and deployment easier. These tools are also containerized and can be integrated into deployments as needed.
+This directory contains containerized tools that complement the core Open AD Kit images.
+
+- [Scenario Simulator](./scenario-simulator/README.md): Runs Tier IV Scenario Simulator in a container for scenario-based validation and local testing.


### PR DESCRIPTION
## Summary
- Standardize naming and wording across top-level, deployment, platform, and docs-site guides.
- Refresh sample/deployment docs pages for consistency and readability while preserving behavior.
- Keep this PR editorial and documentation-only.

## Split context
- Extracted from the broader docs consistency work in https://github.com/autowarefoundation/openadkit/pull/64.