### PR TITLE
docs: consistency and completeness overhaul

### DIFF
--- a/components/visualizer/README.md
+++ b/components/visualizer/README.md
@@ -1,11 +1,11 @@
-# Autoware Tools - Visualizer
+# Visualizer
 
 Opens a remote RViz display for Autoware.
 
 ## Standalone Run
 
 ```bash
-docker run --rm --name visualizer -p 6080:6080 ghcr.io/autowarefoundation/autoware-tools:visualizer
+docker run --rm --name visualizer -p 6080:6080 ghcr.io/autowarefoundation/openadkit:visualizer
 ```
 
 ## Settings

--- a/deployments/demos/zenoh-bridge/docker-compose.yaml
+++ b/deployments/demos/zenoh-bridge/docker-compose.yaml
@@ -80,7 +80,7 @@ services:
       -c /config/zenoh-bridge-ros2dds.json5
 
   visualizer:
-    image: ghcr.io/autowarefoundation/autoware-tools:visualizer-20251009
+    image: ghcr.io/autowarefoundation/openadkit:visualizer
     environment:
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - ROS_DOMAIN_ID=1

--- a/docs/.pages
+++ b/docs/.pages
@@ -3,7 +3,6 @@ nav:
   - getting-started
   - deployments
   - components
-  - tools
   - platforms
   - hardware
   - contributing

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -37,3 +37,15 @@ The `vehicle-system` image packages both the vehicle interface and system-level 
 ### API
 
 The API component is responsible for providing [AD API](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-interfaces/ad-api/) interface for the vehicle's state. API component can be configured to enable or disable various interfaces. For more details, see the [Autoware Interface design document](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-architecture-v1/interfaces/).
+
+### Simulator
+
+The `simulator` image packages the Autoware simulator modules, providing a virtual environment for testing the autonomous driving stack without requiring real-world sensors or vehicles. It enables closed-loop simulation for validation, CI, and local development.
+
+### Visualizer
+
+The `visualizer` image provides a browser-accessible RViz environment via noVNC, allowing remote inspection of Autoware topics and state. It is designed as a lightweight component that can be deployed alongside the core stack or on a separate machine for remote monitoring.
+
+### CARLA Interface
+
+The `carla-interface` image packages the `autoware_carla_interface` bridge, enabling closed-loop end-to-end simulation with the [CARLA](https://carla.org/) simulator. It connects Autoware's control outputs to CARLA's ego vehicle and translates CARLA sensor data into Autoware-compatible messages.

--- a/docs/deployments/index.md
+++ b/docs/deployments/index.md
@@ -14,4 +14,4 @@ Sample deployment configurations to help you get started. Recommended for **lear
 
 Demo deployment configurations that are specific to certain **use case scenarios**.
 
-- [Zenoh-bridge](demos/zenoh-bridge/index.md) - Demonstrates a "Cloud-Edge" deployment model by seamlessly bridging two isolated ROS 2 environments, decoupling compute-intensive components from lightweight visualization tools.
+- [Zenoh-bridge](demos/zenoh-bridge/index.md) - Demonstrates a "Cloud-Edge" deployment model by seamlessly bridging two isolated ROS 2 environments, decoupling compute-intensive components from lightweight visualization components.

--- a/docs/deployments/samples/scenario-simulation/index.md
+++ b/docs/deployments/samples/scenario-simulation/index.md
@@ -2,6 +2,10 @@
 
 This sample deployment demonstrates the Open AD Kit scenario simulation workflow with the official [TIER IV Scenario Simulator container](https://github.com/tier4/scenario_simulator_v2/pkgs/container/scenario_simulator_v2).
 
+The [TIER IV Scenario Simulator](https://tier4.github.io/scenario_simulator_v2-docs/) enables users to test their autonomous driving system in a virtual environment. It uses a scenario runner to execute more complex simulations based on predefined scenarios, and it can be used both in CI and on a local machine.
+
+Open AD Kit deployments use the official TIER IV runtime image directly instead of building a custom wrapper image.
+
 ## Source of Truth
 
 The complete operational instructions for this deployment live alongside the deployment assets in `deployments/samples/scenario-simulation/README.md`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ A **deployment** is a running instance of Open AD Kit, a specific combination of
 
 Deployments are defined using container orchestration files (e.g., `docker-compose.yaml`). This makes them portable and easy to reproduce across different environments, from a developer's laptop to edge devices in a vehicle. This container-based approach is a cornerstone of the Open AD Kit's cloud-native and platform-agnostic philosophy, aligning with standards like SOAFEE.
 
-This modular structure allows users to start with a minimal deployment and incrementally add components and tools as their system evolves.
+This modular structure allows users to start with a minimal deployment and incrementally add components as their system evolves.
 
 For more details, see the [Deployments](./deployments/index.md).
 
@@ -33,14 +33,6 @@ The primary images include:
 - **Visualizer**: Provides a browser-accessible RViz environment for remote inspection.
 
 These images communicate through ROS 2 middleware, and some deployments bridge isolated environments with Zenoh. For more details, see the [Autoware components](./components/index.md).
-
-## Tools
-
-In addition to the **Autoware components**, Open AD Kit integrates essential containerized tools for development, simulation, and visualization.
-
-- **TIER IV Scenario Simulator**: Runs scenario-based simulations for validation, CI, and local development.
-
-For more details, see the [Tools](./tools/index.md).
 
 ## Supported Platforms
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,9 +1,0 @@
-# Tools
-
-Open AD Kit uses containerized third-party tools for testing, deploying, and managing autonomous driving systems. These tools complement the **Autoware components** and can be integrated into deployments as needed.
-
-## Scenario Simulator
-
-The [TIER IV Scenario Simulator](https://tier4.github.io/scenario_simulator_v2-docs/) enables users to test their autonomous driving system in a virtual environment. It uses a scenario runner to execute more complex simulations based on predefined scenarios, and it can be used both in CI and on a local machine.
-
-Open AD Kit deployments use the official TIER IV runtime image directly instead of building a custom wrapper image. See the [Scenario Simulation sample](../deployments/samples/scenario-simulation/index.md) for a runnable Open AD Kit workflow using `ghcr.io/tier4/scenario_simulator_v2`.


### PR DESCRIPTION
**⚠️ Depends on: the CARLA Interface component PR must be merged before this PR.**

## Summary

This PR officially completes the transition from a separate "tools" section to treating all built containers as first-class "components" under the openadkit GHCR registry.

## Motivation

We recently decided to eliminate the tools section inside Open AD Kit. All containers built in this repository—including visualizer, simulator, and carla-interface—are now kept in the components section and published to the openadkit registry directly, rather than a separate autoware-tools registry.

## Changes

- **GHCR references**: Updated stale autoware-tools image references to openadkit:
  - zenoh-bridge docker-compose visualizer image
  - visualizer README standalone run example
- **Documentation navigation**: Removed tools from MkDocs nav (docs/.pages)
- **Content rehome**: Deleted docs/tools/ directory and moved the TIER IV Scenario Simulator description into deployments/docs
- **Landing page**: Removed the dedicated "Tools" section from docs/index.md and updated phrasing to reference only "components"
- **Component docs**: Added Simulator, Visualizer, and CARLA Interface as documented first-class components in docs/components/index.md
- **Deployment docs**: Updated terminology from "tools" to "components" in deployments
- **README cleanup**: Updated visualizer component README title to drop the "Autoware Tools" prefix