### PR TITLE
fix(ci): restore component image builds

### DIFF
--- a/components/planning-control/Dockerfile
+++ b/components/planning-control/Dockerfile
@@ -35,7 +35,7 @@ RUN --mount=type=cache,target="${CCACHE_DIR}" \
   && /scripts/cleanup_apt.sh true \
   && source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
-  && /scripts/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware
+  && /scripts/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware "-DBUILD_TESTING=OFF"
 
 # =============================================================================
 # Runtime stage: planning-control

--- a/components/simulator/Dockerfile
+++ b/components/simulator/Dockerfile
@@ -24,6 +24,7 @@ RUN --mount=type=cache,target="${CCACHE_DIR}" \
   --mount=type=bind,source=/autoware/src/universe/autoware_universe/sensing/autoware_cuda_utils,target=/autoware/src/universe/autoware_universe/perception/autoware_cuda_utils \
   --mount=type=bind,source=/autoware/src/universe/autoware_universe/sensing/autoware_pointcloud_preprocessor,target=/autoware/src/universe/autoware_universe/sensing/autoware_pointcloud_preprocessor \
   --mount=type=bind,source=/autoware/src/universe/autoware_universe/sensing/autoware_pcl_extensions,target=/autoware/src/universe/autoware_universe/sensing/autoware_pcl_extensions \
+  --mount=type=bind,source=/autoware/src/universe/autoware_universe/control/autoware_external_cmd_selector,target=/autoware/src/universe/autoware_universe/control/autoware_external_cmd_selector \
   --mount=type=bind,source=/autoware/src/universe/autoware_universe/vehicle/autoware_raw_vehicle_cmd_converter,target=/autoware/src/universe/autoware_universe/vehicle/autoware_raw_vehicle_cmd_converter \
   apt-get update \
   && source /opt/ros/"$ROS_DISTRO"/setup.bash \


### PR DESCRIPTION
## Summary
- Mount `autoware_external_cmd_selector` in the simulator component image so rosdep resolves it as workspace source.
- Disable test builds in the planning-control component image to avoid the test-only acados link failure during image builds.

## Validation
- `docker buildx bake --file components/docker-bake.hcl --print simulator planning-control`
- `git diff --check`

## Notes
- This PR is stacked on #74 because the component image builds require the common image build fix first.