### PR TITLE
feat(deployments): add AWSIM v2 simulation sample

### DIFF
--- a/components/visualizer/Dockerfile
+++ b/components/visualizer/Dockerfile
@@ -87,8 +87,9 @@ RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=
       pipx && \
     PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install yamale && \
     PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install xmlschema && \
-    curl -fsSL -o /tmp/virtualgl.deb https://github.com/VirtualGL/virtualgl/releases/download/3.1.2/virtualgl_3.1.2_amd64.deb && \
+    curl -fsSL -o /tmp/virtualgl.deb "https://github.com/VirtualGL/virtualgl/releases/download/3.1.2/virtualgl_3.1.2_$(dpkg --print-architecture).deb" && \
     apt-get install -y --no-install-recommends /tmp/virtualgl.deb && \
+    ln -sf /opt/VirtualGL/bin/vglrun /usr/local/bin/vglrun && \
     rm -f /tmp/virtualgl.deb
 
 # Create SSL certificate for NoVNC.
@@ -108,6 +109,7 @@ RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /root/.bashrc && \
 # Copy startup scripts.
 COPY components/visualizer/etc/xstartup /root/.vnc/xstartup
 COPY components/visualizer/etc/visualizer_entrypoint.sh /usr/local/bin/visualizer_entrypoint.sh
-RUN chmod +x /usr/local/bin/visualizer_entrypoint.sh /root/.vnc/xstartup
+COPY components/visualizer/etc/start-rviz2.sh /usr/local/bin/start-rviz2-gpu
+RUN chmod +x /usr/local/bin/visualizer_entrypoint.sh /root/.vnc/xstartup /usr/local/bin/start-rviz2-gpu
 
 ENTRYPOINT ["/usr/local/bin/visualizer_entrypoint.sh"]

--- a/components/visualizer/etc/start-rviz2.sh
+++ b/components/visualizer/etc/start-rviz2.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+export DISPLAY=:99
+export VGL_DISPLAY=egl
+
+source /opt/ros/"$ROS_DISTRO"/setup.bash
+source /opt/autoware/setup.bash
+
+RVIZ_GPU="${RVIZ_GPU:-auto}"
+rviz_launcher=""
+if [ "$RVIZ_GPU" != "off" ]; then
+    vglrun_bin=""
+    if command -v vglrun >/dev/null 2>&1; then
+        vglrun_bin="$(command -v vglrun)"
+    elif [ -x /opt/VirtualGL/bin/vglrun ]; then
+        vglrun_bin=/opt/VirtualGL/bin/vglrun
+    fi
+
+    if [ "$RVIZ_GPU" = "on" ]; then
+        if [ ! -e /dev/nvidia0 ] || [ -z "$vglrun_bin" ]; then
+            echo "RViz: GPU rendering requested but NVIDIA device or VirtualGL is unavailable" >&2
+            exit 1
+        fi
+        rviz_launcher="$vglrun_bin -d egl"
+        echo "RViz: GPU-accelerated rendering forced via VirtualGL (EGL)"
+    elif [ -e /dev/nvidia0 ] && [ -n "$vglrun_bin" ] && ldconfig -p 2>/dev/null | grep -Eq 'libEGL_nvidia|libGLX_nvidia'; then
+        rviz_launcher="$vglrun_bin -d egl"
+        echo "RViz: GPU-accelerated rendering via VirtualGL (EGL)"
+    fi
+fi
+[ -z "$rviz_launcher" ] && echo "RViz: software rendering (no GPU detected; set RVIZ_GPU=on to force VirtualGL)"
+
+exec $rviz_launcher rviz2 -d "$RVIZ_CONFIG" --ros-args -p use_sim_time:="$USE_SIM_TIME"

