### PR TITLE
feat(x5h): add the CR52 dual-boot + RPMsg foundation

### DIFF
--- a/platforms/autosd/x5h/README.md
+++ b/platforms/autosd/x5h/README.md
@@ -21,6 +21,10 @@ answered before board time.
 > mean that fork's runs. Board bring-up is manual either way — no CI has the
 > hardware.
 
+- [CR52 dual boot + RPMsg](rpmsg-dualboot.md) — run FreeRTOS on the
+  realtime core under AutoSD; remoteproc `start` publishes RPMsg state to
+  a CR52 that is already executing, it does not load or release it.
+
 ## Folder Structure
 
 - `aib/`: automotive-image-builder manifest (distro `autosd10-sig`)

--- a/platforms/autosd/x5h/rpmsg-dualboot.md
+++ b/platforms/autosd/x5h/rpmsg-dualboot.md
@@ -1,66 +1,48 @@
 # X5H dual boot: CR52 FreeRTOS under AutoSD, with RPMsg
 
 Runs a FreeRTOS payload on the CR52 realtime core while AutoSD runs on
-the CA720AE cluster, using the kernel remoteproc/RPMsg stack. No flash
-is written by this procedure: `echo start` on the `cr52_1` remoteproc
-publishes the resource table into the CR52's reserved-memory carveout,
-allocates the vrings, and enables the MFIS doorbell for a CR52 that is
-already executing — it does not load an ELF onto the core or release
-it from reset. A power cycle always returns the board to its default
-boot.
+the CA720AE cluster, and exchanges RPMsg messages between them over the
+kernel remoteproc/RPMsg stack.
+
+The realtime payload is **not** loaded by Linux. It is flashed into the
+realtime core's boot slot and started by the boot firmware, so it is
+already executing before Linux comes up. `echo start` on the `cr52_1`
+remoteproc only parses the resource table out of the staged ELF,
+publishes the vrings into the CR52's reserved-memory carveout, and rings
+the MFIS doorbell. This is the vendor-normative arrangement: on this SoC
+`.load` and `.stop` are no-ops, so runtime loading through remoteproc is
+not merely unsupported, it is not implemented.
 
 ## Status on real hardware
 
-Validated on the board on 2026-08-06, on both the BSP Yocto reference
-boot (`6.1.102-yocto-standard`) and AutoSD (`6.1.102-autosd`).
+Validated on the board on 2026-08-07, on both the BSP Yocto reference
+boot (`6.1.102-yocto-standard`) and AutoSD (`6.1.102-autosd`), with a
+vendor-supplied CR52 RPMsg firmware built for **MFIS channel 1** flashed
+into the realtime core's boot slot.
 
-**The Linux side works and is identical on both OSes.** The `cr52_1`
-remoteproc enumerates, accepts a firmware name, goes `offline` →
-`running`, and brings up a working virtio RPMsg bus:
+**Both OSes pass, with byte-identical marker lines:**
+
+```
+virtio_rpmsg_bus virtio0: creating channel rpmsg-client-sample addr 0x400
+RPMSG_PING_PASS n=100 service=rpmsg-client-sample dst=0x400 mode=responder reply='Hello world from CR52/Free-RTOS!'
+RPMSG_SMOKE_PASS cycles=1 msgs=100
+```
+
+The round trip is confirmed from both ends independently: Linux received
+100 replies, all byte-identical, and the CR52's own console logged
+`Incoming msg: x5h-rpmsg-ping seq=0` … `seq=99` — the exact sequenced
+payloads `rpmsg-ping` sent. AutoSD produced no SELinux AVC denials and no
+rpmsg/remoteproc errors.
 
 | Check | Both OSes |
 |---|---|
 | `remoteproc0` name / state / default firmware | `cr52_1` / `offline` / `rproc-cr52_1-fw` |
-| Probe log | `rcar_mfis: channel 1 initialized`, `mfis-mbox: MFIS mailbox enabled with 2 chans`, `remoteproc0: cr52_1 is available` |
-| After `start` | `virtio_rpmsg_bus virtio0: rpmsg host is online`, `remote processor cr52_1 is now up` |
-| `virtio0` status | `0x07` (ACKNOWLEDGE \| DRIVER \| DRIVER_OK) |
-| rpmsg bus | `virtio0.rpmsg_ctrl.0.0`, `virtio0.rpmsg_ns.53.53`, `/dev/rpmsg_ctrl0` |
-| SELinux (AutoSD, permissive) | no AVC denials touching rpmsg / remoteproc / firmware |
+| After `start` | `rpmsg host is online`, `remote processor cr52_1 is now up` |
+| Announced channel | `rpmsg-client-sample` at `addr 0x400` |
+| Round trips | 100/100, reply constant |
 
-**The echo round trip does not work, because nothing is running on the
-CR52 to answer it.** Both OSes stop at:
-
-```
-RPMSG_SMOKE_FAIL cycle=1 reason=service_timeout service=rpmsg-client-sample
-```
-
-A second `start` in the same boot then logs:
-
-```
-rcar-gen5-rproc soc:cr52_1: rcar_gen5_rproc_kick failed
-```
-
-which is the decisive evidence. That message means the MFIS doorbell
-rung by the *first* `start` was never acknowledged: the kick helper
-refuses to ring again while the remote is still flagged as processing
-the previous interrupt, and the remote only clears that flag when it
-services the doorbell. So the CR52 is not servicing MFIS channel 1 at
-all — it is not merely missing an RPMsg service.
-
-Getting an RPMsg-capable payload onto the CR52 requires writing its
-boot-firmware flash slot, which the zero-flash-write rule this work is
-held to forbids. There is no software path around it: the SoC's
-remoteproc driver does not load or start the core (see Notes), and
-U-Boot on this board has no remoteproc support either — `help rproc`
-returns `Unknown command`, and the command list has no `rproc`, no
-`cpu`, and nothing else CR52-related. Loading the ELF from RAM at the
-U-Boot prompt is therefore not an option.
-
-**What this means for a failing run:** a `reason=service_timeout` on
-this board is the *expected* result today. It is neither a defect in
-this tooling nor an AutoSD regression — the AutoSD result is
-byte-for-byte the same as the vendor BSP reference. Do not open a
-vendor escalation on the strength of a `service_timeout` alone.
+Zero AutoSD-vs-vendor-BSP delta: every observation on AutoSD matched the
+Yocto reference exactly.
 
 ## What the kernel already provides
 
@@ -70,18 +52,30 @@ with `CONFIG_RCAR_GEN5_REMOTEPROC=y`, `CONFIG_RCAR_MFIS=y`,
 `cr52_1` remoteproc node on MFIS channel 1, and its reserved-memory
 carveout. Nothing needs rebuilding to use them.
 
+Note that the device tree pins which realtime core is reachable, and
+how. `cr52_1` is the only enabled remoteproc node (`cr52_0` and `cr52_2`
+are `disabled`), and `renesas,mfis-channels` is a *list of channel
+indices*, not a count — `<1>` registers channel 1 only. The
+userspace-UIO alternative is wired the other way round: `rpmsg_shm0` /
+`rpmsg_ipi0` (channel 0) are enabled while their channel-1 counterparts
+are disabled. So on this device tree the kernel rpmsg_char path reaches
+core 1 and nothing else, and a firmware flashed for a different channel
+will never be serviced no matter how healthy the Linux side looks.
+
 ## Prerequisites
 
