### PR TITLE
chore: drop trt_batched_nms from the sensing-perception build paths

### DIFF
--- a/components/sensing-perception/Dockerfile
+++ b/components/sensing-perception/Dockerfile
@@ -33,7 +33,6 @@ RUN --mount=type=bind,source=autoware/src,target=/tmp/autoware/src \
       --base-paths \
         /tmp/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_perception_launch \
         /tmp/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_sensing_launch \
-        /tmp/autoware/src/universe/external/trt_batched_nms \
         /tmp/autoware/src/universe/external/bevdet_vendor \
         /tmp/autoware/src/universe/external/cuda_blackboard \
         /tmp/autoware/src/universe/external/negotiated \

--- a/components/sensing-perception/Dockerfile.cuda
+++ b/components/sensing-perception/Dockerfile.cuda
@@ -39,7 +39,6 @@ RUN --mount=type=bind,source=autoware/src,target=/tmp/autoware/src \
       --base-paths \
         /tmp/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_perception_launch \
         /tmp/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_sensing_launch \
-        /tmp/autoware/src/universe/external/trt_batched_nms \
         /tmp/autoware/src/universe/external/bevdet_vendor \
         /tmp/autoware/src/universe/external/cuda_blackboard \
         /tmp/autoware/src/universe/external/negotiated \


### PR DESCRIPTION
## Description

- `trt_batched_nms` is being removed from `autowarefoundation/autoware`. autowarefoundation/autoware#7253 drops the `universe/external/trt_batched_nms` entry from `repositories/autoware.repos`, because its only consumer was `autoware_tensorrt_rtmdet`, which was never merged and whose parent issue autowarefoundation/autoware_universe#7235 is now closed as not planned. Tracked in autowarefoundation/autoware#7252.

`build-all-images.yaml` clones `autowarefoundation/autoware` as `autoware-metadata` and derives `autoware-lock.repos` from it, so once #7253 merges `vcs import` no longer creates that directory and both `--base-paths` entries point at a path that does not exist.

Removes the entry from `components/sensing-perception/Dockerfile:36` and `components/sensing-perception/Dockerfile.cuda:42`.

## How was this PR tested?

- `git grep -in trt_batched_nms` returns nothing on the branch.
- Both `RUN` blocks re-read end to end: line continuations intact, 8 remaining `--base-paths` entries each still ending in a backslash, `--install-base` and `--cmake-args` unchanged.
- No Docker build run locally.

## Effects on system behavior

No functional effect, and no ordering constraint against #7253: safe to merge before or after it. `colcon` walks base paths with `os.walk()`, which yields nothing for a missing directory and does not raise, so CI stays green either way. The only observable change is that newly built `sensing-perception` images no longer contain `libtrt_batched_nms_plugin.so`, which nothing loads.
