### PR TITLE
perf(ci): persist BuildKit cache mounts across runs

### DIFF
--- a/.github/workflows/build-all-images.yaml
+++ b/.github/workflows/build-all-images.yaml
@@ -401,31 +401,16 @@ jobs:
       - name: Inject BuildKit cache mounts
         uses: reproducible-containers/buildkit-cache-dance@v3
         with:
+          # Only ccache is persisted across runs: it is the entire ~4.5x
+          # recompile win and stays small (~0.14 GB/leg). apt/pip mounts were
+          # dropped to keep the repo-wide 10 GB cache budget clear of LRU
+          # eviction (their bandwidth-bound saving is largely covered by the
+          # registry layer cache anyway).
           cache-map: |
             {
-              "cache-mounts/apt-cache": {
-                "id": "apt-cache-${{ matrix.ros-distro }}",
-                "target": "/var/cache/apt"
-              },
-              "cache-mounts/apt-lists": {
-                "id": "apt-lists-${{ matrix.ros-distro }}",
-                "target": "/var/lib/apt/lists"
-              },
               "cache-mounts/ccache": {
                 "id": "ccache-${{ matrix.ros-distro }}",
                 "target": "/home/aw/.ccache",
-                "uid": "1000",
-                "gid": "1000"
-              },
-              "cache-mounts/pip": {
-                "id": "pip-cache",
-                "target": "/home/aw/.cache/pip",
-                "uid": "1000",
-                "gid": "1000"
-              },
-              "cache-mounts/pipx": {
-                "id": "pipx-cache",
-                "target": "/home/aw/.cache/pipx",
                 "uid": "1000",
                 "gid": "1000"
               }
@@ -574,28 +559,14 @@ jobs:
       - name: Inject BuildKit cache mounts
         uses: reproducible-containers/buildkit-cache-dance@v3
         with:
+          # Only ccache is persisted across runs (see build-common above for
+          # the rationale). A single uniform map also drops the previous CUDA
+          # apt special-case.
           cache-map: |
             {
-              ${{ matrix.target != 'sensing-perception-cuda' && format('"cache-mounts/apt-cache": {{ "id": "apt-cache-{0}", "target": "/var/cache/apt" }},', matrix.ros-distro) || '' }}
-              "cache-mounts/apt-lists": {
-                "id": "apt-lists-${{ matrix.ros-distro }}",
-                "target": "/var/lib/apt/lists"
-              },
               "cache-mounts/ccache": {
                 "id": "ccache-${{ matrix.ros-distro }}",
                 "target": "/home/aw/.ccache",
-                "uid": "1000",
-                "gid": "1000"
-              },
-              "cache-mounts/pip": {
-                "id": "pip-cache",
-                "target": "/home/aw/.cache/pip",
-                "uid": "1000",
-                "gid": "1000"
-              },
-              "cache-mounts/pipx": {
-                "id": "pipx-cache",
-                "target": "/home/aw/.cache/pipx",
                 "uid": "1000",
                 "gid": "1000"
               }

--- a/.github/workflows/build-all-images.yaml
+++ b/.github/workflows/build-all-images.yaml
@@ -272,9 +272,12 @@ jobs:
     needs: prepare
     runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-22.04' || 'ubuntu-22.04-arm' }}
     permissions:
-      actions: read
+      actions: write
       contents: read
       packages: write
+    env:
+      CACHE_KEY_PREFIX: buildkit-mounts-universe-common-${{ matrix.ros-distro }}-${{ matrix.platform-label }}-
+      IS_MAIN_PUSH: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     strategy:
       fail-fast: false
       max-parallel: 8
@@ -378,6 +381,57 @@ jobs:
           [ "${fail}" -eq 0 ]
         shell: bash
 
+      - name: Restore BuildKit cache mounts
+        id: cache-restore
+        uses: actions/cache/restore@v5
+        with:
+          path: cache-mounts
+          key: ${{ env.CACHE_KEY_PREFIX }}${{ github.sha }}
+          restore-keys: |
+            ${{ env.CACHE_KEY_PREFIX }}
+
+      - name: Arm post-step save of BuildKit cache mounts (main only)
+        if: env.IS_MAIN_PUSH == 'true'
+        uses: actions/cache@v5
+        with:
+          path: cache-mounts
+          key: ${{ env.CACHE_KEY_PREFIX }}${{ github.sha }}
+          lookup-only: true
+
+      - name: Inject BuildKit cache mounts
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          cache-map: |
+            {
+              "cache-mounts/apt-cache": {
+                "id": "apt-cache-${{ matrix.ros-distro }}",
+                "target": "/var/cache/apt"
+              },
+              "cache-mounts/apt-lists": {
+                "id": "apt-lists-${{ matrix.ros-distro }}",
+                "target": "/var/lib/apt/lists"
+              },
+              "cache-mounts/ccache": {
+                "id": "ccache-${{ matrix.ros-distro }}",
+                "target": "/home/aw/.ccache",
+                "uid": "1000",
+                "gid": "1000"
+              },
+              "cache-mounts/pip": {
+                "id": "pip-cache",
+                "target": "/home/aw/.cache/pip",
+                "uid": "1000",
+                "gid": "1000"
+              },
+              "cache-mounts/pipx": {
+                "id": "pipx-cache",
+                "target": "/home/aw/.cache/pipx",
+                "uid": "1000",
+                "gid": "1000"
+              }
+            }
+          skip-extraction: ${{ steps.cache-restore.outputs.cache-hit }}
+
       - name: Build and push universe-common images
         uses: docker/bake-action@v5
         env:
@@ -404,6 +458,29 @@ jobs:
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/openadkit-buildcache:universe-common-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-main
             *.cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/openadkit-buildcache:universe-common-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-main,mode=max
 
+      - name: Prune BuildKit cache mount lineage (main only)
+        if: env.IS_MAIN_PUSH == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KEEP_KEY: ${{ env.CACHE_KEY_PREFIX }}${{ github.sha }}
+          MAX_GB: 6
+        run: |
+          set -euo pipefail
+          # KEEP_KEY is written by the actions/cache POST step, which runs after
+          # this step, so it is never present here: this prune only removes
+          # prior-lineage caches. The size check refreshes an oversized cache on
+          # a same-SHA rerun (when KEEP_KEY already exists). --limit caps recovery
+          # if a lineage ever exceeds it; steady state keeps a single entry.
+          max_bytes=$((MAX_GB * 1000 * 1000 * 1000))
+          gh cache list --repo "$GITHUB_REPOSITORY" --key "$CACHE_KEY_PREFIX" --limit 100 --json key,sizeInBytes \
+            | jq -r --arg keep "$KEEP_KEY" --argjson max "$max_bytes" \
+                '.[] | select(.key != $keep or .sizeInBytes > $max) | .key' \
+            | while read -r key; do
+                echo "delete: $key"
+                gh cache delete "$key" --repo "$GITHUB_REPOSITORY" || true
+              done
+        shell: bash
+
   # =============================================================================
   # Stage 2: Build component images (parallel)
   # =============================================================================
@@ -411,9 +488,12 @@ jobs:
     runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-22.04' || 'ubuntu-22.04-arm' }}
     needs: [prepare, build-common]
     permissions:
-      actions: read
+      actions: write
       contents: read
       packages: write
+    env:
+      CACHE_KEY_PREFIX: buildkit-mounts-${{ matrix.target }}-${{ matrix.ros-distro }}-${{ matrix.platform-label }}-
+      IS_MAIN_PUSH: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     strategy:
       fail-fast: false
       max-parallel: 8
@@ -474,6 +554,54 @@ jobs:
           flavor: |
             latest=false
 
+      - name: Restore BuildKit cache mounts
+        id: cache-restore
+        uses: actions/cache/restore@v5
+        with:
+          path: cache-mounts
+          key: ${{ env.CACHE_KEY_PREFIX }}${{ github.sha }}
+          restore-keys: |
+            ${{ env.CACHE_KEY_PREFIX }}
+
+      - name: Arm post-step save of BuildKit cache mounts (main only)
+        if: env.IS_MAIN_PUSH == 'true'
+        uses: actions/cache@v5
+        with:
+          path: cache-mounts
+          key: ${{ env.CACHE_KEY_PREFIX }}${{ github.sha }}
+          lookup-only: true
+
+      - name: Inject BuildKit cache mounts
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          cache-map: |
+            {
+              ${{ matrix.target != 'sensing-perception-cuda' && format('"cache-mounts/apt-cache": {{ "id": "apt-cache-{0}", "target": "/var/cache/apt" }},', matrix.ros-distro) || '' }}
+              "cache-mounts/apt-lists": {
+                "id": "apt-lists-${{ matrix.ros-distro }}",
+                "target": "/var/lib/apt/lists"
+              },
+              "cache-mounts/ccache": {
+                "id": "ccache-${{ matrix.ros-distro }}",
+                "target": "/home/aw/.ccache",
+                "uid": "1000",
+                "gid": "1000"
+              },
+              "cache-mounts/pip": {
+                "id": "pip-cache",
+                "target": "/home/aw/.cache/pip",
+                "uid": "1000",
+                "gid": "1000"
+              },
+              "cache-mounts/pipx": {
+                "id": "pipx-cache",
+                "target": "/home/aw/.cache/pipx",
+                "uid": "1000",
+                "gid": "1000"
+              }
+            }
+          skip-extraction: ${{ steps.cache-restore.outputs.cache-hit }}
+
       - name: Build and push ${{ matrix.target }}
         uses: docker/bake-action@v5
         env:
@@ -499,6 +627,29 @@ jobs:
             *.labels."org.opencontainers.image.autoware-base-version"=${{ needs.prepare.outputs.autoware_base_version }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/openadkit-buildcache:${{ matrix.target }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-main
             *.cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/openadkit-buildcache:${{ matrix.target }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}-${{ matrix.ros-distro }}-main,mode=max
+
+      - name: Prune BuildKit cache mount lineage (main only)
+        if: env.IS_MAIN_PUSH == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KEEP_KEY: ${{ env.CACHE_KEY_PREFIX }}${{ github.sha }}
+          MAX_GB: 6
+        run: |
+          set -euo pipefail
+          # KEEP_KEY is written by the actions/cache POST step, which runs after
+          # this step, so it is never present here: this prune only removes
+          # prior-lineage caches. The size check refreshes an oversized cache on
+          # a same-SHA rerun (when KEEP_KEY already exists). --limit caps recovery
+          # if a lineage ever exceeds it; steady state keeps a single entry.
+          max_bytes=$((MAX_GB * 1000 * 1000 * 1000))
+          gh cache list --repo "$GITHUB_REPOSITORY" --key "$CACHE_KEY_PREFIX" --limit 100 --json key,sizeInBytes \
+            | jq -r --arg keep "$KEEP_KEY" --argjson max "$max_bytes" \
+                '.[] | select(.key != $keep or .sizeInBytes > $max) | .key' \
+            | while read -r key; do
+                echo "delete: $key"
+                gh cache delete "$key" --repo "$GITHUB_REPOSITORY" || true
+              done
+        shell: bash
 
   # =============================================================================
   # Stage 3: Create multi-arch manifests


### PR DESCRIPTION
Persist the BuildKit **ccache** mount cache between CI runs in the two heavy build jobs (`build-common`, `build-components`) using `actions/cache` + `reproducible-containers/buildkit-cache-dance`. The existing registry layer cache (`cache-from`/`cache-to=type=registry`, `mode=max`) restores whole layers but **not** the contents of `--mount=type=cache` directories, so whenever a RUN layer cache-misses — typically on an Autoware source / `autoware_ref` change — the ccache mount starts empty and colcon recompiles everything. Keeping the mount cache warm lets those rebuilds reuse compiled objects.

## How it works

`actions/cache/restore` always runs (with a `restore-keys` prefix fallback to the latest same-lineage cache). On `main` pushes only, an `actions/cache` step armed with `lookup-only: true` registers the post-job save **before** `buildkit-cache-dance` injects the mount, so the reverse-order post steps extract-then-save. Stale lineage is pruned to one warm cache per `(target, distro, arch)`.

## Only ccache is persisted

Of the BuildKit cache mounts, only **ccache** is carried across runs. It is the entire ~4.5× recompile win (see below) and stays small (~0.14 GB per leg). The apt (`apt-cache`/`apt-lists`) and pip (`pip-cache`/`pipx-cache`) mounts were most of the persisted *size* for a bandwidth-bound saving the registry layer cache already largely covers, so persisting them would mainly spend the repo-wide 10 GB cache budget — across ~34 caches per `main` push their aggregate could straddle the ceiling and trigger LRU eviction that churns the valuable ccache cold (and could evict other workflows' caches). They revert to per-build ephemeral caches.

## No Dockerfile changes

The ccache mount id (`ccache-<distro>`) already matches the cache-map, and the upstream base image already routes the compiler through ccache (`CC`/`CXX` = `/usr/lib/ccache/*`, `CCACHE_DIR=/home/aw/.ccache`).

## Measured effect

Controlled A/B benchmark (planning-control, humble/amd64, identical Autoware source, registry layer cache disabled so colcon fully recompiles each run, ccache zeroed with `ccache -z` then dumped with `ccache -s`):

| planning-control build | cold ccache | warm ccache |
| --- | --- | --- |
| job wall-time | 36 min | **8 min** |
| ccache direct hits | 817 / 2056 (40%) | **2056 / 2056 (100%)** |
| ccache direct misses | 1239 | **0** |
| ccache size | 0.14 GB | 0.14 GB |

~4.5× faster on a full recompile, with ccache direct misses collapsing 1239 → 0. With the registry layer cache kept (as in this PR), **unchanged-source rebuilds are already short-circuited by the layer cache** (ccache adds nothing — no regression); the win materializes on source-changed rebuilds (Autoware ref bumps), scaling toward the figures above as the delta shrinks. Persisting ccache only keeps the aggregate across all legs around ~5 GB, comfortably clear of GitHub's repo-wide 10 GB cache budget.

## Verification

Verified green on a fork (`youtalk/openadkit`) run across `{humble,jazzy} × {amd64,arm64}`; the change is behaviour-neutral versus a same-tree run without the dance (near-identical wall-time, all legs success).