-- A CR52 firmware ELF staged as `/lib/firmware/rpmsg-echo-cr52.elf` on
-  the target rootfs, built for this board with MFIS channel 1 — the
-  channel must match the device tree. Only its `.resource_table`
-  segment is consumed: the remoteproc driver's `.load` is a no-op, so
-  the ELF's code and data segments are never copied to the core. The
-  ELF supplies the vring layout Linux publishes into the carveout; the
-  code that would answer on the other end has to already be running on
-  the CR52.
-- `rpmsg-ping` (static aarch64, built from `scripts/rpmsg-ping.c`;
-  takes `-s <service>`, `-n <count>`, and `-t <timeout_s>`) and
+- A CR52 RPMsg firmware **flashed into the realtime core's boot slot**,
+  built for this board with MFIS channel 1 — the channel must match the
+  device tree, and the firmware's `.resource_table` address must equal
+  the `memory-region` of the `cr52_1` node. Flashing is a separate,
+  operator-authorised step: it writes vendor flash and is out of scope
+  for this document.
+- The **same** firmware ELF staged as `/lib/firmware/rpmsg-echo-cr52.elf`
+  on the target rootfs. Only its `.resource_table` is consumed — the
+  code and data segments are never copied to the core — but it is what
+  Linux derives the vring layout from, so a stale ELF that no longer
+  matches the flashed image will disagree about the ring layout.
+- `rpmsg-ping` (static aarch64, built from `scripts/rpmsg-ping.c`) and
   `scripts/rpmsg-smoke.sh` on the target. `rpmsg-smoke.sh` resolves
   `rpmsg-ping` relative to its own directory first, falling back to
   `PATH`, so `rpmsg-ping` must be executable and either sit next to
@@ -89,12 +83,12 @@ carveout. Nothing needs rebuilding to use them.
 
 ### Staging the assets
 
-Both rootfs images netboot over NFS, so the host can drop files
-straight into the export instead of copying them to a running board.
-`/tmp` is a tmpfs on *both* the BSP Yocto and the AutoSD rootfs, so
-anything written to `<export>/tmp` from the host is invisible on the
-target — use a path that is not a mount point. On AutoSD, `/var/tmp`
-is a plain directory on the NFS root and works:
+Both rootfs images netboot over NFS, so the host can drop files straight
+into the export instead of copying them to a running board. `/tmp` is a
+tmpfs on *both* the BSP Yocto and the AutoSD rootfs, so anything written
+to `<export>/tmp` from the host is invisible on the target — use a path
+that is not a mount point. On AutoSD, `/var/tmp` is a plain directory on
+the NFS root and works:
 
 ```
 install -m0755 rpmsg-ping rpmsg-smoke.sh <export>/var/tmp/rpmsg/
@@ -109,79 +103,99 @@ install -m0755 /var/tmp/rpmsg/rpmsg-ping /var/tmp/rpmsg/rpmsg-smoke.sh /usr/loca
 install -m0644 /var/tmp/rpmsg/rpmsg-echo-cr52.elf /lib/firmware/
 ```
 
+If only one export is writable from the host, the board can reach the
+other one itself: NFS-mount it from the target with an explicit
+`-o vers=3,addr=<host>` (both options are required here — without
+`vers=3` the mount fails with `NFS: Version unavailable`) and copy
+across.
+
 ## Procedure
 
