### PR TITLE
feat(docker): add passthrough Dockerfiles for all 7 components

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,0 +1,11 @@
+# docker/api/Dockerfile
+# Passthrough component: api ships only what is already in upstream universe.
+# Kept as a real Dockerfile (not a bare bake re-tag) so every openadkit
+# component has the same CI shape — bake target, hadolint pass, image build.
+
+# hadolint ignore=DL3006
+ARG UPSTREAM_DEVEL
+ARG UPSTREAM_RUN
+ARG ROS_DISTRO=jazzy
+
+FROM ${UPSTREAM_RUN} AS api

--- a/docker/bake.hcl
+++ b/docker/bake.hcl
@@ -101,3 +101,12 @@ target "localization-mapping" {
   tags       = tags("localization-mapping")
   platforms  = PLATFORM == "" ? [] : [PLATFORM]
 }
+
+target "planning-control" {
+  inherits   = ["_component-base"]
+  context    = "."
+  dockerfile = "docker/planning-control/Dockerfile"
+  target     = "planning-control"
+  tags       = tags("planning-control")
+  platforms  = PLATFORM == "" ? [] : [PLATFORM]
+}

--- a/docker/bake.hcl
+++ b/docker/bake.hcl
@@ -110,3 +110,12 @@ target "planning-control" {
   tags       = tags("planning-control")
   platforms  = PLATFORM == "" ? [] : [PLATFORM]
 }
+
+target "sensing-perception" {
+  inherits   = ["_component-base"]
+  context    = "."
+  dockerfile = "docker/sensing-perception/Dockerfile"
+  target     = "sensing-perception"
+  tags       = tags("sensing-perception")
+  platforms  = PLATFORM == "" ? [] : [PLATFORM]
+}

--- a/docker/bake.hcl
+++ b/docker/bake.hcl
@@ -128,3 +128,12 @@ target "simulator" {
   tags       = tags("simulator")
   platforms  = PLATFORM == "" ? [] : [PLATFORM]
 }
+
+target "vehicle-system" {
+  inherits   = ["_component-base"]
+  context    = "."
+  dockerfile = "docker/vehicle-system/Dockerfile"
+  target     = "vehicle-system"
+  tags       = tags("vehicle-system")
+  platforms  = PLATFORM == "" ? [] : [PLATFORM]
+}

--- a/docker/bake.hcl
+++ b/docker/bake.hcl
@@ -83,3 +83,12 @@ target "_component-cuda-base" {
     UPSTREAM_RUN   = upstream("runtime-cuda")
   }
 }
+
+target "api" {
+  inherits   = ["_component-base"]
+  context    = "."
+  dockerfile = "docker/api/Dockerfile"
+  target     = "api"
+  tags       = tags("api")
+  platforms  = PLATFORM == "" ? [] : [PLATFORM]
+}

--- a/docker/bake.hcl
+++ b/docker/bake.hcl
@@ -92,3 +92,12 @@ target "api" {
   tags       = tags("api")
   platforms  = PLATFORM == "" ? [] : [PLATFORM]
 }
+
+target "localization-mapping" {
+  inherits   = ["_component-base"]
+  context    = "."
+  dockerfile = "docker/localization-mapping/Dockerfile"
+  target     = "localization-mapping"
+  tags       = tags("localization-mapping")
+  platforms  = PLATFORM == "" ? [] : [PLATFORM]
+}

--- a/docker/bake.hcl
+++ b/docker/bake.hcl
@@ -137,3 +137,12 @@ target "vehicle-system" {
   tags       = tags("vehicle-system")
   platforms  = PLATFORM == "" ? [] : [PLATFORM]
 }
+
+target "visualizer" {
+  inherits   = ["_component-base"]
+  context    = "."
+  dockerfile = "docker/visualizer/Dockerfile"
+  target     = "visualizer"
+  tags       = tags("visualizer")
+  platforms  = PLATFORM == "" ? [] : [PLATFORM]
+}

--- a/docker/bake.hcl
+++ b/docker/bake.hcl
@@ -119,3 +119,12 @@ target "sensing-perception" {
   tags       = tags("sensing-perception")
   platforms  = PLATFORM == "" ? [] : [PLATFORM]
 }
+
+target "simulator" {
+  inherits   = ["_component-base"]
+  context    = "."
+  dockerfile = "docker/simulator/Dockerfile"
+  target     = "simulator"
+  tags       = tags("simulator")
+  platforms  = PLATFORM == "" ? [] : [PLATFORM]
+}

