### PR TITLE
fix(ci): resilient per-image multi-arch manifest creation

### DIFF
--- a/.github/actions/combine-multi-arch-images/action.yaml
+++ b/.github/actions/combine-multi-arch-images/action.yaml
@@ -1,9 +1,18 @@
 name: combine-multi-arch-images
-description: Combine platform-specific Docker images into multi-arch manifests
+description: Create one image's multi-arch (or single-arch) manifest from per-arch tags
 
 inputs:
+  image:
+    description: Full image prefix, e.g. ghcr.io/<owner>/openadkit
+    required: true
+  target:
+    description: Image target name, e.g. planning-control
+    required: true
   ros-distro:
     description: ROS distribution name
+    required: true
+  arches:
+    description: 'Space-separated required architecture labels, e.g. "amd64 arm64"'
     required: true
   build-tag:
     description: Immutable build tag for this workflow run
@@ -11,19 +20,6 @@ inputs:
   registry:
     description: Container registry
     required: true
-  image-prefix-common:
-    description: Image prefix for common images
-    required: true
-  image-prefix-component:
-    description: Image prefix for component images
-    required: true
-  component-targets:
-    description: 'Space-separated list of component image targets (e.g., "sensing-perception localization-mapping")'
-    required: true
-  single-arch-component-targets:
-    description: 'Space-separated amd64-only component targets from image inventory'
-    required: false
-    default: ''
   token:
     description: GitHub token for registry access
     required: true
@@ -31,61 +27,19 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Login to GitHub Container Registry
+    - name: Log in to Container Registry
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.registry }}
         username: ${{ github.actor }}
         password: ${{ inputs.token }}
 
-    - name: Combine multi-arch images for common packages
-      run: |
-        set -e
-
-        IMAGE="${{ inputs.image-prefix-common }}"
-        DISTRO="${{ inputs.ros-distro }}"
-        BUILD_TAG="${{ inputs.build-tag }}"
-
-        # Known common image variants (universe-common is multi-arch; no CUDA variant)
-        MULTI_ARCH_VARIANTS="universe-common-devel universe-common"
-
-        # Create multi-arch manifests (amd64 + arm64)
-        for variant in ${MULTI_ARCH_VARIANTS}; do
-          base_tag="${variant}-${DISTRO}-${BUILD_TAG}"
-          echo "Creating multi-arch manifest for ${IMAGE}:${base_tag}"
-          docker buildx imagetools create -t "${IMAGE}:${base_tag}" \
-            "${IMAGE}:${variant}-amd64-${DISTRO}-${BUILD_TAG}" \
-            "${IMAGE}:${variant}-arm64-${DISTRO}-${BUILD_TAG}"
-          echo "Created ${IMAGE}:${base_tag}"
-        done
+    - name: Create multi-arch manifest
       shell: bash
-
-    - name: Combine multi-arch images for component packages
-      run: |
-        set -e
-
-        IMAGE="${{ inputs.image-prefix-component }}"
-        DISTRO="${{ inputs.ros-distro }}"
-        BUILD_TAG="${{ inputs.build-tag }}"
-        TARGETS="${{ inputs.component-targets }}"
-        SINGLE_ARCH_TARGETS="${{ inputs.single-arch-component-targets }}"
-
-        for target in ${TARGETS}; do
-          base_tag="${target}-${DISTRO}-${BUILD_TAG}"
-
-          if [[ " ${SINGLE_ARCH_TARGETS} " == *" ${target} "* ]]; then
-            # amd64-only component targets from image inventory
-            echo "Creating single-arch manifest for ${IMAGE}:${base_tag}"
-            docker buildx imagetools create -t "${IMAGE}:${base_tag}" \
-              "${IMAGE}:${target}-amd64-${DISTRO}-${BUILD_TAG}"
-            echo "Created ${IMAGE}:${base_tag}"
-          else
-            # Multi-arch manifest (amd64 + arm64)
-            echo "Creating multi-arch manifest for ${IMAGE}:${base_tag}"
-            docker buildx imagetools create -t "${IMAGE}:${base_tag}" \
-              "${IMAGE}:${target}-amd64-${DISTRO}-${BUILD_TAG}" \
-              "${IMAGE}:${target}-arm64-${DISTRO}-${BUILD_TAG}"
-            echo "Created ${IMAGE}:${base_tag}"
-          fi
-        done
-      shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
+        TARGET: ${{ inputs.target }}
+        ROS_DISTRO: ${{ inputs.ros-distro }}
+        ARCHES: ${{ inputs.arches }}
+        BUILD_TAG: ${{ inputs.build-tag }}
+      run: bash "${GITHUB_ACTION_PATH}/create-manifest.sh"