-1. Boot the target OS (BSP Yocto default boot, or AutoSD via
+1. Power on. The realtime firmware starts from flash before Linux; its
+   console (a separate serial channel from the Linux console, 115200)
+   should show the OpenAMP banner ending in `creating remoteproc virtio`.
+   If that banner is absent, stop — nothing will answer, and the Linux
+   side cannot tell you why.
+2. Boot the target OS (BSP Yocto default boot, or AutoSD via
    `run bootcmd_autosd` netboot).
-2. Block the in-tree sample driver from taking the channel — see Notes
+3. Block the in-tree sample driver from taking the channel — see Notes
    for why this must happen *before* the first `start`:
    ```
    echo 'blacklist rpmsg_client_sample' > /etc/modprobe.d/x5h-rpmsg-diag.conf
+   modprobe rpmsg_ctrl && modprobe rpmsg_char
    ```
-3. Preflight (read-only): `sh rpmsg-smoke.sh --check`
+4. Preflight (read-only): `sh rpmsg-smoke.sh --check`
    — confirms the `cr52_1` remoteproc exists, reports its state, and
    ends with the `RPMSG_SMOKE_CHECK_DONE` marker. Any problem found
    before that point instead prints `RPMSG_SMOKE_FAIL cycle=0
    reason=<...>` and exits 1; `--check` makes no state changes either
    way.
-4. Single-cycle probe: `sh rpmsg-smoke.sh -f rpmsg-echo-cr52.elf \
-   -s rpmsg-client-sample -n 100 -c 1` — one load/start/ping/stop round
-   trip. Run `-c 1` first, always: on the board today this stops at
-   `reason=service_timeout` (see Status), and a multi-cycle run adds
-   nothing until that is resolved.
-5. Multi-cycle probe, only once step 4 passes: `sh rpmsg-smoke.sh \
-   -f rpmsg-echo-cr52.elf -s rpmsg-client-sample -n 100 -c 3` — probes
-   whether the CR52 survives repeated Linux-side vdev teardown, which
-   is a different question from step 4. Because `stop` is a no-op on
-   this SoC (see Notes), a cycle boundary only tears down the Linux
-   side: the CR52 keeps its ring indices and its already-bound
-   endpoint while Linux allocates fresh vrings with reset indices on
-   the next `start`. A failure at cycle 2 or later is therefore an
-   expected, non-blocking outcome of that mismatch, not a regression —
-   treat a passing step 4 as the meaningful result and don't escalate
-   on a later-cycle failure by itself.
-6. A working run prints `RPMSG_PING_PASS n=100 ...` per cycle and a
-   final `RPMSG_SMOKE_PASS cycles=<c> msgs=100`. A failing cycle
-   instead prints `RPMSG_SMOKE_FAIL cycle=<i> reason=<...>` and the
-   script exits 1.
+5. Smoke: `sh rpmsg-smoke.sh -f rpmsg-echo-cr52.elf \
+   -s rpmsg-client-sample -n 100`
+6. A working run prints `RPMSG_PING_PASS n=100 ...` and
+   `RPMSG_SMOKE_PASS cycles=1 msgs=100`. A failing cycle instead prints
+   `RPMSG_SMOKE_FAIL cycle=<i> reason=<...>` and the script exits 1.
+
+**One session per boot.** The CR52 firmware creates and announces its
+RPMsg endpoint exactly once per reset. After the smoke's closing `stop`,
+a further `start` brings the Linux vdev back up but the channel is never
+re-announced, so a second cycle can only ever end in `service_timeout`.
+That is why `-c` defaults to 1; running the smoke again needs a hardware
+reset or power cycle, not a `stop`/`start`. A soft `reboot` of Linux does
+*not* reset the realtime core.
 
 ## Notes
 
-- `start` and `stop` do not touch the CR52. The SoC's remoteproc
-  driver implements `.load` and `.stop` as no-ops and `.start` only
-  validates the boot address; there is no reset, clock, or firmware
-  handoff in it, and `auto_boot` is false with no `.attach`. So the
-  reported `state` describes the Linux-side vdev, not the core: it
-  reads `offline` at boot on both OSes whether or not the CR52 is
-  executing something. Treat `state` as "has Linux published the
-  vrings", never as "is the remote alive".
+- `start` and `stop` do not touch the CR52. The SoC's remoteproc driver
+  implements `.load` and `.stop` as no-ops and `.start` only validates
+  the boot address; there is no reset, clock, or firmware handoff in it,
+  and `auto_boot` is false with no `.attach`. So the reported `state`
+  describes the Linux-side vdev, not the core: it reads `offline` at
+  boot on both OSes whether or not the CR52 is executing something.
+  Treat `state` as "has Linux published the vrings", never as "is the
+  remote alive". The realtime console is the only direct read on the
+  core's health.
 - `reason=service_timeout` after a successful `start` means no remote
-  announced the channel. See Status above for what that currently
-  indicates on this board and why it is not an escalation trigger on
-  its own.
+  announced the channel. Check the realtime console first: a silent one
+  means the flashed payload is not running or was built for a different
+  MFIS channel, and no amount of Linux-side work will fix it.
+- If a `start` logs `rcar_gen5_rproc_kick failed`, the MFIS doorbell
+  rung by an earlier `start` was never acknowledged — the kick helper
+  refuses to ring again while the remote is still flagged as processing
+  the previous interrupt, and only the remote clears that flag. That is
+  a positive indication that nothing is servicing the channel, which is
+  stronger than a timeout alone.
+- `rpmsg-ping` has two reply modes because two remote protocols exist.
+  The default *responder* mode fits the vendor firmware, which answers
+  every request with the same constant string; it requires a non-empty
+  reply per request and that every reply be byte-identical to the first,
+  so a corrupted or mis-sequenced vring still fails. `-e` selects strict
+  *echo* mode, where each reply must match the payload that was sent —
+  use it only against a firmware that really echoes, or every request
+  will fail as `payload_mismatch`.
 - The kernel ships an in-tree `rpmsg_client_sample` sample driver,
   staged as a module in both the BSP Yocto and AutoSD modules trees,
-  that binds a channel named exactly `rpmsg-client-sample` and runs
-  its own message exchange if loaded. Both trees carry the matching
+  that binds a channel named exactly `rpmsg-client-sample` and runs its
+  own message exchange if loaded. Both trees carry the matching
   `alias rpmsg:rpmsg-client-sample` in `modules.alias`, and the rpmsg
   bus announces a `MODALIAS` on every channel add, so under
-  systemd-udevd this module auto-loads on *every* smoke cycle, not
-  just once at boot — unloading it once does not stop it coming back
-  on the next cycle. Blacklist it before the first `start`
-  (procedure step 2); a rootfs file, no flash write. To check:
+  systemd-udevd this module auto-loads on *every* smoke cycle, not just
+  once at boot — unloading it once does not stop it coming back on the
+  next cycle. Blacklist it before the first `start` (procedure step 3);
+  a rootfs file, no flash write. To check:
   ```
   lsmod | grep rpmsg_client_sample
   ```
   If it wins the channel before it is blocked, the damage outlives an
-  `rmmod`: OpenAMP binds the endpoint's destination address to the
-  first remote sender and never re-binds, so the CR52 keeps echoing to
-  the sample driver's address and `rpmsg-ping` sees `rx_timeout` on
-  `seq=0` even after the module is gone. Because `stop`/`start` do not
-  touch the CR52 (see above), only a CR52-side restart clears this — a
-  Linux-side `stop`/`start` cycle will not.
-- Catching the U-Boot prompt on a warm `reboot` needs a tighter key
-  spam than a cold power-on does. The autoboot countdown is about
-  2.5 s ("Hit any key to stop autoboot: 2 1 0"); Enter every 300 ms
-  missed it outright, Enter every 80 ms caught it in 75 keystrokes.
-- Recovery from any wedge: power cycle. The default boot path is never
-  modified by this procedure.
+  `rmmod`: OpenAMP binds the endpoint's destination address to the first
+  remote sender and never re-binds, so the CR52 keeps replying to the
+  sample driver's address and `rpmsg-ping` sees `rx_timeout` on `seq=0`
+  even after the module is gone. Because `stop`/`start` do not touch the
+  CR52 (see above), only a CR52-side restart clears this.
+- Catching the U-Boot prompt on a warm `reboot` needs a tighter key spam
+  than a cold power-on does. The autoboot countdown is about 2.5 s ("Hit
+  any key to stop autoboot: 2 1 0"); Enter every 300 ms missed it
+  outright, Enter every 80 ms caught it in 75 keystrokes.
+- Recovery from any wedge: power cycle. This procedure modifies no boot
+  path and writes no flash; the only persistent state it creates is the
+  staged files and the blacklist on the target rootfs.

--- a/platforms/autosd/x5h/rpmsg-dualboot.md
+++ b/platforms/autosd/x5h/rpmsg-dualboot.md
@@ -1,0 +1,187 @@
+# X5H dual boot: CR52 FreeRTOS under AutoSD, with RPMsg
+
+Runs a FreeRTOS payload on the CR52 realtime core while AutoSD runs on
+the CA720AE cluster, using the kernel remoteproc/RPMsg stack. No flash
+is written by this procedure: `echo start` on the `cr52_1` remoteproc
+publishes the resource table into the CR52's reserved-memory carveout,
+allocates the vrings, and enables the MFIS doorbell for a CR52 that is
+already executing — it does not load an ELF onto the core or release
+it from reset. A power cycle always returns the board to its default
+boot.
+
+## Status on real hardware
+
+Validated on the board on 2026-08-06, on both the BSP Yocto reference
+boot (`6.1.102-yocto-standard`) and AutoSD (`6.1.102-autosd`).
+
+**The Linux side works and is identical on both OSes.** The `cr52_1`
+remoteproc enumerates, accepts a firmware name, goes `offline` →
+`running`, and brings up a working virtio RPMsg bus:
+
+| Check | Both OSes |
+|---|---|
+| `remoteproc0` name / state / default firmware | `cr52_1` / `offline` / `rproc-cr52_1-fw` |
+| Probe log | `rcar_mfis: channel 1 initialized`, `mfis-mbox: MFIS mailbox enabled with 2 chans`, `remoteproc0: cr52_1 is available` |
+| After `start` | `virtio_rpmsg_bus virtio0: rpmsg host is online`, `remote processor cr52_1 is now up` |
+| `virtio0` status | `0x07` (ACKNOWLEDGE \| DRIVER \| DRIVER_OK) |
+| rpmsg bus | `virtio0.rpmsg_ctrl.0.0`, `virtio0.rpmsg_ns.53.53`, `/dev/rpmsg_ctrl0` |
+| SELinux (AutoSD, permissive) | no AVC denials touching rpmsg / remoteproc / firmware |
+
+**The echo round trip does not work, because nothing is running on the
+CR52 to answer it.** Both OSes stop at:
+
+```
+RPMSG_SMOKE_FAIL cycle=1 reason=service_timeout service=rpmsg-client-sample
+```
+
+A second `start` in the same boot then logs:
+
+```
+rcar-gen5-rproc soc:cr52_1: rcar_gen5_rproc_kick failed
+```
+
+which is the decisive evidence. That message means the MFIS doorbell
+rung by the *first* `start` was never acknowledged: the kick helper
+refuses to ring again while the remote is still flagged as processing
+the previous interrupt, and the remote only clears that flag when it
+services the doorbell. So the CR52 is not servicing MFIS channel 1 at
+all — it is not merely missing an RPMsg service.
+
+Getting an RPMsg-capable payload onto the CR52 requires writing its
+boot-firmware flash slot, which the zero-flash-write rule this work is
+held to forbids. There is no software path around it: the SoC's
+remoteproc driver does not load or start the core (see Notes), and
+U-Boot on this board has no remoteproc support either — `help rproc`
+returns `Unknown command`, and the command list has no `rproc`, no
+`cpu`, and nothing else CR52-related. Loading the ELF from RAM at the
+U-Boot prompt is therefore not an option.
+
+**What this means for a failing run:** a `reason=service_timeout` on
+this board is the *expected* result today. It is neither a defect in
+this tooling nor an AutoSD regression — the AutoSD result is
+byte-for-byte the same as the vendor BSP reference. Do not open a
+vendor escalation on the strength of a `service_timeout` alone.
+
+## What the kernel already provides
+
+The 6.1.102-autosd image and `r8a78000-ironhide-uio-autosd.dtb` ship
+with `CONFIG_RCAR_GEN5_REMOTEPROC=y`, `CONFIG_RCAR_MFIS=y`,
+`CONFIG_RPMSG_VIRTIO=y` (`rpmsg_char`/`rpmsg_ctrl` as modules), the
+`cr52_1` remoteproc node on MFIS channel 1, and its reserved-memory
+carveout. Nothing needs rebuilding to use them.
+
+## Prerequisites
+
+- A CR52 firmware ELF staged as `/lib/firmware/rpmsg-echo-cr52.elf` on
+  the target rootfs, built for this board with MFIS channel 1 — the
+  channel must match the device tree. Only its `.resource_table`
+  segment is consumed: the remoteproc driver's `.load` is a no-op, so
+  the ELF's code and data segments are never copied to the core. The
+  ELF supplies the vring layout Linux publishes into the carveout; the
+  code that would answer on the other end has to already be running on
+  the CR52.
+- `rpmsg-ping` (static aarch64, built from `scripts/rpmsg-ping.c`;
+  takes `-s <service>`, `-n <count>`, and `-t <timeout_s>`) and
+  `scripts/rpmsg-smoke.sh` on the target. `rpmsg-smoke.sh` resolves
+  `rpmsg-ping` relative to its own directory first, falling back to
+  `PATH`, so `rpmsg-ping` must be executable and either sit next to
+  `rpmsg-smoke.sh` or be reachable on `PATH`.
+
+### Staging the assets
+
+Both rootfs images netboot over NFS, so the host can drop files
+straight into the export instead of copying them to a running board.
+`/tmp` is a tmpfs on *both* the BSP Yocto and the AutoSD rootfs, so
+anything written to `<export>/tmp` from the host is invisible on the
+target — use a path that is not a mount point. On AutoSD, `/var/tmp`
+is a plain directory on the NFS root and works:
+
+```
+install -m0755 rpmsg-ping rpmsg-smoke.sh <export>/var/tmp/rpmsg/
+install -m0644 rpmsg-echo-cr52.elf        <export>/var/tmp/rpmsg/
+```
+
+then, on the target (the exports are `no_root_squash`, so board-side
+root can write anywhere on them):
+
+```
+install -m0755 /var/tmp/rpmsg/rpmsg-ping /var/tmp/rpmsg/rpmsg-smoke.sh /usr/local/bin/
+install -m0644 /var/tmp/rpmsg/rpmsg-echo-cr52.elf /lib/firmware/
+```
+
+## Procedure
+
+1. Boot the target OS (BSP Yocto default boot, or AutoSD via
+   `run bootcmd_autosd` netboot).
+2. Block the in-tree sample driver from taking the channel — see Notes
+   for why this must happen *before* the first `start`:
+   ```
+   echo 'blacklist rpmsg_client_sample' > /etc/modprobe.d/x5h-rpmsg-diag.conf
+   ```
+3. Preflight (read-only): `sh rpmsg-smoke.sh --check`
+   — confirms the `cr52_1` remoteproc exists, reports its state, and
+   ends with the `RPMSG_SMOKE_CHECK_DONE` marker. Any problem found
+   before that point instead prints `RPMSG_SMOKE_FAIL cycle=0
+   reason=<...>` and exits 1; `--check` makes no state changes either
+   way.
+4. Single-cycle probe: `sh rpmsg-smoke.sh -f rpmsg-echo-cr52.elf \
+   -s rpmsg-client-sample -n 100 -c 1` — one load/start/ping/stop round
+   trip. Run `-c 1` first, always: on the board today this stops at
+   `reason=service_timeout` (see Status), and a multi-cycle run adds
+   nothing until that is resolved.
+5. Multi-cycle probe, only once step 4 passes: `sh rpmsg-smoke.sh \
+   -f rpmsg-echo-cr52.elf -s rpmsg-client-sample -n 100 -c 3` — probes
+   whether the CR52 survives repeated Linux-side vdev teardown, which
+   is a different question from step 4. Because `stop` is a no-op on
+   this SoC (see Notes), a cycle boundary only tears down the Linux
+   side: the CR52 keeps its ring indices and its already-bound
+   endpoint while Linux allocates fresh vrings with reset indices on
+   the next `start`. A failure at cycle 2 or later is therefore an
+   expected, non-blocking outcome of that mismatch, not a regression —
+   treat a passing step 4 as the meaningful result and don't escalate
+   on a later-cycle failure by itself.
+6. A working run prints `RPMSG_PING_PASS n=100 ...` per cycle and a
+   final `RPMSG_SMOKE_PASS cycles=<c> msgs=100`. A failing cycle
+   instead prints `RPMSG_SMOKE_FAIL cycle=<i> reason=<...>` and the
+   script exits 1.
+
+## Notes
+
+- `start` and `stop` do not touch the CR52. The SoC's remoteproc
+  driver implements `.load` and `.stop` as no-ops and `.start` only
+  validates the boot address; there is no reset, clock, or firmware
+  handoff in it, and `auto_boot` is false with no `.attach`. So the
+  reported `state` describes the Linux-side vdev, not the core: it
+  reads `offline` at boot on both OSes whether or not the CR52 is
+  executing something. Treat `state` as "has Linux published the
+  vrings", never as "is the remote alive".
+- `reason=service_timeout` after a successful `start` means no remote
+  announced the channel. See Status above for what that currently
+  indicates on this board and why it is not an escalation trigger on
+  its own.
+- The kernel ships an in-tree `rpmsg_client_sample` sample driver,
+  staged as a module in both the BSP Yocto and AutoSD modules trees,
+  that binds a channel named exactly `rpmsg-client-sample` and runs
+  its own message exchange if loaded. Both trees carry the matching
+  `alias rpmsg:rpmsg-client-sample` in `modules.alias`, and the rpmsg
+  bus announces a `MODALIAS` on every channel add, so under
+  systemd-udevd this module auto-loads on *every* smoke cycle, not
+  just once at boot — unloading it once does not stop it coming back
+  on the next cycle. Blacklist it before the first `start`
+  (procedure step 2); a rootfs file, no flash write. To check:
+  ```
+  lsmod | grep rpmsg_client_sample
+  ```
+  If it wins the channel before it is blocked, the damage outlives an
+  `rmmod`: OpenAMP binds the endpoint's destination address to the
+  first remote sender and never re-binds, so the CR52 keeps echoing to
+  the sample driver's address and `rpmsg-ping` sees `rx_timeout` on
+  `seq=0` even after the module is gone. Because `stop`/`start` do not
+  touch the CR52 (see above), only a CR52-side restart clears this — a
+  Linux-side `stop`/`start` cycle will not.
+- Catching the U-Boot prompt on a warm `reboot` needs a tighter key
+  spam than a cold power-on does. The autoboot countdown is about
+  2.5 s ("Hit any key to stop autoboot: 2 1 0"); Enter every 300 ms
+  missed it outright, Enter every 80 ms caught it in 75 keystrokes.
+- Recovery from any wedge: power cycle. The default boot path is never
+  modified by this procedure.

--- a/platforms/autosd/x5h/scripts/rpmsg-ping.c
+++ b/platforms/autosd/x5h/scripts/rpmsg-ping.c
@@ -1,13 +1,25 @@
 // SPDX-License-Identifier: Apache-2.0
 /*
- * rpmsg-ping: RPMsg echo round-trip tester over the rpmsg_char uAPI.
+ * rpmsg-ping: RPMsg round-trip tester over the rpmsg_char uAPI.
  *
  * Scans /sys/bus/rpmsg/devices for the device whose `name` matches -s,
  * reads its announced `dst` address, creates a char endpoint through
- * /dev/rpmsg_ctrl*, then write()s sequenced payloads and verifies each
- * echo's leading bytes match what was sent (a prefix compare, not a
- * full-length match). Static-linked so the same binary runs on both the
- * BSP Yocto rootfs and the AutoSD NFS rootfs.
+ * /dev/rpmsg_ctrl*, then write()s sequenced payloads and checks the reply
+ * to each one. Static-linked so the same binary runs on both the BSP Yocto
+ * rootfs and the AutoSD NFS rootfs.
+ *
+ * Two remote protocols exist, so the reply check has two modes:
+ *
+ *   responder (default) -- the remote answers every request with the same
+ *       constant string. This is what the vendor CR52 firmware does: it
+ *       logs "Incoming msg: <our payload>" on its own console and replies
+ *       "Hello world from CR52/Free-RTOS!". Verified per request: a reply
+ *       arrives, is non-empty, and is byte-identical to the first one, so
+ *       a corrupted or mis-sequenced vring still fails the run.
+ *
+ *   echo (-e) -- the remote returns the request verbatim; each reply's
+ *       leading bytes must match what was sent (a prefix compare, not a
+ *       full-length match).
  *
  * Exit 0 + "RPMSG_PING_PASS n=<count>" on success; exit 1 + a
  * "RPMSG_PING_FAIL reason=..." line on any failure.
@@ -111,22 +123,24 @@ static int open_ctrl(void)
 int main(int argc, char **argv)
 {
 	const char *service = NULL;
-	int count = 100, timeout_s = 5, opt, i;
+	int count = 100, timeout_s = 5, opt, i, echo_mode = 0;
 	uint32_t dst = 0;
 	uint64_t before, after;
-	char devpath[64], tx[128], rx[128];
+	char devpath[64], tx[128], rx[128], first_rx[128];
+	ssize_t first_len = -1;
 	int ctrl, ept = -1;
 	struct rpmsg_endpoint_info info;
 
-	while ((opt = getopt(argc, argv, "s:n:t:")) != -1) {
+	while ((opt = getopt(argc, argv, "s:n:t:e")) != -1) {
 		switch (opt) {
 		case 's': service = optarg; break;
 		case 'n': count = atoi(optarg); break;
 		case 't': timeout_s = atoi(optarg); break;
+		case 'e': echo_mode = 1; break;
 		default:
 			printf("RPMSG_PING_FAIL reason=bad_args\n");
 			fprintf(stderr,
-				"usage: %s -s <service> [-n count] [-t timeout_s]\n",
+				"usage: %s -s <service> [-n count] [-t timeout_s] [-e]\n",
 				argv[0]);
 			return 1;
 		}
@@ -195,8 +209,24 @@ int main(int argc, char **argv)
 			       i, errno);
 			goto fail;
 		}
-		if (r < n + 1 || memcmp(tx, rx, (size_t)n + 1)) {
-			printf("RPMSG_PING_FAIL reason=payload_mismatch seq=%d len=%zd rx='%.*s'\n",
+		if (r == 0) {
+			printf("RPMSG_PING_FAIL reason=empty_reply seq=%d\n", i);
+			goto fail;
+		}
+		if (echo_mode) {
+			if (r < n + 1 || memcmp(tx, rx, (size_t)n + 1)) {
+				printf("RPMSG_PING_FAIL reason=payload_mismatch seq=%d len=%zd rx='%.*s'\n",
+				       i, r, (int)r, rx);
+				goto fail;
+			}
+		} else if (first_len < 0) {
+			first_len = r;
+			memcpy(first_rx, rx, (size_t)r);
+		} else if (r != first_len || memcmp(rx, first_rx, (size_t)r)) {
+			/* A responder firmware answers every request with the same
+			 * constant. Drift means a corrupted or mis-sequenced vring,
+			 * which a mere "something came back" check would not catch. */
+			printf("RPMSG_PING_FAIL reason=reply_drift seq=%d len=%zd rx='%.*s'\n",
 			       i, r, (int)r, rx);
 			goto fail;
 		}
@@ -204,7 +234,13 @@ int main(int argc, char **argv)
 	ioctl(ept, RPMSG_DESTROY_EPT_IOCTL);
 	close(ept);
 	close(ctrl);
-	printf("RPMSG_PING_PASS n=%d service=%s dst=0x%x\n", count, service, dst);
+	if (echo_mode)
+		printf("RPMSG_PING_PASS n=%d service=%s dst=0x%x mode=echo\n",
+		       count, service, dst);
+	else
+		printf("RPMSG_PING_PASS n=%d service=%s dst=0x%x mode=responder reply='%.*s'\n",
+		       count, service, dst,
+		       (int)strnlen(first_rx, (size_t)first_len), first_rx);
 	return 0;
 fail:
 	if (ept >= 0) {

--- a/platforms/autosd/x5h/scripts/rpmsg-ping.c
+++ b/platforms/autosd/x5h/scripts/rpmsg-ping.c
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * rpmsg-ping: RPMsg echo round-trip tester over the rpmsg_char uAPI.
+ *
+ * Scans /sys/bus/rpmsg/devices for the device whose `name` matches -s,
+ * reads its announced `dst` address, creates a char endpoint through
+ * /dev/rpmsg_ctrl*, then write()s sequenced payloads and verifies each
+ * echo's leading bytes match what was sent (a prefix compare, not a
+ * full-length match). Static-linked so the same binary runs on both the
+ * BSP Yocto rootfs and the AutoSD NFS rootfs.
+ *
+ * Exit 0 + "RPMSG_PING_PASS n=<count>" on success; exit 1 + a
+ * "RPMSG_PING_FAIL reason=..." line on any failure.
+ */
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+struct rpmsg_endpoint_info {
+	char name[32];
+	uint32_t src;
+	uint32_t dst;
+};
+#define RPMSG_CREATE_EPT_IOCTL  _IOW(0xb5, 0x1, struct rpmsg_endpoint_info)
+#define RPMSG_DESTROY_EPT_IOCTL _IO(0xb5, 0x2)
+#define RPMSG_ADDR_ANY 0xFFFFFFFF
+
+static int read_sysfs(const char *path, char *buf, size_t len)
+{
+	FILE *f = fopen(path, "r");
+	if (!f)
+		return -1;
+	if (!fgets(buf, (int)len, f)) {
+		fclose(f);
+		return -1;
+	}
+	fclose(f);
+	buf[strcspn(buf, "\n")] = '\0';
+	return 0;
+}
+
+/* Find the rpmsg device announcing `service`; return its dst address. */
+static int find_service(const char *service, uint32_t *dst)
+{
+	DIR *d = opendir("/sys/bus/rpmsg/devices");
+	struct dirent *e;
+	char path[512], val[64];
+
+	if (!d)
+		return -1;
+	while ((e = readdir(d))) {
+		if (e->d_name[0] == '.')
+			continue;
+		snprintf(path, sizeof(path),
+			 "/sys/bus/rpmsg/devices/%s/name", e->d_name);
+		if (read_sysfs(path, val, sizeof(val)))
+			continue;
+		if (strcmp(val, service))
+			continue;
+		snprintf(path, sizeof(path),
+			 "/sys/bus/rpmsg/devices/%s/dst", e->d_name);
+		if (read_sysfs(path, val, sizeof(val)))
+			continue;
+		*dst = (uint32_t)strtoul(val, NULL, 0);
+		closedir(d);
+		return 0;
+	}
+	closedir(d);
+	return -1;
+}
+
+/* Bitmap of /dev/rpmsgN minors that exist right now (N < 64). */
+static uint64_t eptdev_snapshot(void)
+{
+	uint64_t set = 0;
+	DIR *d = opendir("/sys/class/rpmsg");
+	struct dirent *e;
+
+	if (!d)
+		return 0;
+	while ((e = readdir(d))) {
+		unsigned n;
+		if (sscanf(e->d_name, "rpmsg%u", &n) == 1 && n < 64)
+			set |= 1ULL << n;
+	}
+	closedir(d);
+	return set;
+}
+
+static int open_ctrl(void)
+{
+	char path[64];
+	int i, fd;
+
+	for (i = 0; i < 8; i++) {
+		snprintf(path, sizeof(path), "/dev/rpmsg_ctrl%d", i);
+		fd = open(path, O_RDWR);
+		if (fd >= 0)
+			return fd;
+	}
+	return -1;
+}
+
+int main(int argc, char **argv)
+{
+	const char *service = NULL;
+	int count = 100, timeout_s = 5, opt, i;
+	uint32_t dst = 0;
+	uint64_t before, after;
+	char devpath[64], tx[128], rx[128];
+	int ctrl, ept = -1;
+	struct rpmsg_endpoint_info info;
+
+	while ((opt = getopt(argc, argv, "s:n:t:")) != -1) {
+		switch (opt) {
+		case 's': service = optarg; break;
+		case 'n': count = atoi(optarg); break;
+		case 't': timeout_s = atoi(optarg); break;
+		default:
+			printf("RPMSG_PING_FAIL reason=bad_args\n");
+			fprintf(stderr,
+				"usage: %s -s <service> [-n count] [-t timeout_s]\n",
+				argv[0]);
+			return 1;
+		}
+	}
+	if (!service || count < 1 || timeout_s < 1 || timeout_s > 2147483) {
+		printf("RPMSG_PING_FAIL reason=bad_args\n");
+		return 1;
+	}
+	if (find_service(service, &dst)) {
+		printf("RPMSG_PING_FAIL reason=service_not_found service=%s\n",
+		       service);
+		return 1;
+	}
+	ctrl = open_ctrl();
+	if (ctrl < 0) {
+		printf("RPMSG_PING_FAIL reason=no_rpmsg_ctrl\n");
+		fprintf(stderr, "hint: modprobe rpmsg_ctrl rpmsg_char?\n");
+		return 1;
+	}
+	memset(&info, 0, sizeof(info));
+	snprintf(info.name, sizeof(info.name), "%s", service);
+	info.src = RPMSG_ADDR_ANY;
+	info.dst = dst;
+	before = eptdev_snapshot();
+	if (ioctl(ctrl, RPMSG_CREATE_EPT_IOCTL, &info)) {
+		printf("RPMSG_PING_FAIL reason=create_ept errno=%d\n", errno);
+		return 1;
+	}
+	after = eptdev_snapshot() & ~before;
+	if (!after) {
+		printf("RPMSG_PING_FAIL reason=no_new_eptdev\n");
+		return 1;
+	}
+	for (i = 0; i < 64; i++)
+		if (after & (1ULL << i))
+			break;
+	snprintf(devpath, sizeof(devpath), "/dev/rpmsg%d", i);
+	ept = open(devpath, O_RDWR);
+	if (ept < 0) {
+		printf("RPMSG_PING_FAIL reason=open_eptdev dev=%s errno=%d\n",
+		       devpath, errno);
+		return 1;
+	}
+	for (i = 0; i < count; i++) {
+		struct pollfd pfd = { .fd = ept, .events = POLLIN };
+		int n = snprintf(tx, sizeof(tx), "x5h-rpmsg-ping seq=%d", i);
+
+		if (write(ept, tx, (size_t)n + 1) != n + 1) {
+			printf("RPMSG_PING_FAIL reason=write seq=%d errno=%d\n",
+			       i, errno);
+			goto fail;
+		}
+		if (poll(&pfd, 1, timeout_s * 1000) != 1) {
+			printf("RPMSG_PING_FAIL reason=rx_timeout seq=%d\n", i);
+			goto fail;
+		}
+		if (pfd.revents & (POLLERR | POLLHUP)) {
+			printf("RPMSG_PING_FAIL reason=channel_closed seq=%d revents=0x%x\n",
+			       i, (unsigned int)pfd.revents);
+			goto fail;
+		}
+		memset(rx, 0, sizeof(rx));
+		ssize_t r = read(ept, rx, sizeof(rx));
+		if (r < 0) {
+			printf("RPMSG_PING_FAIL reason=read seq=%d errno=%d\n",
+			       i, errno);
+			goto fail;
+		}
+		if (r < n + 1 || memcmp(tx, rx, (size_t)n + 1)) {
+			printf("RPMSG_PING_FAIL reason=payload_mismatch seq=%d len=%zd rx='%.*s'\n",
+			       i, r, (int)r, rx);
+			goto fail;
+		}
+	}
+	ioctl(ept, RPMSG_DESTROY_EPT_IOCTL);
+	close(ept);
+	close(ctrl);
+	printf("RPMSG_PING_PASS n=%d service=%s dst=0x%x\n", count, service, dst);
+	return 0;
+fail:
+	if (ept >= 0) {
+		ioctl(ept, RPMSG_DESTROY_EPT_IOCTL);
+		close(ept);
+	}
+	close(ctrl);
+	return 1;
+}

--- a/platforms/autosd/x5h/scripts/rpmsg-smoke.sh
+++ b/platforms/autosd/x5h/scripts/rpmsg-smoke.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 # RPMsg dual-boot smoke for the X5H CR52 (runs unchanged on BSP Yocto and
-# AutoSD): load firmware via remoteproc, verify the RPMsg service comes up,
-# run payload-verified echo round-trips, stop, repeat.
+# AutoSD): bring up the RPMsg vdev via remoteproc, verify the service comes
+# up, run verified round-trips, stop.
+#
+# The CR52 firmware is NOT loaded by this script, and not by Linux at all:
+# rcar_gen5_rproc's .load and .stop are both no-ops, so the realtime core runs
+# whatever was flashed into its slot and is already live before Linux boots.
+# `start` only parses the resource table out of the ELF, publishes the vrings
+# and rings the MFIS doorbell. The ELF in /lib/firmware must therefore still
+# match the flashed image, or the vring layout will not agree.
 #
 # Markers on stdout (grep-able, one per line):
 #   RPMSG_SMOKE_PASS cycles=<c> msgs=<n>
@@ -14,7 +21,12 @@ set -u
 FW=rpmsg-echo-cr52.elf
 SERVICE=rpmsg-client-sample
 MSGS=100
-CYCLES=3
+# One session per boot: the CR52 firmware creates and announces its endpoint
+# exactly once, so after a stop/start the channel never reappears and cycle 2
+# would fail on service_timeout no matter how long it waited. Board-confirmed
+# 2026-08-06. More cycles need a hardware reset between them, so -c >1 is
+# opt-in and only meaningful for a firmware that re-announces.
+CYCLES=1
 CHECK=0
 
 while [ $# -gt 0 ]; do

--- a/platforms/autosd/x5h/scripts/rpmsg-smoke.sh
+++ b/platforms/autosd/x5h/scripts/rpmsg-smoke.sh
@@ -1,0 +1,176 @@
+#!/bin/sh
+# RPMsg dual-boot smoke for the X5H CR52 (runs unchanged on BSP Yocto and
+# AutoSD): load firmware via remoteproc, verify the RPMsg service comes up,
+# run payload-verified echo round-trips, stop, repeat.
+#
+# Markers on stdout (grep-able, one per line):
+#   RPMSG_SMOKE_PASS cycles=<c> msgs=<n>
+#   RPMSG_SMOKE_FAIL cycle=<i> reason=<...>
+#
+# --check runs the read-only preflight only (no state changes) so it is safe
+# on a board whose CR52 state is still unknown.
+set -u
+
+FW=rpmsg-echo-cr52.elf
+SERVICE=rpmsg-client-sample
+MSGS=100
+CYCLES=3
+CHECK=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -f|-s|-n|-c)
+            [ $# -ge 2 ] || {
+                echo "RPMSG_SMOKE_FAIL cycle=0 reason=bad_args"
+                exit 1
+            }
+            ;;
+    esac
+    case "$1" in
+        -f) FW=$2; shift 2 ;;
+        -s) SERVICE=$2; shift 2 ;;
+        -n) MSGS=$2; shift 2 ;;
+        -c) CYCLES=$2; shift 2 ;;
+        --check) CHECK=1; shift ;;
+        *)
+            echo "RPMSG_SMOKE_FAIL cycle=0 reason=bad_args"
+            echo "usage: $0 [-f fw] [-s service] [-n msgs] [-c cycles] [--check]"
+            exit 2
+            ;;
+    esac
+done
+
+# Reject non-numeric/zero -c or -n now: an unvalidated CYCLES/MSGS falls
+# straight through the cycle loop below and prints RPMSG_SMOKE_PASS without
+# running anything. This is a pure argument-validation failure, so it is
+# checked before the hardware probe below and fires the same way regardless
+# of board state.
+case "$CYCLES" in
+    ''|*[!0-9]*) echo "RPMSG_SMOKE_FAIL cycle=0 reason=bad_cycles"; exit 1 ;;
+esac
+[ "$CYCLES" -ge 1 ] || { echo "RPMSG_SMOKE_FAIL cycle=0 reason=bad_cycles"; exit 1; }
+case "$MSGS" in
+    ''|*[!0-9]*) echo "RPMSG_SMOKE_FAIL cycle=0 reason=bad_msgs"; exit 1 ;;
+esac
+[ "$MSGS" -ge 1 ] || { echo "RPMSG_SMOKE_FAIL cycle=0 reason=bad_msgs"; exit 1; }
+
+# rpmsg-ping next to this script wins; else rely on PATH.
+HERE=$(dirname "$0")
+PING="$HERE/rpmsg-ping"
+[ -x "$PING" ] || PING=rpmsg-ping
+
+# --- locate the CR52 remoteproc ---------------------------------------------
+RPROC=""
+for d in /sys/class/remoteproc/remoteproc*; do
+    [ -e "$d/name" ] || continue
+    case "$(cat "$d/name")" in
+        cr52*) RPROC=$d; break ;;
+    esac
+done
+if [ -z "$RPROC" ]; then
+    echo "RPMSG_SMOKE_FAIL cycle=0 reason=no_cr52_remoteproc"
+    exit 1
+fi
+echo "INFO rproc=$RPROC name=$(cat "$RPROC/name") state=$(cat "$RPROC/state")"
+
+if [ "$CHECK" = 1 ]; then
+    echo "INFO firmware=$(cat "$RPROC/firmware")"
+    echo "INFO rpmsg devices:"
+    if [ -n "$(ls -A /sys/bus/rpmsg/devices/ 2>/dev/null)" ]; then
+        ls /sys/bus/rpmsg/devices/
+    else
+        echo "  (none)"
+    fi
+    echo "INFO modules: $(lsmod 2>/dev/null | grep -cE 'rpmsg_(char|ctrl)') rpmsg char/ctrl loaded"
+    if [ -e "/lib/firmware/$FW" ]; then
+        echo "INFO fw_staged=yes fw=/lib/firmware/$FW"
+    else
+        echo "INFO fw_staged=no fw=/lib/firmware/$FW"
+    fi
+    if command -v "$PING" >/dev/null 2>&1; then
+        echo "INFO ping=$PING"
+    else
+        echo "INFO ping=missing (expected next to this script or on PATH)"
+    fi
+    if lsmod 2>/dev/null | grep -q '^rpmsg_client_sample'; then
+        echo "INFO rpmsg_client_sample=loaded (will contend for the channel; see Notes)"
+    else
+        echo "INFO rpmsg_client_sample=not_loaded"
+    fi
+    echo "RPMSG_SMOKE_CHECK_DONE"
+    exit 0
+fi
+
+[ -e "/lib/firmware/$FW" ] || {
+    echo "RPMSG_SMOKE_FAIL cycle=0 reason=firmware_missing fw=/lib/firmware/$FW"
+    exit 1
+}
+modprobe rpmsg_char 2>/dev/null || true
+modprobe rpmsg_ctrl 2>/dev/null || true
+
+wait_state() {  # $1=want  $2=timeout_s
+    t=0
+    while [ "$t" -lt "$2" ]; do
+        [ "$(cat "$RPROC/state")" = "$1" ] && return 0
+        sleep 1; t=$((t + 1))
+    done
+    return 1
+}
+
+wait_service() {  # $1=timeout_s
+    t=0
+    while [ "$t" -lt "$1" ]; do
+        for dev in /sys/bus/rpmsg/devices/*; do
+            [ -e "$dev/name" ] || continue
+            [ "$(cat "$dev/name")" = "$SERVICE" ] && return 0
+        done
+        sleep 1; t=$((t + 1))
+    done
+    return 1
+}
+
+i=1
+while [ "$i" -le "$CYCLES" ]; do
+    if [ "$(cat "$RPROC/state")" != "offline" ]; then
+        echo stop > "$RPROC/state"
+        wait_state offline 10 || {
+            echo "RPMSG_SMOKE_FAIL cycle=$i reason=cannot_reach_offline state=$(cat "$RPROC/state")"
+            exit 1
+        }
+    fi
+    echo "$FW" > "$RPROC/firmware" || {
+        echo "RPMSG_SMOKE_FAIL cycle=$i reason=firmware_write_error"
+        exit 1
+    }
+    [ "$(cat "$RPROC/firmware")" = "$FW" ] || {
+        echo "RPMSG_SMOKE_FAIL cycle=$i reason=firmware_readback_mismatch"
+        exit 1
+    }
+    echo start > "$RPROC/state" || {
+        echo "RPMSG_SMOKE_FAIL cycle=$i reason=start_write_error"
+        exit 1
+    }
+    wait_state running 10 || {
+        echo "RPMSG_SMOKE_FAIL cycle=$i reason=not_running state=$(cat "$RPROC/state")"
+        echo stop > "$RPROC/state"
+        exit 1
+    }
+    wait_service 15 || {
+        echo "RPMSG_SMOKE_FAIL cycle=$i reason=service_timeout service=$SERVICE"
+        echo stop > "$RPROC/state"
+        exit 1
+    }
+    "$PING" -s "$SERVICE" -n "$MSGS" || {
+        echo "RPMSG_SMOKE_FAIL cycle=$i reason=ping"
+        echo stop > "$RPROC/state"
+        exit 1
+    }
+    echo stop > "$RPROC/state"
+    wait_state offline 10 || {
+        echo "RPMSG_SMOKE_FAIL cycle=$i reason=stop_timeout"
+        exit 1
+    }
+    echo "INFO cycle $i/$CYCLES OK"
+    i=$((i + 1))
+done
+echo "RPMSG_SMOKE_PASS cycles=$CYCLES msgs=$MSGS"


### PR DESCRIPTION
Part of #120 (milestone 3). Third of three stacked PRs; based on `feat/autosd-x5h-kernel-upstream`.

Brings the CR52 realtime cluster up under AutoSD on the rebuilt kernel, with a documented procedure (`rpmsg-dualboot.md`), a round-trip tester (`scripts/rpmsg-ping.c`) and a smoke script (`scripts/rpmsg-smoke.sh`).

This is the foundation the single-ECU work in #120 needs: the transport that replaces the CES 2026 demo's Ethernet cable between the two boxes.

**Updated 2026-08-07: the RPMsg round trip now passes on real hardware, on both operating systems.** An earlier revision of this PR documented it as blocked and deferred the unblocking step to milestone 4 of #120. That step has since been taken with operator authorisation, and the last three commits correct the tooling and the document accordingly. What follows is the current state.

## What works

**The full round trip, with zero behavioural delta against the vendor BSP Yocto reference.** On both `6.1.102-yocto-standard` and `6.1.102-autosd`, the marker lines are byte-identical:

```
virtio_rpmsg_bus virtio0: creating channel rpmsg-client-sample addr 0x400
RPMSG_PING_PASS n=100 service=rpmsg-client-sample dst=0x400 mode=responder reply='Hello world from CR52/Free-RTOS!'
RPMSG_SMOKE_PASS cycles=1 msgs=100
```

Confirmed from both ends independently: the Linux side received 100 replies, all byte-identical, and the CR52's own console logged `Incoming msg: x5h-rpmsg-ping seq=0` … `seq=99` — the exact sequenced payloads the tester sent, in order. Zero SELinux AVC denials and zero rpmsg/remoteproc errors on AutoSD. The binary that ran on the board rebuilds byte-identically from the source in this PR.

## What the earlier `service_timeout` actually was

Not an AutoSD problem, and not a defect in this tooling: **nothing was executing on the realtime core.**

`rcar_gen5_rproc` implements `.load` and `.stop` as `return 0` and `.start` only validates `bootaddr`, so Linux never transfers a payload to the CR52 and never releases it from reset. `echo start` parses the resource table out of the staged ELF, publishes the vrings into the CR52 carveout and rings the MFIS doorbell — for a core that must already be running. Runtime loading through `remoteproc` is not merely unsupported on this SoC, it is not implemented, and the vendor documentation classifies it as non-compliant. The realtime payload has to be flashed into its boot slot, where the boot firmware starts it before Linux comes up; the vendor's own boot-certificate source confirms that slot is a FreeRTOS slot by design.

With a vendor-supplied firmware built for **MFIS channel 1** flashed there, the channel came up and the exchange worked on the first attempt on both operating systems.

## Findings now encoded in the tooling

- **The firmware is a responder, not an echo server.** It answers every request with the same constant string. `rpmsg-ping` had asserted echo semantics, so the very first round trip failed as `payload_mismatch` even though the exchange had worked in both directions. The default is now a responder mode, with `-e` retained for a genuinely echoing remote. Responder mode does not weaken the assertion to "something came back": it requires a non-empty reply per request and that every reply be byte-identical to the first, so a corrupted or mis-sequenced vring still fails the run.
- **One session per boot.** The CR52 creates and announces its endpoint exactly once per reset; after the closing `stop`, a further `start` brings the Linux vdev back up but the channel is never re-announced. The previous default of 3 cycles could therefore never pass, and `-c` now defaults to 1. Confirmed by stopping and restarting on the board: no channel reappeared. A soft `reboot` of Linux does not reset the realtime core either.
- **The device tree silently decides which core is reachable, and how.** `cr52_1` is the only enabled `remoteproc` node; `renesas,mfis-channels` is a *list of channel indices*, not a count, so `<1>` registers channel 1 alone; and the userspace-UIO alternative is wired to the opposite channel. A firmware flashed for the wrong channel is never serviced however healthy the Linux side looks — worth stating explicitly, because every Linux-side symptom is identical either way.

## Corollaries worth keeping

- **`remoteproc` `state` describes the Linux-side vdev, never the core.** It reads `offline` at boot regardless of what the CR52 is doing. It is not a liveness signal; the realtime console is the only direct read on the core's health.
- **A `service_timeout` is a realtime-side symptom, not a Linux-side bug.** Check the realtime console first: a silent one means no payload is running or it was built for a different MFIS channel. If a `start` logs `rcar_gen5_rproc_kick failed`, that is positive evidence that nothing is servicing the channel — the doorbell from an earlier `start` was never acknowledged, and only the remote clears that flag.
- `/tmp` is a tmpfs on *both* rootfs images, not just AutoSD, so anything staged into `<export>/tmp` from the host is invisible on the target.

## Scope

Nothing in this PR performs or requires a flash write; it is host- and target-side tooling plus documentation. The flash step is an operator-authorised action described only at capability level, and no vendor file names, package names, SDK paths or flash offsets appear in the repository content.

CI evidence: youtalk/openadkit#14.