--- a/docker/localization-mapping/Dockerfile
+++ b/docker/localization-mapping/Dockerfile
@@ -1,0 +1,11 @@
+# docker/localization-mapping/Dockerfile
+# Passthrough component: localization-mapping ships only what is already
+# in upstream universe. Will become a two-stage build once openadkit-only
+# sources are added to extras/localization-mapping/src/.
+
+# hadolint ignore=DL3006
+ARG UPSTREAM_DEVEL
+ARG UPSTREAM_RUN
+ARG ROS_DISTRO=jazzy
+
+FROM ${UPSTREAM_RUN} AS localization-mapping

--- a/docker/planning-control/Dockerfile
+++ b/docker/planning-control/Dockerfile
@@ -1,0 +1,11 @@
+# docker/planning-control/Dockerfile
+# Passthrough component: planning-control ships only what is already in
+# upstream universe. Will become a two-stage build once openadkit-only
+# sources are added to extras/planning-control/src/.
+
+# hadolint ignore=DL3006
+ARG UPSTREAM_DEVEL
+ARG UPSTREAM_RUN
+ARG ROS_DISTRO=jazzy
+
+FROM ${UPSTREAM_RUN} AS planning-control

--- a/docker/sensing-perception/Dockerfile
+++ b/docker/sensing-perception/Dockerfile
@@ -1,0 +1,11 @@
+# docker/sensing-perception/Dockerfile
+# Passthrough component: sensing-perception ships only what is already in
+# upstream universe. Will become a two-stage build once openadkit-only
+# sources are added to extras/sensing-perception/src/.
+
+# hadolint ignore=DL3006
+ARG UPSTREAM_DEVEL
+ARG UPSTREAM_RUN
+ARG ROS_DISTRO=jazzy
+
+FROM ${UPSTREAM_RUN} AS sensing-perception

--- a/docker/simulator/Dockerfile
+++ b/docker/simulator/Dockerfile
@@ -1,0 +1,11 @@
+# docker/simulator/Dockerfile
+# Passthrough component: simulator ships only what is already in upstream
+# universe. Will become a two-stage build once openadkit-only sources are
+# added to extras/simulator/src/.
+
+# hadolint ignore=DL3006
+ARG UPSTREAM_DEVEL
+ARG UPSTREAM_RUN
+ARG ROS_DISTRO=jazzy
+
+FROM ${UPSTREAM_RUN} AS simulator

--- a/docker/vehicle-system/Dockerfile
+++ b/docker/vehicle-system/Dockerfile
@@ -1,0 +1,11 @@
+# docker/vehicle-system/Dockerfile
+# Passthrough component: vehicle-system ships only what is already in
+# upstream universe. Will become a two-stage build once openadkit-only
+# sources are added to extras/vehicle-system/src/.
+
+# hadolint ignore=DL3006
+ARG UPSTREAM_DEVEL
+ARG UPSTREAM_RUN
+ARG ROS_DISTRO=jazzy
+
+FROM ${UPSTREAM_RUN} AS vehicle-system

--- a/docker/visualizer/Dockerfile
+++ b/docker/visualizer/Dockerfile
@@ -1,0 +1,11 @@
+# docker/visualizer/Dockerfile
+# Passthrough component: visualizer ships only what is already in upstream
+# universe. The VNC/NoVNC desktop layer from components/visualizer/ is
+# folded back in as part of Task 7 (add-on layer) in a later PR.
+
+# hadolint ignore=DL3006
+ARG UPSTREAM_DEVEL
+ARG UPSTREAM_RUN
+ARG ROS_DISTRO=jazzy
+
+FROM ${UPSTREAM_RUN} AS visualizer


### PR DESCRIPTION
> Draft / stacked on #76. Merge #76 first, then this rebases onto `main` and is marked ready for review.

## Summary

Adds a passthrough `docker/<component>/Dockerfile` and bake target for each of the seven openadkit components:

- `api`
- `localization-mapping`
- `planning-control`
- `sensing-perception`
- `simulator`
- `vehicle-system`
- `visualizer`

Each Dockerfile is a thin re-tag of `ghcr.io/autowarefoundation/autoware:universe-${ROS_DISTRO}`, kept as a real Dockerfile (rather than a bake-only re-tag) so every component shares the same CI shape — bake target, hadolint pass, image build.

After this lands, `docker buildx bake -f docker/bake.hcl --print <component>` works for every non-CUDA component, and a single-component build (`--load <component>`) produces `openadkit:<component>-<distro>` locally. Add-on layers (extras/<component>/src + colcon build) and CUDA siblings land in subsequent stacked PRs.

Refs: #47, #50
Depends on: #76

## Test plan

- [x] `docker buildx bake -f docker/bake.hcl --print <component>` resolves for all 7 components
- [x] `docker buildx bake -f docker/bake.hcl --load api` produces `openadkit:api-jazzy` locally (linux/amd64)
- [x] `docker run --rm -i hadolint/hadolint < docker/<component>/Dockerfile` clean for all 7
- [ ] CI green after rebase onto main