### PR TITLE
fix(ci): restore common image build

### DIFF
--- a/components/common/Dockerfile
+++ b/components/common/Dockerfile
@@ -90,7 +90,6 @@ RUN --mount=type=ssh \
   --mount=type=bind,source=autoware/src/universe/external/pointcloud_to_laserscan,target=/autoware/src/universe/external/pointcloud_to_laserscan \
   --mount=type=bind,source=autoware/src/universe/external/rtklib_ros_bridge,target=/autoware/src/universe/external/rtklib_ros_bridge \
   --mount=type=bind,source=autoware/src/universe/external/tier4_autoware_msgs,target=/autoware/src/universe/external/tier4_autoware_msgs \
-  --mount=type=bind,source=autoware/src/middleware/external,target=/autoware/src/middleware/external \
   apt-get update \
   && source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && rosdep update \
@@ -113,8 +112,7 @@ RUN --mount=type=cache,target="${CCACHE_DIR}" \
   --mount=type=bind,source=autoware/src/universe/external/pointcloud_to_laserscan,target=/autoware/src/universe/external/pointcloud_to_laserscan \
   --mount=type=bind,source=autoware/src/universe/external/rtklib_ros_bridge,target=/autoware/src/universe/external/rtklib_ros_bridge \
   --mount=type=bind,source=autoware/src/universe/external/tier4_autoware_msgs,target=/autoware/src/universe/external/tier4_autoware_msgs \
-  --mount=type=bind,source=autoware/src/middleware/external,target=/autoware/src/middleware/external \
-  --mount=type=bind,source=/autoware/src/launcher,target=/autoware/src/launcher \
+  --mount=type=bind,source=autoware/src/launcher,target=/autoware/src/launcher \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && /scripts/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware
 

--- a/components/planning-control/Dockerfile
+++ b/components/planning-control/Dockerfile
@@ -35,7 +35,7 @@ RUN --mount=type=cache,target="${CCACHE_DIR}" \
   && /scripts/cleanup_apt.sh true \
   && source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
-  && /scripts/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware "-DBUILD_TESTING=OFF"
+  && /scripts/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware "--cmake-args -DBUILD_TESTING=OFF"
 
 # =============================================================================
 # Runtime stage: planning-control

--- a/components/planning-control/Dockerfile
+++ b/components/planning-control/Dockerfile
@@ -35,7 +35,7 @@ RUN --mount=type=cache,target="${CCACHE_DIR}" \
   && /scripts/cleanup_apt.sh true \
   && source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
-  && /scripts/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware
+  && /scripts/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware "-DBUILD_TESTING=OFF"
 
 # =============================================================================
 # Runtime stage: planning-control

--- a/components/sensing-perception/Dockerfile
+++ b/components/sensing-perception/Dockerfile
@@ -31,7 +31,7 @@ RUN --mount=type=cache,target="${CCACHE_DIR}" \
   && /scripts/cleanup_apt.sh true \
   && source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
-  && /scripts/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware
+  && /scripts/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware "--parallel-workers 1 --cmake-args -DBUILD_TESTING=OFF"
 
 # =============================================================================
 # Runtime stage: sensing-perception

--- a/components/simulator/Dockerfile
+++ b/components/simulator/Dockerfile
@@ -24,6 +24,7 @@ RUN --mount=type=cache,target="${CCACHE_DIR}" \
   --mount=type=bind,source=/autoware/src/universe/autoware_universe/sensing/autoware_cuda_utils,target=/autoware/src/universe/autoware_universe/perception/autoware_cuda_utils \
   --mount=type=bind,source=/autoware/src/universe/autoware_universe/sensing/autoware_pointcloud_preprocessor,target=/autoware/src/universe/autoware_universe/sensing/autoware_pointcloud_preprocessor \
   --mount=type=bind,source=/autoware/src/universe/autoware_universe/sensing/autoware_pcl_extensions,target=/autoware/src/universe/autoware_universe/sensing/autoware_pcl_extensions \
+  --mount=type=bind,source=/autoware/src/universe/autoware_universe/control/autoware_external_cmd_selector,target=/autoware/src/universe/autoware_universe/control/autoware_external_cmd_selector \
   --mount=type=bind,source=/autoware/src/universe/autoware_universe/vehicle/autoware_raw_vehicle_cmd_converter,target=/autoware/src/universe/autoware_universe/vehicle/autoware_raw_vehicle_cmd_converter \
   apt-get update \
   && source /opt/ros/"$ROS_DISTRO"/setup.bash \


### PR DESCRIPTION
## Summary
- Remove stale Autoware middleware bind mounts from the common image build.
- Use the repository-relative launcher bind mount path so Docker Buildx can resolve it from the build context.

## Testing
- docker buildx bake --file components/docker-bake.hcl --print common-devel