### PR TITLE
feat(docker): add universe + universe-cuda aggregators on upstream

### DIFF
--- a/docker/bake.hcl
+++ b/docker/bake.hcl
@@ -164,3 +164,12 @@ target "universe" {
   tags       = tags("universe")
   platforms  = PLATFORM == "" ? [] : [PLATFORM]
 }
+
+target "universe-cuda" {
+  inherits   = ["_component-cuda-base"]
+  context    = "."
+  dockerfile = "docker/universe/Dockerfile.cuda"
+  target     = "universe-cuda"
+  tags       = tags("universe-cuda")
+  platforms  = PLATFORM == "" ? [] : [PLATFORM]
+}

--- a/docker/bake.hcl
+++ b/docker/bake.hcl
@@ -155,3 +155,12 @@ target "sensing-perception-cuda" {
   tags       = tags("sensing-perception-cuda")
   platforms  = PLATFORM == "" ? [] : [PLATFORM]
 }
+
+target "universe" {
+  inherits   = ["_component-base"]
+  context    = "."
+  dockerfile = "docker/universe/Dockerfile"
+  target     = "universe"
+  tags       = tags("universe")
+  platforms  = PLATFORM == "" ? [] : [PLATFORM]
+}

--- a/docker/universe/Dockerfile
+++ b/docker/universe/Dockerfile
@@ -1,0 +1,14 @@
+# docker/universe/Dockerfile
+# Passthrough aggregator: openadkit:universe-<distro> re-tags the upstream
+# universe-<distro> runtime image. The container-build-revamp inventory
+# (2026-05-20) confirmed zero openadkit-only sources across all components,
+# so upstream universe already IS the aggregator. This Dockerfile exists so
+# universe has the same CI shape as every other openadkit component
+# (bake target, hadolint pass, image build).
+
+# hadolint ignore=DL3006
+ARG UPSTREAM_DEVEL
+ARG UPSTREAM_RUN
+ARG ROS_DISTRO=jazzy
+
+FROM ${UPSTREAM_RUN} AS universe

--- a/docker/universe/Dockerfile.cuda
+++ b/docker/universe/Dockerfile.cuda
@@ -1,0 +1,13 @@
+# docker/universe/Dockerfile.cuda
+# Passthrough CUDA aggregator: openadkit:universe-cuda-<distro> re-tags the
+# upstream universe-cuda-<distro> runtime image. Same shape as
+# docker/universe/Dockerfile but parented on the CUDA flavor. arm64
+# availability is gated by upstream and probed at CI job start via
+# scripts/probe_upstream_cuda_arm64.sh.
+
+# hadolint ignore=DL3006
+ARG UPSTREAM_DEVEL
+ARG UPSTREAM_RUN
+ARG ROS_DISTRO=jazzy
+
+FROM ${UPSTREAM_RUN} AS universe-cuda


### PR DESCRIPTION
> Draft / stacked on #81 (which is stacked on #80, which is stacked on #76). Merge #76 → #80 → #81 first; this PR rebases onto its new base automatically as the stack lands.

## Summary

PR4 of the container-build revamp. Adds the openadkit-flavored aggregator images on the new upstream-derived pipeline:

- `docker/universe/Dockerfile` — passthrough on `ghcr.io/autowarefoundation/autoware:universe-<distro>`
- `docker/universe/Dockerfile.cuda` — passthrough on `ghcr.io/autowarefoundation/autoware:universe-cuda-<distro>`
- `docker/bake.hcl` — adds `target "universe"` (inherits `_component-base`) and `target "universe-cuda"` (inherits `_component-cuda-base`) so the existing `default` / `default-cuda` group entries from #76 resolve.

**Why passthrough:** the inventory of bind-mount paths across every component Dockerfile (see PR1) found zero openadkit-only sources — upstream `autoware.repos` covers everything. The upstream universe image therefore *is* the aggregator; this PR exists only to give the universe targets the same CI shape (bake target, hadolint pass, image build) as every other openadkit component.

Depends on: #81
Refs: #47, #50

## Test plan

- [x] `docker buildx bake -f docker/bake.hcl --print default` resolves all 8 component targets including `universe`
- [x] `docker buildx bake -f docker/bake.hcl --print default-cuda` resolves both `sensing-perception-cuda` and `universe-cuda`
- [x] `docker buildx bake -f docker/bake.hcl --load universe` builds; `ros2 pkg list | wc -l` = 768 inside `openadkit:universe-jazzy`
- [x] `PLATFORM=linux/amd64 docker buildx bake -f docker/bake.hcl --load universe-cuda` builds on amd64; `ros2 pkg list | wc -l` = 778
- [x] hadolint clean on both new Dockerfiles
- [x] `scripts/probe_upstream_cuda_arm64.sh jazzy` prints `true` (upstream CUDA arm64 manifest is currently available)
- [ ] CI green after rebase onto new base as the stack lands