### PR TITLE
feat(docker): add CUDA sibling, arm64 probe, and universe aggregators

### DIFF
--- a/docker/bake.hcl
+++ b/docker/bake.hcl
@@ -164,3 +164,12 @@ target "universe" {
   tags       = tags("universe")
   platforms  = PLATFORM == "" ? [] : [PLATFORM]
 }
+
+target "universe-cuda" {
+  inherits   = ["_component-cuda-base"]
+  context    = "."
+  dockerfile = "docker/universe/Dockerfile.cuda"
+  target     = "universe-cuda"
+  tags       = tags("universe-cuda")
+  platforms  = PLATFORM == "" ? [] : [PLATFORM]
+}

--- a/docker/bake.hcl
+++ b/docker/bake.hcl
@@ -146,3 +146,12 @@ target "visualizer" {
   tags       = tags("visualizer")
   platforms  = PLATFORM == "" ? [] : [PLATFORM]
 }
+
+target "sensing-perception-cuda" {
+  inherits   = ["_component-cuda-base"]
+  context    = "."
+  dockerfile = "docker/sensing-perception/Dockerfile.cuda"
+  target     = "sensing-perception-cuda"
+  tags       = tags("sensing-perception-cuda")
+  platforms  = PLATFORM == "" ? [] : [PLATFORM]
+}

--- a/docker/bake.hcl
+++ b/docker/bake.hcl
@@ -155,3 +155,12 @@ target "sensing-perception-cuda" {
   tags       = tags("sensing-perception-cuda")
   platforms  = PLATFORM == "" ? [] : [PLATFORM]
 }
+
+target "universe" {
+  inherits   = ["_component-base"]
+  context    = "."
+  dockerfile = "docker/universe/Dockerfile"
+  target     = "universe"
+  tags       = tags("universe")
+  platforms  = PLATFORM == "" ? [] : [PLATFORM]
+}

--- a/docker/sensing-perception/Dockerfile.cuda
+++ b/docker/sensing-perception/Dockerfile.cuda
@@ -1,0 +1,11 @@
+# docker/sensing-perception/Dockerfile.cuda
+# Passthrough CUDA component: sensing-perception-cuda re-tags the upstream
+# universe-cuda-<distro> image. Will become a two-stage build only if
+# openadkit-only CUDA sources are ever added to extras/sensing-perception/src/.
+
+# hadolint ignore=DL3006
+ARG UPSTREAM_DEVEL
+ARG UPSTREAM_RUN
+ARG ROS_DISTRO=jazzy
+
+FROM ${UPSTREAM_RUN} AS sensing-perception-cuda

--- a/docker/universe/Dockerfile
+++ b/docker/universe/Dockerfile
@@ -1,0 +1,14 @@
+# docker/universe/Dockerfile
+# Passthrough aggregator: openadkit:universe-<distro> re-tags the upstream
+# universe-<distro> runtime image. The container-build-revamp inventory
+# (2026-05-20) confirmed zero openadkit-only sources across all components,
+# so upstream universe already IS the aggregator. This Dockerfile exists so
+# universe has the same CI shape as every other openadkit component
+# (bake target, hadolint pass, image build).
+
+# hadolint ignore=DL3006
+ARG UPSTREAM_DEVEL
+ARG UPSTREAM_RUN
+ARG ROS_DISTRO=jazzy
+
+FROM ${UPSTREAM_RUN} AS universe

--- a/docker/universe/Dockerfile.cuda
+++ b/docker/universe/Dockerfile.cuda
@@ -1,0 +1,13 @@
+# docker/universe/Dockerfile.cuda
+# Passthrough CUDA aggregator: openadkit:universe-cuda-<distro> re-tags the
+# upstream universe-cuda-<distro> runtime image. Same shape as
+# docker/universe/Dockerfile but parented on the CUDA flavor. arm64
+# availability is gated by upstream and probed at CI job start via
+# scripts/probe_upstream_cuda_arm64.sh.
+
+# hadolint ignore=DL3006
+ARG UPSTREAM_DEVEL
+ARG UPSTREAM_RUN
+ARG ROS_DISTRO=jazzy
+
+FROM ${UPSTREAM_RUN} AS universe-cuda