--- a/components/visualizer/etc/visualizer_entrypoint.sh
+++ b/components/visualizer/etc/visualizer_entrypoint.sh
@@ -35,32 +35,11 @@ configure_vnc() {
   </applications>
 </openbox_config>
 EOF
-    # Create rviz2 start script
-    cat >/usr/local/bin/start-rviz2.sh <<'EOF'
-#!/bin/bash
-source /opt/ros/"$ROS_DISTRO"/setup.bash
-source /opt/autoware/setup.bash
-
-# Optional GPU-accelerated rendering via VirtualGL (EGL). RViz renders in
-# software (llvmpipe) by default, which is slow for dense point clouds and
-# camera images. When an NVIDIA GPU is available in the container, render on
-# it instead. Detection is at runtime so the same image works with or without
-# a GPU. Override with RVIZ_GPU=on (force) or RVIZ_GPU=off (disable).
-RVIZ_GPU="${RVIZ_GPU:-auto}"
-rviz_launcher=""
-if [ "$RVIZ_GPU" != "off" ]; then
-    if [ "$RVIZ_GPU" = "on" ] || { [ -e /dev/nvidia0 ] && command -v vglrun >/dev/null 2>&1 && ldconfig -p 2>/dev/null | grep -q libEGL_nvidia; }; then
-        rviz_launcher="vglrun -d egl"
-        echo "RViz: GPU-accelerated rendering via VirtualGL (EGL)"
-    fi
-fi
-[ -z "$rviz_launcher" ] && echo "RViz: software rendering (no GPU detected; set RVIZ_GPU=on to force VirtualGL)"
-
-exec $rviz_launcher rviz2 -d "$RVIZ_CONFIG" --ros-args -p use_sim_time:="$USE_SIM_TIME"
-EOF
-    chmod +x /usr/local/bin/start-rviz2.sh
+    # Launch the pre-installed GPU-aware rviz2 script (installed by the Dockerfile).
+    # RVIZ_GPU=auto detects, RVIZ_GPU=on forces (errors if GPU/VirtualGL
+    # are missing), RVIZ_GPU=off skips VirtualGL.
     echo "echo 'Autostart executed at $(date)' >> /tmp/autostart.log" >>/etc/xdg/openbox/autostart
-    echo "/usr/local/bin/start-rviz2.sh" >>/etc/xdg/openbox/autostart
+    echo "/usr/local/bin/start-rviz2-gpu" >>/etc/xdg/openbox/autostart
 
     # Configure VNC password
     if [ -z "$REMOTE_PASSWORD" ]; then

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -3,6 +3,7 @@
 This directory contains deployment configurations for **Open AD Kit**. Each folder contains a README file with detailed instructions on how to deploy the deployment configuration.
 
 - **Sample deployment** configurations for development and testing.
+  - [AWSIM Simulation](./samples/awsim-simulation): Open AD Kit deployment that demonstrates the open-source planning stack with AWSIM v2 as an external simulator.
   - [CARLA Simulation](./samples/carla-simulation): Simple Open AD Kit deployment that demonstrates the open-source planning stack with CARLA as an external simulator.
   - [Planning Simulation](./samples/planning-simulation): Simple Open AD Kit deployment that demonstrates the autoware **planning features** with planning simulation.
   - [Scenario Simulation](./samples/scenario-simulation): Simple Open AD Kit deployment that demonstrates **scenario-based validation** with the TIER IV Scenario Simulator.

--- a/deployments/samples/awsim-simulation/Dockerfile
+++ b/deployments/samples/awsim-simulation/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:22.04
+
+ARG AWSIM_VERSION=v2.0.1
+ARG AWSIM_ASSET=AWSIM-Demo-Lightweight.zip
+# Optional: set to the expected SHA-256 of the AWSIM asset to verify the
+# download. Left empty by default so the build works without pinning.
+ARG AWSIM_SHA256=
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    libasound2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libgl1 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnss3 \
+    libvulkan1 \
+    libx11-6 \
+    libxcursor1 \
+    libxext6 \
+    libxi6 \
+    libxinerama1 \
+    libxrandr2 \
+    libxrender1 \
+    libxss1 \
+    unzip \
+    xvfb \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/awsim
+
+RUN curl -L --fail -A Mozilla/5.0 -o /tmp/awsim.zip "https://github.com/autowarefoundation/AWSIM/releases/download/${AWSIM_VERSION}/${AWSIM_ASSET}" \
+  && if [ -n "${AWSIM_SHA256}" ]; then echo "${AWSIM_SHA256}  /tmp/awsim.zip" | sha256sum -c -; fi \
+  && unzip -q /tmp/awsim.zip -d /opt/awsim \
+  && chmod +x "$(find /opt/awsim -name 'AWSIM*.x86_64' -print -quit)" \
+  && rm /tmp/awsim.zip
+
+COPY awsim-entrypoint.sh /usr/local/bin/awsim-entrypoint.sh
+RUN chmod +x /usr/local/bin/awsim-entrypoint.sh
+
+ENTRYPOINT ["awsim-entrypoint.sh"]

--- a/deployments/samples/awsim-simulation/README.md
+++ b/deployments/samples/awsim-simulation/README.md
@@ -1,0 +1,99 @@
+# Autoware Open AD Kit AWSIM E2E Simulation
+
+This sample runs closed-loop AWSIM v2 end-to-end simulation with modular OpenADKit containers.
+
+AWSIM publishes Autoware-compatible ROS 2 sensor and vehicle status topics directly, so this sample does not need a simulator bridge container like the CARLA sample.
+
+## Runtime
+
+- AWSIM: `AWSIM-Demo-Lightweight.zip` from `autowarefoundation/AWSIM` `v2.0.1`, built into a local Docker image
+- Autoware modules: standard OpenADKit split images
+- AWSIM map: West Shinjuku, Tokyo
+- Autoware map assets: `$HOME/autoware_data/maps/Shinjuku`
+- RViz/noVNC: `ghcr.io/autowarefoundation/openadkit:visualizer`
+
+## Requirements
+
+- Ubuntu 22.04 host with Docker and Docker Compose
+- NVIDIA GPU with driver 570 or newer for AWSIM v2 raytracing
+- NVIDIA Container Toolkit registered as the Docker `nvidia` runtime
+- Host NVIDIA Vulkan ICD at `/usr/share/vulkan/icd.d/nvidia_icd.json`
+- `curl` and `unzip` on the host for map download/extraction
+- Large kernel UDP buffers for DDS; the start script raises them via `sudo sysctl`
+
+AWSIM runs under `xvfb-run` by default, so a physical X display is not required on a remote GPU VM. The AWSIM Xvfb server uses display `:98` by default to avoid colliding with the visualizer TigerVNC display `:99`.
+
+## Start
+
+```bash
+./start-awsim-e2e-demo.sh
+```
+
+The helper will:
+
+- Build `openadkit-awsim-demo:v2.0.1` from the sample Dockerfile if missing.
+- Download and unpack the official AWSIM Shinjuku map assets if missing.
+- Start AWSIM as `awsim-e2e` in host-networked, NVIDIA-enabled Docker.
+- Start modular OpenADKit map, system, sensing, perception, localization, planning, vehicle, control, and API containers.
+- Start the browser RViz/noVNC visualizer.
+- Verify `/clock`, AWSIM LiDAR, and Autoware localization.
+
+Use `--build` to force rebuilding the AWSIM runtime image. Use `--skip-build` when the image already exists and should not be rebuilt. Other options: `--no-visualizer` (skip the RViz/noVNC container), `--skip-verify` (skip topic and localization checks), and `--dry-run` (print the planned commands without running them). Run `./start-awsim-e2e-demo.sh --help` for the full list.
+
+The default behavior is no-drive. Set the route and engage manually in RViz.
+
+## Open RViz
+
+When running on a remote GPU host, forward the noVNC port over SSH:
+
+```bash
+ssh -L 6080:localhost:6080 <user>@<gpu-host>
+```
+
+Open:
+
+```text
+http://localhost:6080/vnc.html
+```
+
+Password:
+
+```text
+openadkit
+```
+
+In RViz:
+
+- Use `2D Goal Pose` to set a route on the Shinjuku map.
+- Wait for routing and planning to become available.
+- Click `Auto` to engage autonomous driving.
+
+## Optional Drive Check
+
+To attempt an automated route, engage autonomous mode, ask AWSIM to switch to autonomous control mode, and verify movement:
+
+```bash
+./start-awsim-e2e-demo.sh --drive
+```
+
+By default, `awsim-simulation.e2e.env` includes a lane-valid Shinjuku goal for the deterministic ego start pose in `awsim-config.json`. To use a different route, set another fixed goal:
+
+```text
+AWSIM_E2E_GOAL_X=<map x>
+AWSIM_E2E_GOAL_Y=<map y>
+AWSIM_E2E_GOAL_YAW=<yaw radians>
+```
+
+## Stop
+
+```bash
+docker compose --env-file awsim-simulation.e2e.env -f docker-compose.yaml down
+```
+
+## Configuration
+
+`awsim-config.json` is mounted into the AWSIM container and passed with `--json_path`. It fixes the Shinjuku ego start pose and random traffic seed to keep runs repeatable.
+
+Set `AWSIM_ASSET=AWSIM-Demo.zip` in `awsim-simulation.e2e.env` if you want the full AWSIM demo asset instead of the lightweight asset.
+
+Set `VISUALIZER_IMAGE` if you need to test a locally built visualizer image, for example when validating RViz GPU/VirtualGL changes before they are published to GHCR.

--- a/deployments/samples/awsim-simulation/awsim-config.json
+++ b/deployments/samples/awsim-simulation/awsim-config.json
@@ -1,0 +1,23 @@
+{
+  "TimeScale": 1,
+  "TimeSourceType": 0,
+  "RandomTrafficSeed": 33,
+  "MaxVehicleCount": 10,
+  "EgoVehicleSettings": {
+    "_maxSteerTireAngleInput": 35,
+    "_maxAccelerationInput": 2,
+    "_maxDecelerationInput": 2
+  },
+  "EgoPose": {
+    "Position": {
+      "x": 81381.7265625,
+      "y": 49920.1890625,
+      "z": 41.57674865722656
+    },
+    "EulerAngles": {
+      "x": 0.0,
+      "y": 0.0,
+      "z": 35.0
+    }
+  }
+}

--- a/deployments/samples/awsim-simulation/awsim-entrypoint.sh
+++ b/deployments/samples/awsim-simulation/awsim-entrypoint.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AWSIM_HEADLESS=${AWSIM_HEADLESS:-true}
+AWSIM_XVFB_SERVER_NUM=${AWSIM_XVFB_SERVER_NUM:-98}
+AWSIM_XVFB_SCREEN=${AWSIM_XVFB_SCREEN:-1280x720x24}
+AWSIM_RESX=${AWSIM_RESX:-1280}
+AWSIM_RESY=${AWSIM_RESY:-720}
+AWSIM_LOG_FILE=${AWSIM_LOG_FILE:--}
+AWSIM_CONFIG_PATH=${AWSIM_CONFIG_PATH:-}
+
+if [[ -n "${AWSIM_EXECUTABLE:-}" ]]; then
+  executable=$AWSIM_EXECUTABLE
+else
+  executable=$(find /opt/awsim -name 'AWSIM*.x86_64' -print -quit)
+fi
+
+if [[ -z "$executable" || ! -x "$executable" ]]; then
+  printf 'AWSIM executable was not found or is not executable: %s\n' "$executable" >&2
+  exit 1
+fi
+
+cd "$(dirname "$executable")"
+executable=./$(basename "$executable")
+
+args=(
+  "$executable"
+  -force-vulkan
+  -screen-width "$AWSIM_RESX"
+  -screen-height "$AWSIM_RESY"
+  -logFile "$AWSIM_LOG_FILE"
+)
+
+if [[ -n "$AWSIM_CONFIG_PATH" ]]; then
+  args+=(--json_path "$AWSIM_CONFIG_PATH")
+fi
+
+if [[ $# -gt 0 ]]; then
+  args+=("$@")
+fi
+
+if [[ "$AWSIM_HEADLESS" == true ]]; then
+  exec xvfb-run -n "$AWSIM_XVFB_SERVER_NUM" -s "-screen 0 ${AWSIM_XVFB_SCREEN}" "${args[@]}"
+fi
+
+exec "${args[@]}"

--- a/deployments/samples/awsim-simulation/awsim-simulation.e2e.env
+++ b/deployments/samples/awsim-simulation/awsim-simulation.e2e.env
@@ -1,0 +1,89 @@
+# ROS settings
+ROS_DOMAIN_ID=1
+ROS_DISTRO=humble
+USE_SIM_TIME=true
+
+# AWSIM runtime image built from this sample Dockerfile.
+AWSIM_IMAGE=openadkit-awsim-demo:v2.0.1
+AWSIM_CONTAINER_NAME=awsim-e2e
+AWSIM_VERSION=v2.0.1
+AWSIM_ASSET=AWSIM-Demo-Lightweight.zip
+# Optional SHA-256 of the AWSIM asset; when set it is verified at image build time.
+AWSIM_SHA256=
+AWSIM_HEADLESS=true
+AWSIM_XVFB_SERVER_NUM=98
+AWSIM_XVFB_SCREEN=1280x720x24
+AWSIM_RESX=1280
+AWSIM_RESY=720
+AWSIM_CONFIG_PATH=/opt/awsim/awsim-config.json
+AWSIM_VK_ICD_HOST_PATH=/usr/share/vulkan/icd.d/nvidia_icd.json
+AWSIM_VK_ICD_CONTAINER_PATH=/usr/share/vulkan/icd.d/nvidia_icd.json
+AWSIM_START_GRACE_SECONDS=20
+AWSIM_START_TIMEOUT=60
+# Image used by the helper to check that AWSIM is publishing /clock.
+AWSIM_E2E_HELPER_IMAGE=ghcr.io/autowarefoundation/openadkit:localization-mapping
+SENSING_PERCEPTION_IMAGE=ghcr.io/autowarefoundation/openadkit:sensing-perception-cuda
+VISUALIZER_IMAGE=ghcr.io/autowarefoundation/openadkit:visualizer
+
+# AWSIM Shinjuku map assets for Autoware.
+AWSIM_E2E_MAP_PATH=$HOME/autoware_data/maps/Shinjuku
+AWSIM_E2E_MAP_URL=https://github.com/autowarefoundation/AWSIM/releases/download/v2.0.0/Shinjuku-Map.zip
+# Optional SHA-256 of the map archive; when set it is verified after download.
+AWSIM_E2E_MAP_SHA256=
+
+# Autoware map settings
+MAP_PATH=$HOME/autoware_data/maps/Shinjuku
+LANELET2_MAP_FILE=lanelet2_map.osm
+POINTCLOUD_MAP_FILE=pointcloud_map.pcd
+DATA_PATH=$HOME/autoware_data
+
+# Common Autoware settings
+POINTCLOUD_CONTAINER_NAME=pointcloud_container
+SCENARIO_SIMULATION=false
+SENSOR_MODEL=awsim_sensor_kit
+VEHICLE_ID=default
+VEHICLE_MODEL=sample_vehicle
+
+# Planning and control settings
+ENABLE_ALL_MODULES_AUTO_MODE=false
+IS_SIMULATION_MODE=true
+PLANNING_MODULE_PRESET=default
+CHECK_EXTERNAL_EMERGENCY_HEARTBEAT=false
+CONTROL_MODULE_PRESET=default
+LATERAL_CONTROLLER_MODE=mpc
+LONGITUDINAL_CONTROLLER_MODE=pid
+
+# Vehicle and system settings
+LAUNCH_VEHICLE_INTERFACE=false
+SYSTEM_RUN_MODE=online
+LAUNCH_SYSTEM_MONITOR=false
+LAUNCH_DUMMY_DIAG_PUBLISHER=false
+
+# Sensing and perception settings
+LAUNCH_POINTCLOUD_CONTAINER_SENSING=true
+LAUNCH_SENSING_DRIVER=false
+LAUNCH_POINTCLOUD_CONTAINER_PERCEPTION=false
+LIDAR_DETECTION_MODEL=clustering
+OCCUPANCY_GRID_MAP_METHOD=pointcloud_based
+PERCEPTION_MODE=lidar
+
+# Autoware launch settings
+AUTOWARE_E2E_EMPTY_OBJECTS=false
+AUTOWARE_E2E_USE_TRAFFIC_LIGHT_RECOGNITION=false
+AUTOWARE_E2E_START_VISUALIZER=true
+AUTOWARE_E2E_VERIFY_TIMEOUT=180
+AUTOWARE_E2E_VERIFY_INTERVAL=5
+
+# Visualization settings
+RVIZ_CONFIG=/opt/autoware/share/autoware_launch/rviz/autoware.rviz
+
+# Demo route and engage settings
+AUTOWARE_E2E_AUTO_DRIVE=false
+AUTOWARE_E2E_ROUTE_FORWARD_DISTANCE=55.0
+AUTOWARE_E2E_ROUTE_SETTLE_TIMEOUT=90
+AUTOWARE_E2E_DRIVE_VERIFY_TIMEOUT=90
+AUTOWARE_E2E_DRIVE_VERIFY_DISTANCE=5.0
+# Lane-valid Shinjuku goal for the deterministic ego start pose in awsim-config.json.
+AWSIM_E2E_GOAL_X=81403.475
+AWSIM_E2E_GOAL_Y=49962.463
+AWSIM_E2E_GOAL_YAW=1.713

--- a/deployments/samples/awsim-simulation/awsim_e2e_helper.py
+++ b/deployments/samples/awsim-simulation/awsim_e2e_helper.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+
+import argparse
+import math
+import os
+import time
+
+
+_MISSING = object()
+
+
+def _env(name, cast=str, default=_MISSING):
+    value = os.environ.get(name)
+    if value is None or value == "":
+        if default is not _MISSING:
+            return default
+        raise KeyError(name)
+    return cast(value)
+
+
+def _yaw_from_quaternion(q):
+    siny_cosp = 2.0 * (q.w * q.z + q.x * q.y)
+    cosy_cosp = 1.0 - 2.0 * (q.y * q.y + q.z * q.z)
+    return math.atan2(siny_cosp, cosy_cosp)
+
+
+def _quaternion_from_yaw(yaw):
+    from geometry_msgs.msg import Quaternion
+
+    q = Quaternion()
+    q.z = math.sin(yaw / 2.0)
+    q.w = math.cos(yaw / 2.0)
+    return q
+
+
+def verify_runtime():
+    import rclpy
+    from nav_msgs.msg import Odometry
+    from rclpy.qos import qos_profile_sensor_data
+    from rosgraph_msgs.msg import Clock
+    from sensor_msgs.msg import PointCloud2
+
+    rclpy.init()
+    node = rclpy.create_node("openadkit_awsim_e2e_runtime_verifier")
+    try:
+        state = {"clock": None, "odom": None, "lidar": None}
+
+        node.create_subscription(Clock, "/clock", lambda msg: state.__setitem__("clock", msg), 10)
+        node.create_subscription(Odometry, "/localization/kinematic_state", lambda msg: state.__setitem__("odom", msg), 10)
+        node.create_subscription(
+            PointCloud2,
+            "/sensing/lidar/top/pointcloud_raw",
+            lambda msg: state.__setitem__("lidar", msg),
+            qos_profile_sensor_data,
+        )
+
+        deadline = time.time() + _env("AUTOWARE_E2E_VERIFY_RUNTIME_TIMEOUT", float, 20.0)
+        while time.time() < deadline and any(value is None for value in state.values()):
+            rclpy.spin_once(node, timeout_sec=0.2)
+
+        missing = [name for name, value in state.items() if value is None]
+        if missing:
+            raise RuntimeError("Timed out waiting for " + ", ".join(missing))
+
+        pose = state["odom"].pose.pose.position
+        print(f"AWSIM runtime verified: pose=({pose.x:.2f}, {pose.y:.2f})")
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+def set_route_and_engage():
+    import rclpy
+    from autoware_adapi_v1_msgs.msg import OperationModeState, RouteState
+    from autoware_adapi_v1_msgs.srv import ChangeOperationMode, ClearRoute, SetRoutePoints
+    from autoware_vehicle_msgs.srv import ControlModeCommand
+    from geometry_msgs.msg import Pose
+    from nav_msgs.msg import Odometry
+
+    forward_distance = _env("AUTOWARE_E2E_ROUTE_FORWARD_DISTANCE", float)
+    settle_timeout = _env("AUTOWARE_E2E_ROUTE_SETTLE_TIMEOUT", float)
+    autonomous_mode = OperationModeState.AUTONOMOUS
+
+    rclpy.init()
+    node = rclpy.create_node("openadkit_awsim_e2e_route_and_engage")
+    try:
+        state = {"odom": None, "operation": None, "route": None}
+
+        node.create_subscription(Odometry, "/localization/kinematic_state", lambda msg: state.__setitem__("odom", msg), 10)
+        node.create_subscription(OperationModeState, "/api/operation_mode/state", lambda msg: state.__setitem__("operation", msg), 10)
+        node.create_subscription(RouteState, "/api/routing/state", lambda msg: state.__setitem__("route", msg), 10)
+
+        def spin_until(predicate, timeout, description):
+            deadline = time.time() + timeout
+            while time.time() < deadline:
+                rclpy.spin_once(node, timeout_sec=0.2)
+                if predicate():
+                    return
+            raise RuntimeError(f"Timed out waiting for {description}")
+
+        def wait_for_service(client, timeout):
+            deadline = time.time() + timeout
+            while time.time() < deadline:
+                if client.wait_for_service(timeout_sec=1.0):
+                    return True
+            return False
+
+        def call_service(client, request, timeout, name, required=True):
+            if not wait_for_service(client, timeout):
+                if required:
+                    raise RuntimeError(f"Timed out waiting for service {name}")
+                print(f"Service unavailable, skipping: {name}")
+                return None
+            future = client.call_async(request)
+            deadline = time.time() + timeout
+            while time.time() < deadline:
+                rclpy.spin_once(node, timeout_sec=0.2)
+                if future.done():
+                    response = future.result()
+                    if response is None:
+                        raise RuntimeError(f"{name} returned no response")
+                    status = getattr(response, "status", None)
+                    if status is not None and not status.success:
+                        raise RuntimeError(f"{name} failed: {status.message}")
+                    return response
+            raise RuntimeError(f"Timed out waiting for response from {name}")
+
+        spin_until(lambda: state["odom"] is not None, settle_timeout, "/localization/kinematic_state")
+        start_pose = state["odom"].pose.pose
+
+        clear_route = node.create_client(ClearRoute, "/api/routing/clear_route")
+        set_route = node.create_client(SetRoutePoints, "/api/routing/set_route_points")
+        change_route = node.create_client(SetRoutePoints, "/api/routing/change_route_points")
+        change_to_autonomous = node.create_client(ChangeOperationMode, "/api/operation_mode/change_to_autonomous")
+        awsim_control_mode = node.create_client(ControlModeCommand, "input/control_mode_request")
+
+        call_service(clear_route, ClearRoute.Request(), settle_timeout, "/api/routing/clear_route")
+
+        clear_deadline = time.time() + min(10.0, settle_timeout)
+        while time.time() < clear_deadline:
+            rclpy.spin_once(node, timeout_sec=0.2)
+            if state["route"] is not None and state["route"].state == RouteState.UNSET:
+                break
+
+        request = SetRoutePoints.Request()
+        request.header.frame_id = "map"
+        request.option.allow_goal_modification = True
+        request.goal = Pose()
+
+        goal_x = _env("AWSIM_E2E_GOAL_X", float, None)
+        goal_y = _env("AWSIM_E2E_GOAL_Y", float, None)
+        goal_yaw = _env("AWSIM_E2E_GOAL_YAW", float, None)
+        yaw = _yaw_from_quaternion(start_pose.orientation)
+        if goal_x is None or goal_y is None:
+            forward_x = math.cos(yaw) * forward_distance
+            forward_y = math.sin(yaw) * forward_distance
+            if goal_x is None:
+                goal_x = start_pose.position.x + forward_x
+            if goal_y is None:
+                goal_y = start_pose.position.y + forward_y
+        if goal_yaw is None:
+            goal_yaw = yaw
+
+        request.goal.position.x = goal_x
+        request.goal.position.y = goal_y
+        request.goal.position.z = 0.0
+        request.goal.orientation = _quaternion_from_yaw(goal_yaw)
+
+        try:
+            call_service(set_route, request, settle_timeout, "/api/routing/set_route_points")
+        except RuntimeError as error:
+            error_text = str(error).lower()
+            if "route is already set" not in error_text and "invalid_state" not in error_text:
+                raise
+            call_service(change_route, request, settle_timeout, "/api/routing/change_route_points")
+        print(
+            "Route set: "
+            f"start=({start_pose.position.x:.2f}, {start_pose.position.y:.2f}) "
+            f"goal=({request.goal.position.x:.2f}, {request.goal.position.y:.2f})"
+        )
+
+        spin_until(
+            lambda: state["operation"] is not None and state["operation"].is_autonomous_mode_available,
+            settle_timeout,
+            "autonomous mode availability",
+        )
+        call_service(change_to_autonomous, ChangeOperationMode.Request(), settle_timeout, "/api/operation_mode/change_to_autonomous")
+        spin_until(lambda: state["operation"] is not None and state["operation"].mode == autonomous_mode, settle_timeout, "autonomous mode transition")
+
+        control_mode_request = ControlModeCommand.Request()
+        control_mode_request.mode = 1
+        call_service(awsim_control_mode, control_mode_request, 5.0, "input/control_mode_request", required=False)
+        print("Autonomous mode active")
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+def verify_motion():
+    import rclpy
+    from nav_msgs.msg import Odometry
+
+    timeout = _env("AUTOWARE_E2E_DRIVE_VERIFY_TIMEOUT", float)
+    required_distance = _env("AUTOWARE_E2E_DRIVE_VERIFY_DISTANCE", float)
+
+    rclpy.init()
+    node = rclpy.create_node("openadkit_awsim_e2e_motion_verifier")
+    try:
+        state = {"odom": None}
+        node.create_subscription(Odometry, "/localization/kinematic_state", lambda msg: state.__setitem__("odom", msg), 10)
+
+        deadline = time.time() + timeout
+        while state["odom"] is None and time.time() < deadline:
+            rclpy.spin_once(node, timeout_sec=0.2)
+
+        if state["odom"] is None:
+            raise RuntimeError("Timed out waiting for /localization/kinematic_state")
+
+        start = state["odom"].pose.pose.position
+        start_x = start.x
+        start_y = start.y
+
+        while time.time() < deadline:
+            rclpy.spin_once(node, timeout_sec=0.2)
+            current = state["odom"].pose.pose.position
+            distance = math.hypot(current.x - start_x, current.y - start_y)
+            if distance >= required_distance:
+                print(
+                    f"Moved {distance:.2f} m: "
+                    f"start=({start_x:.2f}, {start_y:.2f}) "
+                    f"current=({current.x:.2f}, {current.y:.2f})"
+                )
+                return
+
+        current = state["odom"].pose.pose.position
+        distance = math.hypot(current.x - start_x, current.y - start_y)
+        raise RuntimeError(f"Autonomous motion verification failed: moved {distance:.2f} m")
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="AWSIM e2e helper commands")
+    parser.add_argument("command", choices=["verify-runtime", "set-route-and-engage", "verify-motion"])
+    args = parser.parse_args()
+
+    commands = {
+        "verify-runtime": verify_runtime,
+        "set-route-and-engage": set_route_and_engage,
+        "verify-motion": verify_motion,
+    }
+    commands[args.command]()
+
+
+if __name__ == "__main__":
+    main()

--- a/deployments/samples/awsim-simulation/docker-compose.yaml
+++ b/deployments/samples/awsim-simulation/docker-compose.yaml
@@ -1,0 +1,275 @@
+services:
+  awsim:
+    image: ${AWSIM_IMAGE}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        AWSIM_VERSION: ${AWSIM_VERSION}
+        AWSIM_ASSET: ${AWSIM_ASSET}
+        AWSIM_SHA256: ${AWSIM_SHA256:-}
+    container_name: ${AWSIM_CONTAINER_NAME}
+    network_mode: host
+    init: true
+    ipc: host
+    runtime: nvidia
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+      - AWSIM_HEADLESS=${AWSIM_HEADLESS}
+      - AWSIM_XVFB_SERVER_NUM=${AWSIM_XVFB_SERVER_NUM}
+      - AWSIM_XVFB_SCREEN=${AWSIM_XVFB_SCREEN}
+      - AWSIM_RESX=${AWSIM_RESX}
+      - AWSIM_RESY=${AWSIM_RESY}
+      - AWSIM_CONFIG_PATH=${AWSIM_CONFIG_PATH}
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics,display
+      - VK_ICD_FILENAMES=${AWSIM_VK_ICD_CONTAINER_PATH}
+    volumes:
+      - ./awsim-config.json:${AWSIM_CONFIG_PATH}:ro
+      - ${AWSIM_VK_ICD_HOST_PATH}:${AWSIM_VK_ICD_CONTAINER_PATH}:ro
+    restart: on-failure
+
+  map:
+    image: ghcr.io/autowarefoundation/openadkit:localization-mapping
+    container_name: autoware-map
+    network_mode: host
+    init: true
+    ipc: host
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+    volumes:
+      - ${MAP_PATH}:/autoware_map:ro
+    command: >
+      ros2 launch autoware_launch tier4_map_component.launch.xml
+      lanelet2_map_file:=${LANELET2_MAP_FILE}
+      map_path:=/autoware_map
+      pointcloud_map_file:=${POINTCLOUD_MAP_FILE}
+      use_sim_time:=${USE_SIM_TIME}
+      vehicle_model:=${VEHICLE_MODEL}
+    restart: on-failure
+
+  system:
+    image: ghcr.io/autowarefoundation/openadkit:vehicle-system
+    container_name: autoware-system
+    network_mode: host
+    init: true
+    ipc: host
+    pid: service:map
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+    depends_on:
+      - map
+    command: >
+      ros2 launch autoware_launch tier4_system_component.launch.xml
+      launch_dummy_diag_publisher:=${LAUNCH_DUMMY_DIAG_PUBLISHER}
+      launch_system_monitor:=${LAUNCH_SYSTEM_MONITOR}
+      sensor_model:=${SENSOR_MODEL}
+      system_run_mode:=${SYSTEM_RUN_MODE}
+      use_sim_time:=${USE_SIM_TIME}
+      vehicle_model:=${VEHICLE_MODEL}
+    restart: on-failure
+
+  sensing:
+    image: ${SENSING_PERCEPTION_IMAGE}
+    container_name: autoware-sensing
+    network_mode: host
+    init: true
+    ipc: host
+    pid: service:map
+    runtime: nvidia
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    depends_on:
+      - awsim
+      - map
+      - system
+    command: >
+      ros2 launch autoware_launch tier4_sensing_component.launch.xml
+      launch_pointcloud_container:=${LAUNCH_POINTCLOUD_CONTAINER_SENSING}
+      launch_sensing_driver:=${LAUNCH_SENSING_DRIVER}
+      pointcloud_container_name:=${POINTCLOUD_CONTAINER_NAME}
+      sensor_model:=${SENSOR_MODEL}
+      use_sim_time:=${USE_SIM_TIME}
+      vehicle_model:=${VEHICLE_MODEL}
+    restart: on-failure
+
+  perception:
+    image: ${SENSING_PERCEPTION_IMAGE}
+    container_name: autoware-perception
+    network_mode: host
+    init: true
+    ipc: host
+    pid: service:map
+    runtime: nvidia
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    volumes:
+      - ${DATA_PATH}:/autoware_data:rw
+    depends_on:
+      - map
+      - sensing
+      - system
+    command: >
+      ros2 launch autoware_launch tier4_perception_component.launch.xml
+      data_path:=/autoware_data
+      launch_pointcloud_container:=${LAUNCH_POINTCLOUD_CONTAINER_PERCEPTION}
+      lidar_detection_model:=${LIDAR_DETECTION_MODEL}
+      occupancy_grid_map_method:=${OCCUPANCY_GRID_MAP_METHOD}
+      perception_mode:=${PERCEPTION_MODE}
+      pointcloud_container_name:=${POINTCLOUD_CONTAINER_NAME}
+      use_empty_dynamic_object_publisher:=${AUTOWARE_E2E_EMPTY_OBJECTS}
+      use_sim_time:=${USE_SIM_TIME}
+      use_traffic_light_recognition:=${AUTOWARE_E2E_USE_TRAFFIC_LIGHT_RECOGNITION}
+      vehicle_model:=${VEHICLE_MODEL}
+    restart: on-failure
+
+  localization:
+    image: ghcr.io/autowarefoundation/openadkit:localization-mapping
+    container_name: autoware-localization
+    network_mode: host
+    init: true
+    ipc: host
+    pid: service:map
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+    depends_on:
+      - map
+      - sensing
+      - perception
+      - system
+    command: >
+      ros2 launch autoware_launch tier4_localization_component.launch.xml
+      system_run_mode:=${SYSTEM_RUN_MODE}
+      use_sim_time:=${USE_SIM_TIME}
+      vehicle_model:=${VEHICLE_MODEL}
+    restart: on-failure
+
+  planning:
+    image: ghcr.io/autowarefoundation/openadkit:planning-control
+    container_name: autoware-planning
+    network_mode: host
+    init: true
+    ipc: host
+    pid: service:map
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+    depends_on:
+      - map
+      - localization
+      - perception
+      - system
+    command: >
+      ros2 launch autoware_launch tier4_planning_component.launch.xml
+      component_wise_launch:=true
+      enable_all_modules_auto_mode:=${ENABLE_ALL_MODULES_AUTO_MODE}
+      is_simulation:=${IS_SIMULATION_MODE}
+      module_preset:=${PLANNING_MODULE_PRESET}
+      pointcloud_container_name:=${POINTCLOUD_CONTAINER_NAME}
+      use_sim_time:=${USE_SIM_TIME}
+      vehicle_model:=${VEHICLE_MODEL}
+    restart: on-failure
+
+  vehicle:
+    image: ghcr.io/autowarefoundation/openadkit:vehicle-system
+    container_name: autoware-vehicle
+    network_mode: host
+    init: true
+    ipc: host
+    pid: service:map
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+    depends_on:
+      - map
+      - awsim
+    command: >
+      ros2 launch tier4_vehicle_launch vehicle.launch.xml
+      launch_vehicle_interface:=${LAUNCH_VEHICLE_INTERFACE}
+      raw_vehicle_cmd_converter_param_path:=/opt/autoware/share/autoware_launch/config/vehicle/raw_vehicle_cmd_converter/raw_vehicle_cmd_converter.param.yaml
+      sensor_model:=${SENSOR_MODEL}
+      use_sim_time:=${USE_SIM_TIME}
+      vehicle_id:=${VEHICLE_ID}
+      vehicle_model:=${VEHICLE_MODEL}
+    restart: on-failure
+
+  control:
+    image: ghcr.io/autowarefoundation/openadkit:planning-control
+    container_name: autoware-control
+    network_mode: host
+    init: true
+    ipc: host
+    pid: service:map
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+    depends_on:
+      - map
+      - planning
+      - system
+    command: >
+      ros2 launch autoware_launch tier4_control_component.launch.xml
+      check_external_emergency_heartbeat:=${CHECK_EXTERNAL_EMERGENCY_HEARTBEAT}
+      component_wise_launch:=true
+      lateral_controller_mode:=${LATERAL_CONTROLLER_MODE}
+      longitudinal_controller_mode:=${LONGITUDINAL_CONTROLLER_MODE}
+      module_preset:=${CONTROL_MODULE_PRESET}
+      use_sim_time:=${USE_SIM_TIME}
+      vehicle_id:=${VEHICLE_ID}
+      vehicle_model:=${VEHICLE_MODEL}
+    restart: on-failure
+
+  api:
+    image: ghcr.io/autowarefoundation/openadkit:api
+    container_name: autoware-api
+    network_mode: host
+    init: true
+    ipc: host
+    pid: service:map
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+    depends_on:
+      - map
+      - system
+    command: >
+      ros2 launch autoware_launch tier4_autoware_api_component.launch.xml
+      component_wise_launch:=true
+      scenario_simulation:=${SCENARIO_SIMULATION}
+      use_sim_time:=${USE_SIM_TIME}
+      vehicle_model:=${VEHICLE_MODEL}
+    restart: on-failure
+
+  visualizer:
+    image: ${VISUALIZER_IMAGE}
+    container_name: autoware-e2e-visualizer
+    network_mode: host
+    init: true
+    ipc: host
+    pid: service:map
+    runtime: nvidia
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+      - RVIZ_CONFIG=${RVIZ_CONFIG}
+      - USE_SIM_TIME=${USE_SIM_TIME}
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=graphics,compute,utility,display
+      - RVIZ_GPU=auto
+    depends_on:
+      - map
+      - api
+      - planning
+      - control
+      - awsim
+    restart: on-failure

--- a/deployments/samples/awsim-simulation/start-awsim-e2e-demo.sh
+++ b/deployments/samples/awsim-simulation/start-awsim-e2e-demo.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+ENV_FILE=awsim-simulation.e2e.env
+PYTHON_HELPER=$SCRIPT_DIR/awsim_e2e_helper.py
+DRY_RUN=false
+BUILD_IMAGE=auto
+SKIP_VERIFY=false
+START_VISUALIZER_OVERRIDE=
+AUTO_DRIVE_OVERRIDE=
+
+usage() {
+  cat <<'EOF'
+Usage: ./start-awsim-e2e-demo.sh [options]
+
+Starts the closed-loop AWSIM v2 e2e demo using the AWSIM demo binary and
+modular OpenADKit Autoware containers.
+
+Options:
+  --build               Build the local AWSIM runtime image before starting
+  --skip-build          Do not build the AWSIM image; require it to exist
+  --skip-verify         Skip topic and localization verification
+  --no-visualizer       Do not start the browser RViz/noVNC visualizer container
+  --drive               Set a forward route and engage autonomous mode
+  --no-drive            Start the stack without setting a route or engaging
+  --dry-run             Print planned commands without running them
+  -h, --help            Show this help text
+EOF
+}
+
+while (($#)); do
+  case "$1" in
+    --build)
+      BUILD_IMAGE=true
+      ;;
+    --skip-build)
+      BUILD_IMAGE=false
+      ;;
+    --skip-verify)
+      SKIP_VERIFY=true
+      ;;
+    --no-visualizer)
+      START_VISUALIZER_OVERRIDE=false
+      ;;
+    --drive)
+      AUTO_DRIVE_OVERRIDE=true
+      ;;
+    --no-drive)
+      AUTO_DRIVE_OVERRIDE=false
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown option: %s\n\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+run() {
+  printf '+ %s\n' "$*"
+  if [[ "$DRY_RUN" == false ]]; then
+    "$@"
+  fi
+}
+
+run_compose() {
+  printf '+ docker compose --env-file %s -f docker-compose.yaml %s\n' "$ENV_FILE" "$*"
+  if [[ "$DRY_RUN" == false ]]; then
+    docker compose --env-file "$ENV_FILE" -f docker-compose.yaml "$@"
+  fi
+}
+
+load_env() {
+  set -a
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+  set +a
+
+  if [[ -z "${SENSING_PERCEPTION_IMAGE:-}" ]]; then
+    SENSING_PERCEPTION_IMAGE=ghcr.io/autowarefoundation/openadkit:sensing-perception-cuda
+  fi
+
+  if [[ -n "$START_VISUALIZER_OVERRIDE" ]]; then
+    AUTOWARE_E2E_START_VISUALIZER=$START_VISUALIZER_OVERRIDE
+  fi
+
+  if [[ -n "$AUTO_DRIVE_OVERRIDE" ]]; then
+    AUTOWARE_E2E_AUTO_DRIVE=$AUTO_DRIVE_OVERRIDE
+  fi
+}
+
+UDP_MEM_MAX_REQUIRED=2147483647
+UDP_MEM_DEFAULT_REQUIRED=134217728
+
+ensure_udp_buffers() {
+  printf '+ ensure kernel UDP buffer sizes for DDS\n'
+  if [[ "$DRY_RUN" == true ]]; then
+    return 0
+  fi
+
+  local rmem_max wmem_max rmem_default wmem_default
+  rmem_max=$(sysctl -n net.core.rmem_max)
+  wmem_max=$(sysctl -n net.core.wmem_max)
+  rmem_default=$(sysctl -n net.core.rmem_default)
+  wmem_default=$(sysctl -n net.core.wmem_default)
+  if ((rmem_max >= UDP_MEM_MAX_REQUIRED && wmem_max >= UDP_MEM_MAX_REQUIRED \
+    && rmem_default >= UDP_MEM_DEFAULT_REQUIRED && wmem_default >= UDP_MEM_DEFAULT_REQUIRED)); then
+    return 0
+  fi
+
+  local sysctl_args=(
+    "net.core.rmem_max=$UDP_MEM_MAX_REQUIRED"
+    "net.core.wmem_max=$UDP_MEM_MAX_REQUIRED"
+    "net.core.rmem_default=$UDP_MEM_DEFAULT_REQUIRED"
+    "net.core.wmem_default=$UDP_MEM_DEFAULT_REQUIRED"
+  )
+  local sudo_cmd=()
+  if [[ $EUID -ne 0 ]]; then
+    if [[ -t 0 ]]; then
+      sudo_cmd=(sudo)
+    else
+      sudo_cmd=(sudo -n)
+    fi
+  fi
+  if run "${sudo_cmd[@]}" sysctl -qw "${sysctl_args[@]}"; then
+    return 0
+  fi
+
+  printf 'Failed to raise kernel UDP buffer limits. Run this and retry:\n' >&2
+  printf '  sudo sysctl -w %s %s %s %s\n' "${sysctl_args[@]}" >&2
+  return 1
+}
+
+prepare_map() {
+  if [[ "$DRY_RUN" == true ]]; then
+    printf '+ prepare AWSIM Shinjuku map at %s\n' "$AWSIM_E2E_MAP_PATH"
+    return 0
+  fi
+
+  mkdir -p "$AWSIM_E2E_MAP_PATH"
+  if [[ -s "$AWSIM_E2E_MAP_PATH/$POINTCLOUD_MAP_FILE" && -s "$AWSIM_E2E_MAP_PATH/$LANELET2_MAP_FILE" ]]; then
+    return 0
+  fi
+
+  local cache_dir tmp_dir archive
+  cache_dir=${DATA_PATH:-$HOME/autoware_data}/cache
+  archive=$cache_dir/Shinjuku-Map.zip
+  tmp_dir=$(mktemp -d)
+  mkdir -p "$cache_dir"
+  trap 'rm -rf "$tmp_dir"; trap - RETURN' RETURN
+
+  if [[ ! -s "$archive" ]]; then
+    run curl -L --fail -A Mozilla/5.0 -o "$archive" "$AWSIM_E2E_MAP_URL"
+  fi
+  if [[ -n "${AWSIM_E2E_MAP_SHA256:-}" ]]; then
+    echo "${AWSIM_E2E_MAP_SHA256}  $archive" | sha256sum -c -
+  fi
+  run unzip -o -q "$archive" -d "$tmp_dir"
+
+  local pcd osm projector
+  pcd=$(find "$tmp_dir" -name "$POINTCLOUD_MAP_FILE" -print -quit)
+  osm=$(find "$tmp_dir" -name "$LANELET2_MAP_FILE" -print -quit)
+  if [[ -z "$pcd" ]]; then
+    pcd=$(find "$tmp_dir" -name '*.pcd' -print -quit)
+  fi
+  if [[ -z "$osm" ]]; then
+    osm=$(find "$tmp_dir" -name '*.osm' -print -quit)
+  fi
+  projector=$(find "$tmp_dir" -name map_projector_info.yaml -print -quit)
+  if [[ -z "$pcd" || -z "$osm" ]]; then
+    printf 'Shinjuku map archive did not contain %s and %s\n' "$POINTCLOUD_MAP_FILE" "$LANELET2_MAP_FILE" >&2
+    return 1
+  fi
+
+  run cp "$pcd" "$AWSIM_E2E_MAP_PATH/$POINTCLOUD_MAP_FILE"
+  run cp "$osm" "$AWSIM_E2E_MAP_PATH/$LANELET2_MAP_FILE"
+  if [[ -n "$projector" ]]; then
+    run cp "$projector" "$AWSIM_E2E_MAP_PATH/map_projector_info.yaml"
+  elif [[ ! -s "$AWSIM_E2E_MAP_PATH/map_projector_info.yaml" ]]; then
+    printf 'projector_type: MGRS\nvertical_datum: WGS84\n' > "$AWSIM_E2E_MAP_PATH/map_projector_info.yaml"
+  fi
+}
+
+ensure_awsim_image() {
+  if [[ "$BUILD_IMAGE" == false ]]; then
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == false && "$BUILD_IMAGE" == auto ]] && docker image inspect "$AWSIM_IMAGE" >/dev/null 2>&1; then
+    printf '+ AWSIM image %s present, skipping build\n' "$AWSIM_IMAGE"
+    return 0
+  fi
+
+  run_compose build awsim
+}
+
+start_awsim() {
+  run docker rm -f "$AWSIM_CONTAINER_NAME" || true
+  run_compose up -d --force-recreate awsim
+  if [[ "$DRY_RUN" == false && "$AWSIM_START_GRACE_SECONDS" != 0 ]]; then
+    run sleep "$AWSIM_START_GRACE_SECONDS"
+  fi
+  wait_for_awsim_clock
+}
+
+wait_for_awsim_clock() {
+  printf '+ wait for AWSIM /clock topic\n'
+  if [[ "$DRY_RUN" == true ]]; then
+    return 0
+  fi
+
+  printf '+ docker pull %s\n' "$AWSIM_E2E_HELPER_IMAGE"
+  docker pull "$AWSIM_E2E_HELPER_IMAGE" >/dev/null 2>&1 || true
+
+  local deadline=$((SECONDS + AWSIM_START_TIMEOUT))
+  while ((SECONDS < deadline)); do
+    if docker run --rm --network host \
+      "$AWSIM_E2E_HELPER_IMAGE" \
+      bash -lc "source /opt/ros/${ROS_DISTRO}/setup.bash; source /opt/autoware/setup.bash; ros2 topic echo /clock --once --timeout 3" \
+      >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  printf 'Timed out waiting for AWSIM /clock on host network\n' >&2
+  return 1
+}
+
+start_autoware() {
+  run_compose up -d --force-recreate \
+    map \
+    system \
+    sensing \
+    perception \
+    localization \
+    planning \
+    vehicle \
+    control \
+    api
+
+  if [[ "$DRY_RUN" == false ]] \
+    && ! run_compose exec -T map test -s "/autoware_map/$POINTCLOUD_MAP_FILE"; then
+    printf 'Pointcloud map not visible in container at /autoware_map/%s; check MAP_PATH=%s\n' \
+      "$POINTCLOUD_MAP_FILE" "$MAP_PATH" >&2
+    return 1
+  fi
+}
+
+start_visualizer() {
+  if [[ "$AUTOWARE_E2E_START_VISUALIZER" != true ]]; then
+    return 0
+  fi
+
+  run docker rm -f autoware-e2e-visualizer || true
+  run_compose up -d --force-recreate visualizer
+}
+
+verify_runtime() {
+  if [[ "$SKIP_VERIFY" == true ]]; then
+    return 0
+  fi
+
+  printf '+ verify AWSIM e2e runtime\n'
+  if [[ "$DRY_RUN" == true ]]; then
+    return 0
+  fi
+
+  local deadline=$((SECONDS + AUTOWARE_E2E_VERIFY_TIMEOUT))
+  local output=""
+  while ((SECONDS < deadline)); do
+    if output=$(docker exec -i \
+      -e ROS_DOMAIN_ID="$ROS_DOMAIN_ID" \
+      -e AUTOWARE_E2E_VERIFY_RUNTIME_TIMEOUT="${AUTOWARE_E2E_VERIFY_RUNTIME_TIMEOUT:-20.0}" \
+      autoware-api \
+      bash -lc "source /opt/ros/${ROS_DISTRO}/setup.bash; source /opt/autoware/setup.bash; python3 - verify-runtime" \
+      < "$PYTHON_HELPER" 2>&1); then
+      printf '%s\n' "$output"
+      return 0
+    fi
+    sleep "$AUTOWARE_E2E_VERIFY_INTERVAL"
+  done
+
+  docker compose --env-file "$ENV_FILE" -f docker-compose.yaml logs --tail 160 >&2 || true
+  printf 'Timed out waiting for AWSIM e2e verification\n' >&2
+  return 1
+}
+
+start_autonomous_drive() {
+  if [[ "$AUTOWARE_E2E_AUTO_DRIVE" != true ]]; then
+    return 0
+  fi
+
+  printf '+ set route and engage autonomous mode\n'
+  if [[ "$DRY_RUN" == true ]]; then
+    return 0
+  fi
+
+  docker exec \
+    -i \
+    -e AUTOWARE_E2E_ROUTE_FORWARD_DISTANCE="$AUTOWARE_E2E_ROUTE_FORWARD_DISTANCE" \
+    -e AUTOWARE_E2E_ROUTE_SETTLE_TIMEOUT="$AUTOWARE_E2E_ROUTE_SETTLE_TIMEOUT" \
+    -e AWSIM_E2E_GOAL_X="${AWSIM_E2E_GOAL_X:-}" \
+    -e AWSIM_E2E_GOAL_Y="${AWSIM_E2E_GOAL_Y:-}" \
+    -e AWSIM_E2E_GOAL_YAW="${AWSIM_E2E_GOAL_YAW:-}" \
+    autoware-api \
+    bash -lc "source /opt/ros/${ROS_DISTRO}/setup.bash; source /opt/autoware/setup.bash; python3 - set-route-and-engage" \
+    < "$PYTHON_HELPER"
+}
+
+verify_autonomous_drive() {
+  if [[ "$AUTOWARE_E2E_AUTO_DRIVE" != true || "$SKIP_VERIFY" == true ]]; then
+    return 0
+  fi
+
+  printf '+ verify autonomous AWSIM motion\n'
+  if [[ "$DRY_RUN" == true ]]; then
+    return 0
+  fi
+
+  docker exec \
+    -i \
+    -e AUTOWARE_E2E_DRIVE_VERIFY_TIMEOUT="$AUTOWARE_E2E_DRIVE_VERIFY_TIMEOUT" \
+    -e AUTOWARE_E2E_DRIVE_VERIFY_DISTANCE="$AUTOWARE_E2E_DRIVE_VERIFY_DISTANCE" \
+    autoware-api \
+    bash -lc "source /opt/ros/${ROS_DISTRO}/setup.bash; source /opt/autoware/setup.bash; python3 - verify-motion" \
+    < "$PYTHON_HELPER"
+}
+
+main() {
+  cd "$SCRIPT_DIR"
+  load_env
+  ensure_udp_buffers
+  prepare_map
+  ensure_awsim_image
+  start_awsim
+  start_autoware
+  start_visualizer
+  verify_runtime
+  start_autonomous_drive
+  verify_autonomous_drive
+}
+
+main

