### PR TITLE
fix(containers): bridge CUDA 13 cccl headers for legacy thrust/cub includes

### DIFF
--- a/components/common/Dockerfile
+++ b/components/common/Dockerfile
@@ -58,6 +58,25 @@ RUN --mount=type=ssh \
   && pipx uninstall ansible \
   && /scripts/cleanup_apt.sh true
 
+# CUDA 13 moved Thrust, CUB, and the libcudacxx `cuda/` headers under
+# /usr/local/cuda/include/cccl/. Downstream consumers that still use the
+# legacy unprefixed includes (e.g. `#include <thrust/sort.h>` in
+# autoware_universe's bevdet_vendor) need both:
+#   (a) `<thrust/...>` and `<cub/...>` to resolve — handled by relative
+#       symlinks below;
+#   (b) Thrust's INTERNAL chain to find `<cuda/__cccl_config>` etc., which
+#       live at .../include/cccl/cuda/ — handled by adding the cccl include
+#       root to CPATH so both nvcc and gcc/g++ pick it up transparently.
+# Both are no-ops on CUDA 12.x: the cccl/ subdir doesn't exist there, the
+# `for d` loop runs but creates nothing, and an unmatched CPATH entry is
+# silently ignored by the compiler driver.
+RUN for d in thrust cub; do \
+      if [ -d "/usr/local/cuda/include/cccl/${d}" ] && [ ! -e "/usr/local/cuda/include/${d}" ]; then \
+        ln -s "cccl/${d}" "/usr/local/cuda/include/${d}"; \
+      fi; \
+    done
+ENV CPATH="/usr/local/cuda/include/cccl${CPATH:+:$CPATH}"
+
 # =============================================================================
 # Stage: common-devel
 # Common development image with ROS and autoware-universe common packages
@@ -129,3 +148,12 @@ RUN --mount=type=ssh \
   ./setup-dev-env.sh -y --module all --no-cuda-drivers --ros-distro "$ROS_DISTRO" openadkit  \
   && pipx uninstall ansible \
   && /scripts/cleanup_apt.sh true
+
+# Bridge CUDA 13's cccl/ subdir to legacy thrust/cub/cuda includes.
+# No-op on CUDA 12.x.
+RUN for d in thrust cub; do \
+      if [ -d "/usr/local/cuda/include/cccl/${d}" ] && [ ! -e "/usr/local/cuda/include/${d}" ]; then \
+        ln -s "cccl/${d}" "/usr/local/cuda/include/${d}"; \
+      fi; \
+    done
+ENV CPATH="/usr/local/cuda/include/cccl${CPATH:+:$CPATH}"


### PR DESCRIPTION
**Fixes CI build failure:**
[build-components (linux/amd64, amd64, jazzy, sensing-perception-cuda)](https://github.com/autowarefoundation/openadkit/actions/runs/27065558313/job/79891437501)

Fails with:
```
fatal error: thrust/sort.h: No such file or directory
```

Upstream `bevdet_vendor`'s use of legacy unprefixed thrust includes (e.g. `#include <thrust/sort.h>`) fails on CUDA 13 because NVIDIA moved Thrust, CUB, and libcudacxx headers under `/usr/local/cuda/include/cccl/`.

**What changed**
- Added relative symlinks for `thrust` and `cub` from `/usr/local/cuda/include/cccl/` to `/usr/local/cuda/include/` in both `common-base-cuda` and `common-devel-cuda` stages.
- Added `CPATH=/usr/local/cuda/include/cccl` so Thrust's internal header chain (`<cuda/__cccl_config>`, etc.) resolves for both nvcc and gcc/g++.

**Compatibility**
- Both changes are no-ops on CUDA 12.x: the `cccl/` subdir does not exist there, the symlink loop creates nothing, and an unmatched CPATH entry is silently ignored by the compiler driver.

**Upstream reference**
- autowarefoundation/autoware#7108 — same fix applied to upstream Autoware Dockerfiles.

**Verification**
- `git diff --check`
- `bash -n build.sh`
- `python3 -m json.tool .github/image-inventory.json`