--- a/.github/actions/combine-multi-arch-images/create-manifest.sh
+++ b/.github/actions/combine-multi-arch-images/create-manifest.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Create one image's multi-arch (or single-arch) manifest from per-arch tags.
+# Fails (and creates nothing) if any required architecture is missing, so a
+# degraded manifest is never published.
+#
+# Required env: IMAGE TARGET ROS_DISTRO ARCHES BUILD_TAG
+set -euo pipefail
+
+: "${IMAGE:?IMAGE is required}"
+: "${TARGET:?TARGET is required}"
+: "${ROS_DISTRO:?ROS_DISTRO is required}"
+: "${ARCHES:?ARCHES is required}"
+: "${BUILD_TAG:?BUILD_TAG is required}"
+
+target_ref="${IMAGE}:${TARGET}-${ROS_DISTRO}-${BUILD_TAG}"
+
+read -ra arch_list <<< "${ARCHES}"
+sources=()
+missing=()
+for arch in "${arch_list[@]}"; do
+  ref="${IMAGE}:${TARGET}-${arch}-${ROS_DISTRO}-${BUILD_TAG}"
+  if docker buildx imagetools inspect "${ref}" >/dev/null 2>&1; then
+    sources+=("${ref}")
+  else
+    missing+=("${arch}")
+  fi
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "::error::Cannot create ${target_ref}: missing architecture(s): ${missing[*]}"
+  exit 1
+fi
+
+echo "Creating ${target_ref} from: ${sources[*]}"
+docker buildx imagetools create -t "${target_ref}" "${sources[@]}"
+echo "Created ${target_ref}"