--- a/docs/deployments/samples/awsim-simulation/index.md
+++ b/docs/deployments/samples/awsim-simulation/index.md
@@ -1,0 +1,33 @@
+# Autoware Open AD Kit AWSIM E2E Simulation
+
+This sample runs a closed-loop AWSIM v2 end-to-end simulation with modular OpenADKit containers.
+
+## Source of Truth
+
+The complete operational instructions for this deployment live alongside the deployment assets in [`deployments/samples/awsim-simulation/README.md`](https://github.com/autowarefoundation/openadkit/blob/main/deployments/samples/awsim-simulation/README.md).
+
+That README covers:
+
+- requirements and runtime images
+- startup, RViz access, and shutdown commands
+- optional autonomous drive check
+
+## Quick Start
+
+From `deployments/samples/awsim-simulation/`:
+
+```bash
+./start-awsim-e2e-demo.sh
+```
+
+Open the visualizer at:
+
+```text
+http://localhost:6080/vnc.html
+```
+
+To stop the deployment:
+
+```bash
+docker compose --env-file awsim-simulation.e2e.env -f docker-compose.yaml down
+```

--- a/docs/deployments/samples/index.md
+++ b/docs/deployments/samples/index.md
@@ -3,6 +3,7 @@
 Sample deployment configurations to help you get started. Recommended for **learning and development**.
 
 - [CARLA Simulation](carla-simulation/index.md) - Run the open-source planning stack with CARLA as an external simulator.
+- [AWSIM Simulation](awsim-simulation/index.md) - Run the open-source planning stack with AWSIM v2 as an external simulator.
 - [Planning Simulation](planning-simulation/index.md) - Run the Autoware planning simulation with a sample map.
 - [Scenario Simulation](scenario-simulation/index.md) - Run the Autoware scenario simulation with the TIER IV Scenario Simulator.
 - [Logging Simulation](logging-simulation/index.md) - Run the Autoware logging simulation with a sample rosbag.


### PR DESCRIPTION
Adds a new sample deployment for closed-loop AWSIM v2 simulation using modular OpenADKit containers.

## What's new

- **New deployment**: `deployments/samples/awsim-simulation/`
  - `docker-compose.yaml` with AWSIM + modular Autoware containers
  - `Dockerfile` to build AWSIM runtime image from official binary
  - `start-awsim-e2e-demo.sh` with `--drive` / `--no-drive` modes
  - `awsim-config.json` with deterministic Shinjuku ego pose
  - `awsim_e2e_helper.py` for runtime verification and auto-drive
- **GPU-accelerated RViz** via VirtualGL:
  - `components/visualizer/Dockerfile`: install VirtualGL, copy GPU-aware launcher
  - `components/visualizer/etc/start-rviz2.sh`: standalone GPU detection with `vglrun -d egl`
  - `components/visualizer/etc/visualizer_entrypoint.sh`: copy GPU launcher at boot; add debug logging
- **Documentation**:
  - `deployments/README.md` and `docs/deployments/samples/index.md`: add AWSIM links
  - `docs/deployments/samples/awsim-simulation/index.md`: quick start guide

## Verified on VM

| Check | Result |
|-------|--------|
| E2E demo `--drive` | Moved 3.01 m autonomously |
| RViz GPU acceleration | `nvidia-smi pmon` shows `rviz2 type G` |
| AWSIM headless | Xvfb :98, Vulkan raytracing working |
| VNC/NoVNC | TigerVNC :5999 + NoVNC :6080 accessible |
| X display collision | AWSIM :98, visualizer :99 — no stale lock issues |

## Usage

+ ensure kernel UDP buffer sizes for DDS
+ sudo -n sysctl -qw net.core.rmem_max=2147483647 net.core.wmem_max=2147483647 net.core.rmem_default=134217728 net.core.wmem_default=134217728
+ ensure kernel UDP buffer sizes for DDS
+ sudo -n sysctl -qw net.core.rmem_max=2147483647 net.core.wmem_max=2147483647 net.core.rmem_default=134217728 net.core.wmem_default=134217728