--- a/scripts/probe_upstream_cuda_arm64.sh
+++ b/scripts/probe_upstream_cuda_arm64.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# scripts/probe_upstream_cuda_arm64.sh
+# Prints "true" or "false" on stdout depending on whether the upstream CUDA
+# image manifest for the given distro contains a linux/arm64 entry.
+#
+# CI workflows call this at job start to decide whether to include arm64 in
+# the CUDA build matrix (see spec D3). Always exits 0 so the calling step
+# can branch on stdout without worrying about set -e.
+set -euo pipefail
+
+distro="${1:?usage: $0 <ros_distro>}"
+image="ghcr.io/autowarefoundation/autoware:universe-cuda-${distro}"
+
+# The raw manifest list is JSON, sometimes compact and sometimes pretty-printed
+# (`docker buildx imagetools inspect --raw` formatting varies by buildx version).
+# Match the architecture field tolerantly to whitespace so both forms work.
+if docker buildx imagetools inspect --raw "${image}" 2>/dev/null \
+   | grep -Eq '"architecture"[[:space:]]*:[[:space:]]*"arm64"'; then
+  echo "true"
+else
+  echo "false"
+fi


### PR DESCRIPTION
> Draft / stacked on #80 (which is stacked on #76). Merge #76 then #80 first; this PR then rebases onto main.

## Summary

Combined PR3 + PR4 of the container-build revamp. Implements:

- **Task 8** — `docker/sensing-perception/Dockerfile.cuda` + `sensing-perception-cuda` bake target inheriting `_component-cuda-base` (parents on `universe-devel-cuda-<distro>` / `universe-cuda-<distro>`).
- **Task 10** — `scripts/probe_upstream_cuda_arm64.sh`. CI calls this at the start of every CUDA job to decide whether to include `linux/arm64` in the matrix; degrades to amd64-only when upstream lacks an arm64 layer.
- **Task 9** — `docker/universe/Dockerfile` + `docker/universe/Dockerfile.cuda` + matching `target "universe"` / `target "universe-cuda"` bake blocks. Both are passthrough re-tags of upstream `universe-<distro>` / `universe-cuda-<distro>`; they exist only to give the universe targets the same CI shape (bake target, hadolint pass, image build) as every other openadkit component.

**Note on Task 7 (add-on layers):** the inventory step audited all 43 bind-mount paths in today's `components/*/Dockerfile` and found **zero openadkit-only sources** — every path is covered by upstream `autoware.repos`, including `sensor_component`. Per the plan's fallback ("if the inventory says 'no openadkit-only sources', skip the component — its passthrough is the final form"), Task 7 collapses to a no-op and every component, including the CUDA variant and both universe aggregators added here, ships as a passthrough re-tag.

Depends on: #80
Refs: #47, #50

## Test plan

- [x] `docker buildx bake -f docker/bake.hcl --print sensing-perception-cuda` resolves with CUDA upstream tags
- [x] `docker buildx bake -f docker/bake.hcl --print default` resolves all 8 component targets including `universe`
- [x] `docker buildx bake -f docker/bake.hcl --print default-cuda` resolves both `sensing-perception-cuda` and `universe-cuda`
- [x] `PLATFORM=linux/amd64 docker buildx bake --load sensing-perception-cuda` builds (linux/amd64)
- [x] `docker buildx bake --load universe` builds; `ros2 pkg list | wc -l` = 768 inside `openadkit:universe-jazzy`
- [x] `PLATFORM=linux/amd64 docker buildx bake --load universe-cuda` builds; count = 778 inside `openadkit:universe-cuda-jazzy`
- [x] `scripts/probe_upstream_cuda_arm64.sh jazzy` returns `true` (verified against current upstream manifest)
- [x] hadolint clean on all three new Dockerfiles
- [ ] CI green after rebase onto main