--- a/.github/actions/combine-multi-arch-images/test-create-manifest.sh
+++ b/.github/actions/combine-multi-arch-images/test-create-manifest.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SUT="${SCRIPT_DIR}/create-manifest.sh"
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+# Stub `docker` on PATH: `inspect` succeeds iff the ref is listed in
+# $PRESENT_REFS; `create` records its args to $CREATE_LOG.
+cat > "${work}/docker" <<'STUB'
+#!/usr/bin/env bash
+if [ "$3" = "inspect" ]; then
+  grep -qxF "$4" "${PRESENT_REFS}" && exit 0 || exit 1
+elif [ "$3" = "create" ]; then
+  shift 3
+  echo "create $*" >> "${CREATE_LOG}"
+  exit 0
+fi
+exit 2
+STUB
+chmod +x "${work}/docker"
+export PATH="${work}:${PATH}"
+export CREATE_LOG="${work}/create.log"
+export PRESENT_REFS="${work}/present.txt"
+
+fail=0
+check() { if ! eval "$1"; then echo "FAIL: $1"; fail=1; fi; }
+run_sut() { if env "$@" bash "${SUT}" >"${work}/out.txt" 2>&1; then rc=0; else rc=$?; fi; }
+
+# Case 1: both arches present -> create with both sources, exit 0
+printf '%s\n' \
+  "ghcr.io/x/openadkit:planning-control-amd64-humble-T" \
+  "ghcr.io/x/openadkit:planning-control-arm64-humble-T" > "${PRESENT_REFS}"
+: > "${CREATE_LOG}"
+run_sut IMAGE=ghcr.io/x/openadkit TARGET=planning-control ROS_DISTRO=humble ARCHES="amd64 arm64" BUILD_TAG=T
+check "[ ${rc} -eq 0 ]"
+check "grep -q 'planning-control-amd64-humble-T' '${CREATE_LOG}'"
+check "grep -q 'planning-control-arm64-humble-T' '${CREATE_LOG}'"
+check "grep -q 'ghcr.io/x/openadkit:planning-control-humble-T' '${CREATE_LOG}'"
+
+# Case 2: arm64 missing -> exit 1, no create, error names the arch
+printf '%s\n' "ghcr.io/x/openadkit:visualizer-amd64-humble-T" > "${PRESENT_REFS}"
+: > "${CREATE_LOG}"
+run_sut IMAGE=ghcr.io/x/openadkit TARGET=visualizer ROS_DISTRO=humble ARCHES="amd64 arm64" BUILD_TAG=T
+check "[ ${rc} -eq 1 ]"
+check "[ ! -s '${CREATE_LOG}' ]"
+check "grep -q 'missing architecture' '${work}/out.txt'"
+check "grep -q 'arm64' '${work}/out.txt'"
+
+# Case 3: single arch present -> create with one source, exit 0
+printf '%s\n' "ghcr.io/x/openadkit:carla-interface-amd64-humble-T" > "${PRESENT_REFS}"
+: > "${CREATE_LOG}"
+run_sut IMAGE=ghcr.io/x/openadkit TARGET=carla-interface ROS_DISTRO=humble ARCHES="amd64" BUILD_TAG=T
+check "[ ${rc} -eq 0 ]"
+check "grep -q 'carla-interface-amd64-humble-T' '${CREATE_LOG}'"
+
+if [ "${fail}" -eq 0 ]; then echo "create-manifest: ALL PASS"; else echo "create-manifest: TESTS FAILED"; exit 1; fi

--- a/.github/scripts/report_manifests.sh
+++ b/.github/scripts/report_manifests.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Emit a per-image created/missing multi-arch manifest table (Markdown) to
+# stdout. Reads registry truth, so it is correct regardless of which manifest
+# legs ran. Required env: MANIFEST_MATRIX IMAGE_PREFIX_COMMON
+# IMAGE_PREFIX_COMPONENT BUILD_TAG
+set -euo pipefail
+: "${MANIFEST_MATRIX:?}"
+: "${IMAGE_PREFIX_COMMON:?}"
+: "${IMAGE_PREFIX_COMPONENT:?}"
+: "${BUILD_TAG:?}"
+
+echo "## Multi-arch manifest report"
+echo ""
+echo "| Image | ROS distro | Status |"
+echo "|-------|------------|--------|"
+
+jq -c '.include[]' <<< "${MANIFEST_MATRIX}" | while read -r entry; do
+  repo=$(jq -r '.repo' <<< "${entry}")
+  target=$(jq -r '.target' <<< "${entry}")
+  distro=$(jq -r '."ros-distro"' <<< "${entry}")
+  if [ "${repo}" = "common" ]; then
+    prefix="${IMAGE_PREFIX_COMMON}"
+  else
+    prefix="${IMAGE_PREFIX_COMPONENT}"
+  fi
+  ref="${prefix}:${target}-${distro}-${BUILD_TAG}"
+  if docker buildx imagetools inspect "${ref}" >/dev/null 2>&1; then
+    echo "| \`${target}\` | ${distro} | ✅ created |"
+  else
+    echo "| \`${target}\` | ${distro} | ❌ missing |"
+  fi
+done

--- a/.github/scripts/resolve_image_matrices.py
+++ b/.github/scripts/resolve_image_matrices.py
@@ -53,7 +53,6 @@ def build_matrices(inventory):
         {"platform": p, "platform-label": platform_label(p), "ros-distro": d}
         for p, d in common_pairs
     ]}
-    ros_distro_matrix = {"include": [{"ros-distro": d} for d in distros]}
 
     manifest_include = []
     for image in images:
@@ -70,7 +69,6 @@ def build_matrices(inventory):
     return {
         "common_matrix": common_matrix,
         "component_matrix": matrix_for("component"),
-        "ros_distro_matrix": ros_distro_matrix,
         "manifest_matrix": manifest_matrix,
     }
 

--- a/.github/scripts/resolve_image_matrices.py
+++ b/.github/scripts/resolve_image_matrices.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Resolve GitHub Actions build matrices from the image inventory.
+
+Prints `KEY=<compact-json>` lines for each matrix to stdout. The `prepare`
+job redirects this into `$GITHUB_OUTPUT`. Uses only the standard library so
+it runs before any pip/apt install step.
+"""
+import json
+import pathlib
+import sys
+
+DEFAULT_INVENTORY = ".github/image-inventory.json"
+
+
+def platform_label(platform):
+    if platform == "linux/amd64":
+        return "amd64"
+    if platform == "linux/arm64":
+        return "arm64"
+    raise ValueError(f"unsupported platform: {platform}")
+
+
+def image_distros(image, default_distros):
+    return image.get("ros_distros", default_distros)
+
+
+def build_matrices(inventory):
+    distros = inventory["ros_distros"]
+    images = inventory["images"]
+
+    def matrix_for(stage):
+        include = []
+        for image in images:
+            if image["stage"] != stage:
+                continue
+            for distro in image_distros(image, distros):
+                for platform in image["platforms"]:
+                    include.append({
+                        "platform": platform,
+                        "platform-label": platform_label(platform),
+                        "ros-distro": distro,
+                        "target": image["target"],
+                    })
+        return {"include": include}
+
+    common_pairs = sorted({
+        (platform, distro)
+        for image in images if image["stage"] == "common"
+        for distro in image_distros(image, distros)
+        for platform in image["platforms"]
+    })
+    common_matrix = {"include": [
+        {"platform": p, "platform-label": platform_label(p), "ros-distro": d}
+        for p, d in common_pairs
+    ]}
+    ros_distro_matrix = {"include": [{"ros-distro": d} for d in distros]}
+
+    manifest_include = []
+    for image in images:
+        arches = " ".join(platform_label(p) for p in image["platforms"])
+        for distro in image_distros(image, distros):
+            manifest_include.append({
+                "repo": image["repo"],
+                "target": image["target"],
+                "ros-distro": distro,
+                "arches": arches,
+            })
+    manifest_matrix = {"include": manifest_include}
+
+    return {
+        "common_matrix": common_matrix,
+        "component_matrix": matrix_for("component"),
+        "ros_distro_matrix": ros_distro_matrix,
+        "manifest_matrix": manifest_matrix,
+    }
+
+
+def format_outputs(matrices):
+    lines = [f"{k}={json.dumps(v, separators=(',', ':'))}" for k, v in matrices.items()]
+    return "\n".join(lines) + "\n"
+
+
+def main(argv):
+    path = argv[1] if len(argv) > 1 else DEFAULT_INVENTORY
+    inventory = json.loads(pathlib.Path(path).read_text())
+    sys.stdout.write(format_outputs(build_matrices(inventory)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/scripts/test_report_manifests.sh
+++ b/.github/scripts/test_report_manifests.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SUT="${SCRIPT_DIR}/report_manifests.sh"
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+cat > "${work}/docker" <<'STUB'
+#!/usr/bin/env bash
+if [ "$3" = "inspect" ]; then
+  grep -qxF "$4" "${PRESENT_REFS}" && exit 0 || exit 1
+fi
+exit 2
+STUB
+chmod +x "${work}/docker"
+export PATH="${work}:${PATH}"
+export PRESENT_REFS="${work}/present.txt"
+printf '%s\n' "ghcr.io/x/openadkit:planning-control-humble-T" > "${PRESENT_REFS}"
+
+MM='{"include":[{"repo":"component","target":"planning-control","ros-distro":"humble","arches":"amd64 arm64"},{"repo":"component","target":"visualizer","ros-distro":"humble","arches":"amd64 arm64"}]}'
+out=$(MANIFEST_MATRIX="${MM}" \
+      IMAGE_PREFIX_COMMON=ghcr.io/x/openadkit-common \
+      IMAGE_PREFIX_COMPONENT=ghcr.io/x/openadkit \
+      BUILD_TAG=T bash "${SUT}")
+printf '%s\n' "${out}"
+
+fail=0
+grep -q 'planning-control.*✅ created' <<< "${out}" || { echo "FAIL: created row"; fail=1; }
+grep -q 'visualizer.*❌ missing'      <<< "${out}" || { echo "FAIL: missing row"; fail=1; }
+if [ "${fail}" -eq 0 ]; then echo "report: ALL PASS"; else echo "report: TESTS FAILED"; exit 1; fi

--- a/.github/scripts/test_resolve_image_matrices.py
+++ b/.github/scripts/test_resolve_image_matrices.py
@@ -43,9 +43,8 @@ def test_existing_matrices_unchanged_shape():
     m = r.build_matrices(INVENTORY)
     entry = m["component_matrix"]["include"][0]
     assert set(entry) == {"platform", "platform-label", "ros-distro", "target"}
-    assert m["ros_distro_matrix"] == {
-        "include": [{"ros-distro": "humble"}, {"ros-distro": "jazzy"}]
-    }
+    common_entry = m["common_matrix"]["include"][0]
+    assert set(common_entry) == {"platform", "platform-label", "ros-distro"}
 
 
 def test_old_outputs_removed():
@@ -55,10 +54,10 @@ def test_old_outputs_removed():
     assert "single_arch_component_targets" not in m
 
 
-def test_cli_emits_exactly_four_keys():
+def test_cli_emits_exactly_three_keys():
     out = subprocess.run(
         [sys.executable, ".github/scripts/resolve_image_matrices.py"],
         capture_output=True, text=True, check=True,
     ).stdout
     keys = {line.split("=", 1)[0] for line in out.splitlines() if line}
-    assert keys == {"common_matrix", "component_matrix", "ros_distro_matrix", "manifest_matrix"}
+    assert keys == {"common_matrix", "component_matrix", "manifest_matrix"}

--- a/.github/scripts/test_resolve_image_matrices.py
+++ b/.github/scripts/test_resolve_image_matrices.py
@@ -1,0 +1,64 @@
+import json
+import pathlib
+import subprocess
+import sys
+
+import resolve_image_matrices as r
+
+INVENTORY = json.loads(pathlib.Path(".github/image-inventory.json").read_text())
+
+
+def manifest_index(matrices):
+    return {
+        (e["repo"], e["target"], e["ros-distro"]): e["arches"]
+        for e in matrices["manifest_matrix"]["include"]
+    }
+
+
+def test_multiarch_component_has_both_arches():
+    idx = manifest_index(r.build_matrices(INVENTORY))
+    assert idx[("component", "planning-control", "humble")] == "amd64 arm64"
+    assert idx[("component", "planning-control", "jazzy")] == "amd64 arm64"
+
+
+def test_amd64_only_targets_have_single_arch():
+    idx = manifest_index(r.build_matrices(INVENTORY))
+    assert idx[("component", "sensing-perception-cuda", "humble")] == "amd64"
+    assert idx[("component", "sensing-perception-cuda", "jazzy")] == "amd64"
+
+
+def test_carla_is_humble_only():
+    idx = manifest_index(r.build_matrices(INVENTORY))
+    assert idx[("component", "carla-interface", "humble")] == "amd64"
+    assert ("component", "carla-interface", "jazzy") not in idx
+
+
+def test_common_images_included_multiarch():
+    idx = manifest_index(r.build_matrices(INVENTORY))
+    assert idx[("common", "universe-common", "humble")] == "amd64 arm64"
+    assert idx[("common", "universe-common-devel", "jazzy")] == "amd64 arm64"
+
+
+def test_existing_matrices_unchanged_shape():
+    m = r.build_matrices(INVENTORY)
+    entry = m["component_matrix"]["include"][0]
+    assert set(entry) == {"platform", "platform-label", "ros-distro", "target"}
+    assert m["ros_distro_matrix"] == {
+        "include": [{"ros-distro": "humble"}, {"ros-distro": "jazzy"}]
+    }
+
+
+def test_old_outputs_removed():
+    m = r.build_matrices(INVENTORY)
+    assert "manifest_targets" not in m
+    assert "component_manifest_targets" not in m
+    assert "single_arch_component_targets" not in m
+
+
+def test_cli_emits_exactly_four_keys():
+    out = subprocess.run(
+        [sys.executable, ".github/scripts/resolve_image_matrices.py"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    keys = {line.split("=", 1)[0] for line in out.splitlines() if line}
+    assert keys == {"common_matrix", "component_matrix", "ros_distro_matrix", "manifest_matrix"}

--- a/.github/workflows/build-all-images.yaml
+++ b/.github/workflows/build-all-images.yaml
@@ -6,6 +6,7 @@ on:
       - '.github/actions/combine-multi-arch-images/**'
       - '.github/actions/free-disk-space/**'
       - '.github/image-inventory.json'
+      - '.github/scripts/**'
       - '.github/workflows/build-all-images.yaml'
       - 'components/docker-bake.hcl'
       - 'components/universe-common/**'
@@ -58,9 +59,7 @@ jobs:
       common_matrix: ${{ steps.inventory.outputs.common_matrix }}
       component_matrix: ${{ steps.inventory.outputs.component_matrix }}
       ros_distro_matrix: ${{ steps.inventory.outputs.ros_distro_matrix }}
-      manifest_targets: ${{ steps.inventory.outputs.manifest_targets }}
-      component_manifest_targets: ${{ steps.inventory.outputs.component_manifest_targets }}
-      single_arch_component_targets: ${{ steps.inventory.outputs.single_arch_component_targets }}
+      manifest_matrix: ${{ steps.inventory.outputs.manifest_matrix }}
     steps:
       - name: Checkout OpenADKit repository
         uses: actions/checkout@v6
@@ -123,83 +122,7 @@ jobs:
           set -euo pipefail
           mkdir -p image-inventory
           cp .github/image-inventory.json image-inventory/image-inventory.json
-          python3 <<'PY'
-          import json
-          import os
-          import pathlib
-
-          inventory = json.loads(pathlib.Path(".github/image-inventory.json").read_text())
-          distros = inventory["ros_distros"]
-          images = inventory["images"]
-
-          def image_distros(image):
-              return image.get("ros_distros", distros)
-
-          def platform_label(platform):
-              if platform == "linux/amd64":
-                  return "amd64"
-              if platform == "linux/arm64":
-                  return "arm64"
-              raise ValueError(f"unsupported platform: {platform}")
-
-          def matrix_for(stage):
-              include = []
-              for image in images:
-                  if image["stage"] != stage:
-                      continue
-                  for distro in image_distros(image):
-                      for platform in image["platforms"]:
-                          include.append({
-                              "platform": platform,
-                              "platform-label": platform_label(platform),
-                              "ros-distro": distro,
-                              "target": image["target"],
-                          })
-              return {"include": include}
-
-          common_pairs = sorted({
-              (platform, distro)
-              for image in images if image["stage"] == "common"
-              for distro in image_distros(image)
-              for platform in image["platforms"]
-          })
-          common_matrix = {
-              "include": [
-                  {"platform": platform, "platform-label": platform_label(platform), "ros-distro": distro}
-                  for platform, distro in common_pairs
-              ]
-          }
-          ros_distro_matrix = {"include": [{"ros-distro": distro} for distro in distros]}
-          component_images = [image for image in images if image["repo"] == "component"]
-          manifest_targets = " ".join(image["target"] for image in component_images)
-          component_manifest_targets = {
-              distro: " ".join(
-                  sorted(image["target"] for image in component_images if distro in image_distros(image))
-              )
-              for distro in distros
-          }
-          single_arch_component_targets = " ".join(
-              sorted(
-                  image["target"] for image in component_images
-                  if "linux/arm64" not in image["platforms"]
-              )
-          )
-
-          outputs = {
-              "common_matrix": common_matrix,
-              "component_matrix": matrix_for("component"),
-              "ros_distro_matrix": ros_distro_matrix,
-              "manifest_targets": manifest_targets,
-              "component_manifest_targets": component_manifest_targets,
-              "single_arch_component_targets": single_arch_component_targets,
-          }
-          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
-              for key, value in outputs.items():
-                  if isinstance(value, str):
-                      output.write(f"{key}={value}\n")
-                  else:
-                      output.write(f"{key}={json.dumps(value, separators=(',', ':'))}\n")
-          PY
+          python3 .github/scripts/resolve_image_matrices.py >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Upload image inventory

--- a/.github/workflows/build-all-images.yaml
+++ b/.github/workflows/build-all-images.yaml
@@ -598,6 +598,36 @@ jobs:
           registry: ${{ env.REGISTRY }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  manifest-report:
+    runs-on: ubuntu-22.04
+    needs: [prepare, create-manifests]
+    if: ${{ !cancelled() }}
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Write manifest report
+        env:
+          MANIFEST_MATRIX: ${{ needs.prepare.outputs.manifest_matrix }}
+          IMAGE_PREFIX_COMMON: ${{ env.IMAGE_PREFIX_COMMON }}
+          IMAGE_PREFIX_COMPONENT: ${{ env.IMAGE_PREFIX_COMPONENT }}
+          BUILD_TAG: ${{ needs.prepare.outputs.build_tag }}
+        run: bash .github/scripts/report_manifests.sh >> "$GITHUB_STEP_SUMMARY"
+        shell: bash
+
   capture-metadata:
     runs-on: ubuntu-22.04
     needs: [prepare, create-manifests]

--- a/.github/workflows/build-all-images.yaml
+++ b/.github/workflows/build-all-images.yaml
@@ -58,7 +58,6 @@ jobs:
       scan_requested: ${{ steps.prepare.outputs.scan_requested }}
       common_matrix: ${{ steps.inventory.outputs.common_matrix }}
       component_matrix: ${{ steps.inventory.outputs.component_matrix }}
-      ros_distro_matrix: ${{ steps.inventory.outputs.ros_distro_matrix }}
       manifest_matrix: ${{ steps.inventory.outputs.manifest_matrix }}
     steps:
       - name: Checkout OpenADKit repository
@@ -574,12 +573,13 @@ jobs:
   create-manifests:
     runs-on: ubuntu-22.04
     needs: [prepare, build-common, build-components]
+    if: ${{ !cancelled() }}
     permissions:
       contents: read
       packages: write
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.prepare.outputs.ros_distro_matrix) }}
+      matrix: ${{ fromJson(needs.prepare.outputs.manifest_matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -587,16 +587,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Combine multi-arch images
+      - name: Create multi-arch manifest for ${{ matrix.target }} (${{ matrix.ros-distro }})
         uses: ./.github/actions/combine-multi-arch-images
         with:
+          image: ${{ matrix.repo == 'common' && env.IMAGE_PREFIX_COMMON || env.IMAGE_PREFIX_COMPONENT }}
+          target: ${{ matrix.target }}
           ros-distro: ${{ matrix.ros-distro }}
+          arches: ${{ matrix.arches }}
           build-tag: ${{ needs.prepare.outputs.build_tag }}
           registry: ${{ env.REGISTRY }}
-          image-prefix-common: ${{ env.IMAGE_PREFIX_COMMON }}
-          image-prefix-component: ${{ env.IMAGE_PREFIX_COMPONENT }}
-          component-targets: ${{ fromJson(needs.prepare.outputs.component_manifest_targets)[matrix.ros-distro] }}
-          single-arch-component-targets: ${{ needs.prepare.outputs.single_arch_component_targets }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   capture-metadata:


### PR DESCRIPTION
## Problem

`build-all-images` declares `create-manifests` with `needs: build-components`, and GitHub evaluates `needs` at **job** granularity. When any single `build-components` leg fails — even with `fail-fast: false`, where every other leg still builds and pushes its per-arch image — the whole `create-manifests` job is skipped. Because consumers pull the multi-arch manifest tag (`<repo>:<target>-<distro>-<build_tag>`) rather than the per-arch tags, **no usable image is produced for any target**, including the many that built cleanly. One unrelated leg failure discards the entire run's output.

This is what happened in run #27483717985: three legs failed (`visualizer` arm64 ×2, `carla-interface` amd64), and `create-manifests` / `capture-metadata` / `summarize` were all skipped — every successfully built image was lost.

## Change

Replace the single per-distro `create-manifests` job with a per-image matrix so each image's manifest is created independently:

- `prepare` now emits a `manifest_matrix` (one entry per image × ROS distro, carrying that image's required architectures). The inventory→matrix logic moves into a unit-tested `.github/scripts/resolve_image_matrices.py`. The now-unused `ros_distro_matrix` output (whose only consumer was the old job) is dropped.
- `create-manifests` fans out over `manifest_matrix` with `if: ${{ !cancelled() }}`, so it runs even when sibling build legs failed. Each leg creates exactly one image's manifest **only when all required architectures are present**; if any is missing it fails red and publishes nothing — a degraded "multi-arch" tag silently missing an architecture is never created.
- `combine-multi-arch-images` is rewritten to operate on a single image, backed by a shellcheck-clean, unit-tested `create-manifest.sh`.
- A new always-on `manifest-report` job writes a per-image created/missing table to the run summary by inspecting the registry, regardless of which legs ran.

A successfully built image therefore always gets its manifest, while the run stays red and **non-releasable** whenever anything failed: `capture-metadata` and `summarize` stay strict and are skipped on partial builds, and `release.yaml` is unchanged (it still requires a fully successful source run plus full-inventory build metadata). The `build-common`/`build-components` jobs and `release.yaml`/`scan.yaml` are untouched; the `build-common → build-components` dependency is deliberately left as-is (separate concern).

## Validation

Verified on a fork run that organically hit the same partial failure as the motivating run above (`visualizer` arm64 in both distros and `carla-interface` amd64 broke at build time — pre-existing build breaks, unrelated to this change since it does not touch the build stage):

| | Before (old behavior) | With this change |
|---|---|---|
| Multi-arch manifests created | **0** (create-manifests skipped wholesale) | **18 of 21** |
| Failed manifest legs | all images lost | only the 3 genuinely-incomplete images |
| `capture-metadata` / `summarize` | skipped | skipped (fail-closed) |
| Run conclusion | failure | failure (correctly red) |

The three red legs failed for exactly the right reason — `create-manifest.sh` emitted:

```
Cannot create ...:carla-interface-humble-<tag>: missing architecture(s): amd64
Cannot create ...:visualizer-humble-<tag>:       missing architecture(s): arm64
Cannot create ...:visualizer-jazzy-<tag>:        missing architecture(s): arm64
```

…while the 18 fully-built images (sensing-perception ±cuda, localization-mapping, planning-control, vehicle-system, api, simulator, and the two `universe-common` bases — across both distros) each got their multi-arch manifest pushed. Local unit tests (`pytest` for the resolver, Bash stub-tests for both shell scripts) and the `shellcheck` lint job pass.

Note: because the run stays red on any failure (by design), CI on this PR will be red whenever a component build breaks — that is the intended signal. The point of this change is that such a run now **preserves the manifests for every image that did build**, instead of discarding all of them.

## Related build breaks (separate from this PR)

The component build failures that keep these runs red are tracked separately — this PR is what makes them non-fatal to the rest of the build:

- autowarefoundation/openadkit#98 — `visualizer` arm64 build fails (amd64-only VirtualGL `.deb` installed on arm64)
- autowarefoundation/openadkit#99 — `carla-interface` build fails (`python3 -m pip` unavailable)
