### PR TITLE
feat(x5h): add UFS self-boot and remote development enablement

### DIFF
--- a/platforms/autosd/x5h/README.md
+++ b/platforms/autosd/x5h/README.md
@@ -24,19 +24,33 @@ answered before board time.
 - [CR52 dual boot + RPMsg](rpmsg-dualboot.md) — run FreeRTOS on the
   realtime core under AutoSD; remoteproc `start` publishes RPMsg state to
   a CR52 that is already executing, it does not load or release it.
+- [UFS self-boot](selfboot.md) — boot AutoSD unattended from the board's
+  own storage, with both netboots kept as named rescue commands; also the
+  reset semantics, including why a warm `reboot` restarts the CR52.
+- [CR52 slot update](cr52-slot-update.md) — replace the realtime firmware
+  by writing its boot slot from Linux, instead of the vendor serial-download
+  tool and a trip to the board.
+- [Companion host](companion-host.md) — always-on bench gateway that keeps
+  the board reachable remotely and scopes external developers' access.
+  Executed and verified on hardware, 2026-08-10.
 
 ## Folder Structure
 
 - `aib/`: automotive-image-builder manifest (distro `autosd10-sig`)
-- `config/`: containers.conf drop-ins shipped into the image (base) or staged
-  alongside the rebuilt kernel (`60-nftables.conf`)
+- `config/`: files shipped into the image — containers.conf drop-ins (base)
+  or staged alongside the rebuilt kernel (`60-nftables.conf`), plus the
+  self-boot set: key-only sshd drop-in, `authorized_keys`, the
+  NetworkManager drop-in keeping `tsn5` kernel-managed, static resolvers,
+  the rpmsg sample-driver blacklist and the sshd enable preset
 - `kernel/`: rebuilt-kernel config fragments + build script, shared by the
   QEMU gate and the board — one build, two images: both boot an
   `Image-autosd` from the same source SHA, toolchain and fragments, and the
   only permitted config delta is the `CONFIG_EXTRA_FIRMWARE` pair (see "One
   build, two images")
 - `scripts/`: QEMU gate harness and board staging/smoke scripts
-- `uboot/`: `bootcmd_autosd` template (site values are filled at session time, not committed)
+- `uboot/`: `bootcmd_autosd` template (site values are filled at session
+  time, not committed), and `selfboot-env.txt` — the `env import -t` payload
+  defining the UFS self-boot plus both netboot rescue commands
 
 ## QEMU gate semantics
 

--- a/platforms/autosd/x5h/aib/x5h-rootfs.aib.yml
+++ b/platforms/autosd/x5h/aib/x5h-rootfs.aib.yml
@@ -8,11 +8,18 @@ content:
   rpms:
     - podman
     - btrfs-progs
+    - e2fsprogs
     - gdisk
     - curl
     - iproute
     - procps-ng
     - iptables-nft
+    # The base AutoSD image ships no SSH server at all (only crypto-policies
+    # fragments mention openssh), so without this the sshd drop-in, the baked
+    # authorized_keys and the "enable sshd.service" preset below all describe
+    # a service that cannot exist. Board-verified 2026-08-07: no /usr/sbin/sshd
+    # and no sshd.service unit in the built rootfs.
+    - openssh-server
   # add_files (org.osbuild.copy) does not create parent directories, and
   # nothing else in the pipeline creates /etc/containers/containers.conf.d
   # (init_rootfs_dirs_stage creates /etc itself, but not this subtree).
@@ -29,10 +36,41 @@ content:
     - path: /etc/containers/containers.conf.d
       parents: true
       exist_ok: true
+    - path: /etc/ssh/authorized_keys.d
+      parents: true
+      exist_ok: true
+    - path: /etc/ssh/sshd_config.d
+      parents: true
+      exist_ok: true
+    - path: /etc/NetworkManager/conf.d
+      parents: true
+      exist_ok: true
+    - path: /etc/systemd/system-preset
+      parents: true
+      exist_ok: true
+    - path: /etc/modprobe.d
+      parents: true
+      exist_ok: true
   add_files:
     # add_files only permits /etc and /usr destinations (rehearsal finding).
     - source_path: ../config/50-x5h.conf
       path: /etc/containers/containers.conf.d/50-x5h.conf
+    # Self-boot / shared-tailnet hardening (see selfboot.md): key-only SSH
+    # so the dev root password stays a serial-console-only credential.
+    - source_path: ../config/50-x5h-sshd.conf
+      path: /etc/ssh/sshd_config.d/50-x5h.conf
+    - source_path: ../config/x5h-authorized-keys
+      path: /etc/ssh/authorized_keys.d/root
+    - source_path: ../config/50-x5h-tsn5-unmanaged.conf
+      path: /etc/NetworkManager/conf.d/50-x5h-tsn5-unmanaged.conf
+    # May collide with a resolv.conf symlink in the base image; if the copy
+    # stage fails CI, drop this entry and stage the file post-dd instead.
+    - source_path: ../config/x5h-resolv.conf
+      path: /etc/resolv.conf
+    - source_path: ../config/x5h-rpmsg-diag.conf
+      path: /etc/modprobe.d/x5h-rpmsg-diag.conf
+    - source_path: ../config/80-x5h.preset
+      path: /etc/systemd/system-preset/80-x5h.preset
 
 auth:
   # root password "autosd" — dev/bench image only, never a board deliverable.

--- a/platforms/autosd/x5h/companion-host.md
+++ b/platforms/autosd/x5h/companion-host.md
@@ -555,9 +555,10 @@ leaves the board unreachable, with nothing to correct at either end.
    permits it. Discovering this after the invite is issued costs a round
    trip and presents as a fault at this end.
 2. Invite them from the admin console — Users, then *Invite external users*
-   — by e-mail or by link. Invites are one-time and expire after 30 days,
-   and each user who accepts takes a seat on the tailnet's plan (six on the
-   current free Personal plan, administrator included).
+   — by e-mail or by link. Invites are one-time and expire after 30 days.
+   Each user who accepts counts against the tailnet's plan: a hard cap on
+   the free tier, and a per-user charge on the paid ones, where there is no
+   user limit to plan around.
 3. Once they have accepted, read their identity off the Users page and add
    that string to `group:x5h-ext` exactly as shown. They authenticate with
    whichever provider they choose — any supported IdP, or a passkey — so

--- a/platforms/autosd/x5h/companion-host.md
+++ b/platforms/autosd/x5h/companion-host.md
@@ -554,23 +554,28 @@ leaves the board unreachable, with nothing to correct at either end.
    whose company runs Tailscale cannot accept until their IT administrator
    permits it. Discovering this after the invite is issued costs a round
    trip and presents as a fault at this end.
-2. Invite them from the admin console — Users, then *Invite external users*
+2. Ask them, in the same message, for the delivery address for the invite
+   and for the SSH **public** key step 5 installs — the single
+   `ssh-ed25519 …` line from their `.pub` file, never the private key. Both
+   are yours to request rather than theirs to know: nothing reaches you by
+   itself, and an unrequested key eventually arrives in the wrong half.
+3. Invite them from the admin console — Users, then *Invite external users*
    — by e-mail or by link. Invites are one-time and expire after 30 days.
    Each user who accepts counts against the tailnet's plan: a hard cap on
    the free tier, and a per-user charge on the paid ones, where there is no
    user limit to plan around.
-3. Once they have accepted, read their identity off the Users page and add
+4. Once they have accepted, read their identity off the Users page and add
    that string to `group:x5h-ext` exactly as shown. They authenticate with
    whichever provider they choose — any supported IdP, or a passkey — so
    what belongs in the group is **not knowable before they accept**, and is
    usually an e-mail address rather than a login of this tailnet's own
    provider.
-4. Append their public key to `/etc/ssh/authorized_keys.d/root` on the
+5. Append their public key to `/etc/ssh/authorized_keys.d/root` on the
    board — or to `config/x5h-authorized-keys` if it should survive an
    image rebuild.
-5. Verify with the checks below, from their node.
+6. Verify with the checks below, from their node.
 
-Steps 3 and 4 are independent, and each is silent when omitted: without the
+Steps 4 and 5 are independent, and each is silent when omitted: without the
 grant their SSH hangs, without the key it is refused. Doing one and calling
 it done is the usual result of splitting them across a day.
 

--- a/platforms/autosd/x5h/companion-host.md
+++ b/platforms/autosd/x5h/companion-host.md
@@ -479,12 +479,15 @@ along the way. Match the syntax already in the file: newer tailnets use
 ```jsonc
 {
   "groups": {
-    // Identities are whatever the tailnet's identity provider issues. A
+    // An identity is however its issuer spells it. Users who sign in through
+    // the tailnet's own provider are named as that provider names them: a
     // GitHub-backed tailnet uses GitHub logins, not e-mail addresses, and an
     // address that does not exist here yields an empty group and an admin
-    // rule that grants nothing.
+    // rule that grants nothing. Invited external users are the exception --
+    // they pick their own provider, so their identity is usually an e-mail
+    // address and need not have the same shape as the admin's.
     "group:x5h-admin": ["<admin-login>"],
-    "group:x5h-ext":   [],   // external developer logins land here
+    "group:x5h-ext":   [],   // invited external identities land here
     // Optional middle tier: internal developers who need the board and the
     // gateway's serial consoles, but not the rest of the tailnet. Omit the
     // group and its grant below if two tiers are enough.
@@ -539,11 +542,36 @@ interactively — a scheduled outage for an unattended gateway. Check it with
 
 ### Onboarding an external developer
 
-1. Add their login to `group:x5h-ext`.
-2. Append their public key to `/etc/ssh/authorized_keys.d/root` on the
+External developers join as **users of this tailnet**, by invitation. Do not
+share the gateway node with them instead: **a shared node does not carry its
+subnet routes.** The control plane rewrites the ACLs of an externally shared
+subnet router so the recipient reaches that node and nothing behind it, and
+the board is on the far side of the advertised `192.168.0.0/24` — so a share
+leaves the board unreachable, with nothing to correct at either end.
+
+1. Settle it with their employer first. A tailnet by default lets only its
+   own Admins accept an invitation to an *external* tailnet, so a developer
+   whose company runs Tailscale cannot accept until their IT administrator
+   permits it. Discovering this after the invite is issued costs a round
+   trip and presents as a fault at this end.
+2. Invite them from the admin console — Users, then *Invite external users*
+   — by e-mail or by link. Invites are one-time and expire after 30 days,
+   and each user who accepts takes a seat on the tailnet's plan (six on the
+   current free Personal plan, administrator included).
+3. Once they have accepted, read their identity off the Users page and add
+   that string to `group:x5h-ext` exactly as shown. They authenticate with
+   whichever provider they choose — any supported IdP, or a passkey — so
+   what belongs in the group is **not knowable before they accept**, and is
+   usually an e-mail address rather than a login of this tailnet's own
+   provider.
+4. Append their public key to `/etc/ssh/authorized_keys.d/root` on the
    board — or to `config/x5h-authorized-keys` if it should survive an
    image rebuild.
-3. Verify with the checks below, from their node.
+5. Verify with the checks below, from their node.
+
+Steps 3 and 4 are independent, and each is silent when omitted: without the
+grant their SSH hangs, without the key it is refused. Doing one and calling
+it done is the usual result of splitting them across a day.
 
 Offboarding is the reverse; remember the key on the board outlives the
 tailnet removal.

--- a/platforms/autosd/x5h/companion-host.md
+++ b/platforms/autosd/x5h/companion-host.md
@@ -1,0 +1,708 @@
+# X5H companion host: always-on bench gateway for remote development
+
+Stands up a small always-on PC next to the X5H that owns the bench LAN,
+routes a tailnet into it, and serves the rescue paths (TFTP, NFS) and the
+serial consoles. It is what makes the board reachable when nobody is in
+the room, and it is where external developers' access is scoped.
+
+> **Status: executed and verified on hardware, 2026-08-10.** The procedure
+> below has been run end to end on a companion host, including the reboot
+> drill, both netboot rescue paths, and the access-tier tests from a real
+> external node. Markers recorded: `COMPANION_REBOOT_PASS`, `ACL_ADMIN_OK`,
+> `RESCUE_NETBOOT_YOCTO_PASS`, `RESCUE_NETBOOT_AUTOSD_PASS`,
+> `NEGATIVE_ACCESS_PASS`, `REMOTE_REHEARSAL_PASS`. Everything the first draft
+> got wrong is corrected in place, and the reasons are kept alongside the
+> commands so they do not have to be rediscovered.
+
+## Why a separate machine
+
+The board's bench dependencies used to live on a developer's workstation:
+the TFTP server U-Boot pulled kernels from, the NFS export it mounted as
+root, and the USB serial adapters. That workstation gets rebooted, taken
+home, and put to sleep. [UFS self-boot](selfboot.md) removes the board's
+*need* for those services in the normal path, but the rescue paths still
+want them, and something has to hold the serial consoles and bridge the
+tailnet. That something should be always on and boring.
+
+It also creates the security boundary. The bench LAN carries services with
+no authentication worth the name (TFTP has none; NFS here trusts the
+subnet). Those must never face the tailnet, because the tailnet is shared
+with external developers. The companion is where that separation is
+enforced — twice, independently: in the Tailscale ACL, and in a firewall
+that scopes each service to an interface.
+
+```mermaid
+flowchart TB
+  subgraph TAILNET["Tailnet — WireGuard mesh, GitHub-backed identity"]
+    direction LR
+    ADMIN["Administrator<br/>group:x5h-admin"]
+    DEV["Internal developer<br/>group:x5h-dev (optional middle tier)"]
+    EXT["Contractor<br/>group:x5h-ext / tag:x5h-ext"]
+  end
+
+  ACL{{"Enforcement 1 — Tailscale ACL grants<br/>identity decides who"}}
+
+  ADMIN -- "dst: * — the whole tailnet" --> ACL
+  DEV -- "board :22 + gateway :22" --> ACL
+  EXT -- "board :22 only" --> ACL
+
+  subgraph COMPANION["Companion host — always-on bench gateway"]
+    direction TB
+    TS0["tailscale0<br/>subnet router → 192.168.0.0/24<br/>every Linux node needs --accept-routes"]
+    NFT{{"Enforcement 2 — nftables inet x5h<br/>input policy drop; interface decides from where"}}
+    SERIAL["Serial consoles<br/>tio + tmux, /dev/ttyUSB*<br/>APU + CR52"]
+    BIF["bench NIC 192.168.0.1/24<br/>never-default, ignore-carrier"]
+    RESCUE["Rescue services<br/>tftpd :69 · NFSv3 /export/rfs*<br/>rpc.mountd :20048 pinned"]
+    UPLINK["uplink NIC<br/>masquerade for the bench"]
+    TS0 --> NFT
+    NFT -- "ssh :22" --> SERIAL
+    NFT -- "forward tailscale0 → bench" --> BIF
+    NFT -. "denied — reached tailscale0, not the bench NIC" .-> RESCUE
+    BIF --> UPLINK
+  end
+
+  ACL == "permitted flows only" ==> TS0
+
+  subgraph BENCH["Bench LAN 192.168.0.0/24 — unauthenticated services live only here"]
+    direction TB
+    BOARD["R-Car X5H — tsn5 192.168.0.20<br/>AutoSD self-boot from UFS<br/>sshd key-only, everyone lands as root"]
+    CR52["CR52 realtime core<br/>firmware slot on UFS, written from Linux<br/>reboot = PSCI cold reset, restarts it too"]
+    BOARD --- CR52
+  end
+
+  BIF -- "ssh root@192.168.0.20" --> BOARD
+  SERIAL -- "USB serial — the only way back when the PHY wedges" --> BOARD
+  RESCUE -- "TFTP kernel/dtb + NFS root (rescue boot only)" --> BOARD
+  UPLINK -- "container pulls, DNS 1.1.1.1 / 8.8.8.8" --> NET(["Internet"])
+
+  classDef tier fill:#e8f0fe,stroke:#4285f4,color:#111
+  classDef gate fill:#fff4e5,stroke:#e8a33d,color:#111
+  classDef host fill:#f3f3f3,stroke:#888,color:#111
+  classDef board fill:#e6f4ea,stroke:#34a853,color:#111
+  class ADMIN,DEV,EXT tier
+  class ACL,NFT gate
+  class TS0,SERIAL,BIF,RESCUE,UPLINK host
+  class BOARD,CR52 board
+  linkStyle 6 stroke:#d93025,stroke-width:2px,color:#d93025
+```
+
+The serial consoles turn out to matter more than "something has to hold
+them" suggests. There is a real failure mode in which the board is booted
+and healthy but has no working network, and reports its interface as up
+while being unreachable. Serial is then the only way back in. See
+[Failure modes](#failure-modes-paid-for-in-hardware).
+
+Assumes Ubuntu 24.04 LTS with two interfaces: `<BIF>` for the bench LAN and
+a separate `<uplink>`. Substitute real names throughout. The reference host
+used a USB Gigabit adapter for `<BIF>` and Wi-Fi for the uplink; both work,
+and both have consequences called out below.
+
+## 1. Base packages and tailnet
+
+```sh
+sudo apt update && sudo apt install -y \
+  nftables tftpd-hpa nfs-kernel-server tmux tio rsync unattended-upgrades
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale set --advertise-routes=192.168.0.0/24
+```
+
+Use `tailscale set`, not `tailscale up`: `set` changes the advertised routes
+on a node that is already logged in without re-authenticating it. Approve
+the route in the admin console (or let `autoApprovers` do it, section 6),
+then confirm with `tailscale status --json` that `Self.PrimaryRoutes`
+contains `192.168.0.0/24` — that field, not the advertisement, is what says
+the tailnet is actually routing through this node.
+
+Tagging the companion is optional and is discussed in section 6, together
+with the device-key expiry that will otherwise take the gateway offline on a
+schedule.
+
+> **Every Linux node that needs the bench must run
+> `sudo tailscale set --accept-routes`.** Accepting advertised subnet routes
+> is *off by default on Linux* (it is on by default on macOS and Windows).
+> Without it the node never installs `192.168.0.0/24` and sends bench traffic
+> to its own default gateway instead, so `ssh root@192.168.0.20` hangs and
+> then fails. Nothing in the tailnet or on the companion looks wrong, which
+> makes this read as a firewall or ACL problem for as long as you let it.
+> Check with `ip route get 192.168.0.20` and require `dev tailscale0` in the
+> answer.
+
+If `apt` exits non-zero while every requested package is installed, look for
+unrelated half-configured packages (`dpkg -l | grep -v '^ii'`) before
+believing the failure is yours; provisioning scripts should test for the
+packages they need rather than trusting apt's exit status.
+
+## 2. Bench LAN and forwarding
+
+The companion takes over `192.168.0.1`, the address the board's kernel
+command line already uses as its gateway, so nothing on the board changes
+when the cables move. `serverip` in the board's saved U-Boot environment is
+the same address, so the netboot rescue paths also need no edit.
+
+```sh
+sudo nmcli con add type ethernet ifname <BIF> con-name x5h-lan \
+  ipv4.method manual ipv4.addresses 192.168.0.1/24 \
+  ipv4.never-default yes ipv6.method disabled \
+  connection.autoconnect yes
+echo 'net.ipv4.ip_forward=1' | sudo tee /etc/sysctl.d/99-x5h.conf
+sudo sysctl --system
+```
+
+Three things the obvious version of this gets wrong:
+
+- **Autoconnect priority must beat whatever else claims the NIC, and must be
+  computed rather than guessed.** NetworkManager auto-creates a profile for
+  any wired NIC, and on a carrier event the winner owns the address. If the
+  wrong profile wins, the interface ends up with a link-local address and the
+  board's U-Boot fails its `tftp` with `ARP Retry count exceeded` — a symptom
+  that points nowhere near NetworkManager. Take the highest
+  `autoconnect-priority` among the other profiles on that interface and add
+  100, so winning is a property of the configuration and not of activation
+  history.
+- **`ipv4.never-default yes` and `ipv6.method disabled`** keep a bench
+  profile from ever competing for the default route.
+- **IPv4 forwarding only.** Enabling `net.ipv6.conf.all.forwarding` buys
+  nothing here — the advertised route is IPv4 and the board is IPv4-only —
+  while enabling per-interface IPv6 forwarding suppresses kernel RA
+  processing and is a plausible way to lose the host's own IPv6 default
+  route.
+
+Optionally, keep the address even when the board is powered off:
+
+```sh
+printf '[device-x5h]\nmatch-device=interface-name:<BIF>\nignore-carrier=yes\n' \
+  | sudo tee /etc/NetworkManager/conf.d/50-x5h-ignore-carrier.conf
+sudo systemctl reload NetworkManager
+```
+
+Without this, losing carrier makes NetworkManager deactivate the profile and
+the companion holds no `192.168.0.1` at all while the board is off. Normal
+operation does not care (self-boot never uses TFTP, and the firewall matches
+on interface name rather than address), but a *cold* netboot rescue becomes a
+race: the board's U-Boot starts its transfer a few seconds after power-on,
+and NetworkManager has to have finished assigning the address by then. Either
+set `ignore-carrier`, or check `ip -br addr show <BIF>` before starting a
+rescue.
+
+## 3. Firewall
+
+Identity is the ACL's job; this file's job is to make sure the
+unauthenticated bench services can only ever be reached from the bench
+LAN, whatever the ACL says. `/etc/nftables.conf`:
+
+```
+#!/usr/sbin/nft -f
+# Replace only our own table. A global `flush ruleset` destroys the
+# iptables-nft tables that Docker installs, on every nftables restart.
+table inet x5h
+delete table inet x5h
+
+define BIF = "<BIF>"
+define UPLINK = "<uplink>"
+
+table inet x5h {
+  chain input {
+    type filter hook input priority 0; policy drop;
+    ct state established,related accept
+    iif "lo" accept
+    # Containers reaching host services. Also see the forward chain: a drop
+    # policy in this table vetoes packets that Docker's own table accepted,
+    # because every chain at a hook sees the packet and any drop is final.
+    iifname "docker0" accept
+    # SSH: tailnet and bench LAN.
+    iifname { "tailscale0", $BIF } tcp dport 22 accept
+    # If the uplink is a shared LAN you administer this box from, admit SSH
+    # from that subnet too -- otherwise the tailnet is the single path to a
+    # machine that is supposed to run without a keyboard. Scoped to one
+    # RFC1918 subnet on one interface; it is not reachable from the internet.
+    iifname $UPLINK ip saddr <uplink-subnet> tcp dport 22 accept
+    # TFTP + NFS: bench LAN only -- these face no tailnet, ever.
+    # 20048 is rpc.mountd, pinned in section 4. The board's rescue netboot
+    # mounts with nfsvers=3, so mountd must be reachable or the mount fails;
+    # 69/111/2049 alone is not enough.
+    iifname $BIF udp dport { 69, 111, 2049, 20048 } accept
+    iifname $BIF tcp dport { 111, 2049, 20048 } accept
+    iifname $BIF icmp type echo-request accept
+    iifname "tailscale0" icmp type echo-request accept
+    udp dport 41641 accept
+    # mDNS replies arrive as fresh multicast, not as conntrack-established,
+    # so a drop policy silently breaks .local resolution in both directions
+    # on a host running avahi. Uplink only.
+    iifname $UPLINK udp dport 5353 accept
+    iifname $UPLINK icmp type echo-request accept
+  }
+  chain forward {
+    type filter hook forward priority 0; policy drop;
+    ct state established,related accept
+    iifname "tailscale0" oifname $BIF accept
+    iifname $BIF oifname $UPLINK accept
+    iifname "docker0" accept
+    oifname "docker0" accept
+  }
+  chain postrouting {
+    type nat hook postrouting priority 100;
+    iifname $BIF oifname $UPLINK masquerade
+  }
+}
+```
+
+```sh
+sudo nft -c -f /etc/nftables.conf && sudo systemctl enable --now nftables
+```
+
+The masquerade is what lets the board pull container images; the image
+ships static resolvers because nothing on the bench LAN serves DNS.
+
+Note what this ruleset deliberately does *not* do: it does not scope SSH by
+destination address, so the companion answers on `22` at its bench address
+from the tailnet as well. That is intentional — the address a packet is
+addressed to says nothing about where it came from, and the interface it
+arrived on does.
+
+Before turning this on, inventory what already listens on the host
+(`sudo ss -tulpn`). A default-drop input policy on a machine that was
+previously unfirewalled will silently cut remote-desktop tools, printer and
+device discovery, and anything else with an inbound listener. Outbound stays
+unaffected: there is no output chain, and established/related is accepted, so
+tools that connect out to a relay keep working while tools that expect direct
+inbound connections stop.
+
+## 4. Rescue services and artifact migration
+
+```sh
+sudo mkdir -p /srv/tftp /export/rfs /export/rfs-autosd
+sudo tee /etc/default/tftpd-hpa >/dev/null <<'EOF'
+TFTP_USERNAME="tftp"
+TFTP_DIRECTORY="/srv/tftp"
+TFTP_ADDRESS=":69"
+TFTP_OPTIONS="--secure"
+EOF
+sudo mkdir -p /etc/nfs.conf.d
+printf '[mountd]\nport = 20048\n' | sudo tee /etc/nfs.conf.d/50-x5h.conf
+printf '/export/rfs 192.168.0.0/24(rw,async,no_root_squash,no_subtree_check)\n/export/rfs-autosd 192.168.0.0/24(rw,async,no_root_squash,no_subtree_check)\n' \
+  | sudo tee /etc/exports
+sudo systemctl enable --now tftpd-hpa nfs-kernel-server && sudo exportfs -ra
+```
+
+Why each of those settings is not optional:
+
+- **`--secure`** is what confines tftpd to `TFTP_DIRECTORY`. Upload
+  (`--create`) is deliberately off: netboot only reads, and this host is a
+  security boundary.
+- **`TFTP_ADDRESS` stays `:69`.** Binding to `192.168.0.1:69` would fail at
+  boot whenever the board is powered off and the interface has no address,
+  which breaks the reboot drill. The firewall is what scopes tftpd to the
+  bench LAN.
+- **Everything served over TFTP must be mode 644.** tftpd drops to user
+  `tftp`, and an unreadable file makes U-Boot's `tftp` fail with an opaque
+  timeout rather than a permission error.
+- **`rpc.mountd` on a fixed port.** Its default port is random, so without
+  pinning it there is nothing to open in the firewall and the `nfsvers=3`
+  rescue mount cannot succeed. Verify with
+  `rpcinfo -p localhost | awk '$5=="mountd"'`.
+
+Then move the artifacts across. `/srv/tftp` is world-readable, so only the
+receiving side needs root:
+
+```sh
+sudo rsync -aH --numeric-ids \
+  -e 'ssh -i /home/<admin>/.ssh/id_rsa' \
+  <user>@<workstation>:/srv/tftp/ /srv/tftp/
+```
+
+The `-e` is required: root's `~/.ssh` has no key of its own.
+
+The two NFS roots are different. They are root-owned trees with hundreds of
+files an unprivileged user cannot read, so the *sending* side needs root as
+well — and rsync cannot answer a remote sudo password prompt, because its
+protocol owns the channel that prompt would use. A cached `sudo` credential
+does not help either, since `tty_tickets` binds it to the terminal it was
+entered on and rsync's remote command has no terminal. Either grant a
+narrowly scoped `NOPASSWD` for rsync on the workstation for the duration of
+the copy, or stream through a staging file owned by an unprivileged user, one
+tree at a time:
+
+```sh
+# on the workstation, where sudo can prompt on a real terminal
+sudo tar --numeric-owner --xattrs --xattrs-include='*' --acls -S \
+  -cf - -C /export/rfs . \
+  | ssh <admin>@<companion> 'cat > /home/<admin>/rfs.tar'
+
+# on the companion
+sudo tar --numeric-owner --xattrs --xattrs-include='*' --acls \
+  -xf /home/<admin>/rfs.tar -C /export/rfs && rm /home/<admin>/rfs.tar
+```
+
+**`--xattrs-include='*'` is load-bearing.** GNU tar excludes the `security.*`
+namespace from extraction by default, so without it file capabilities and
+SELinux labels are dropped silently — the same class of failure that shipped
+a rootfs with no kernel modules earlier in this branch. Verify after the
+copy, rather than assuming: the file counts on both sides should match
+exactly (`find <tree> | wc -l`, run as the *same* kind of user on both), and
+`getcap -r <tree>` should return the same set on both. A tree whose source
+has no capabilities at all is a valid answer; the point is that the two
+agree.
+
+Then the repo and the serial tooling:
+
+```sh
+git clone https://github.com/autowarefoundation/openadkit ~/src/openadkit
+sudo usermod -aG dialout "$USER"
+```
+
+`dialout` only takes effect in new login sessions, so `/dev/ttyUSB*` stays
+unreadable until you log in again — or until the reboot drill below. The
+console helper scripts derive their log directory from their own location, so
+they work from any checkout path.
+
+Vendor SDK material stays off this list unless the companion is
+administrator-only; it must not become reachable from a shared tailnet. None
+of the four objectives needs it.
+
+Verify: `showmount -e localhost` lists both exports, and `ss -uln | grep :69`
+shows tftpd listening.
+
+## 5. Host hardening and unattended updates
+
+```sh
+# put the admin pubkey in ~/.ssh/authorized_keys and verify a key login FIRST
+printf 'PasswordAuthentication no\nPermitRootLogin no\n' \
+  | sudo tee /etc/ssh/sshd_config.d/50-x5h.conf
+sudo mkdir -p /run/sshd && sudo sshd -t
+sudo systemctl is-active --quiet ssh.service && sudo systemctl reload ssh.service
+sudo sshd -T | grep -x 'passwordauthentication no'
+sudo dpkg-reconfigure -f noninteractive unattended-upgrades
+```
+
+Ubuntu 24.04 activates sshd through `ssh.socket`, so `ssh.service` is
+inactive and **`systemctl reload ssh` has nothing to reload** — each
+connection spawns a fresh sshd that reads the config anyway. Socket
+activation also means the privilege separation directory only exists for the
+lifetime of a connection, so a bare `sshd -t` fails with
+`Missing privilege separation directory: /run/sshd`; create it first. And
+because a command failing before the final `&&` of a list is exempt from
+`set -e`, the tempting `sshd -t && systemctl reload ssh` will skip the reload
+and let a provisioning script report success either way. Assert the live
+state with `sshd -T` instead of assuming the file you wrote took effect.
+
+If the companion is a laptop, stop the lid from suspending the bench:
+
+```sh
+printf '[Login]\nHandleLidSwitch=ignore\nHandleLidSwitchDocked=ignore\nHandleLidSwitchExternalPower=ignore\n' \
+  | sudo tee /etc/systemd/logind.conf.d/50-x5h-nosuspend.conf
+```
+
+Applied at next boot. Check the idle-suspend setting of the desktop session
+too; a suspended gateway takes the board, TFTP, NFS and the tailnet route
+down with it.
+
+## 6. Access tiers
+
+Administrators get the whole bench. External developers get the board's
+SSH port and nothing else — not the companion, not TFTP, not NFS.
+
+```mermaid
+flowchart LR
+  EXT["Contractor<br/>group:x5h-ext, tag:x5h-ext<br/>grant: board only, tcp:22"]
+  DEV["Internal developer<br/>group:x5h-dev (optional middle tier)<br/>grant: board + gateway, tcp:22"]
+  ADMIN["Administrator<br/>group:x5h-admin<br/>grant: dst * , ip *"]
+
+  subgraph Z0["Zone 0 — no tier reaches this over the tailnet"]
+    RESCUE["tftpd :69 · NFSv3 · rpc.mountd :20048<br/>nftables accepts these on the bench NIC only"]
+  end
+
+  subgraph Z3["Zone 3 — administrator only"]
+    REST["Board ports other than 22<br/>and the companion's other services"]
+    TAILNET["Every other machine on the tailnet<br/>this is why the admin grant must stay dst:*"]
+    CONSOLE["Tailscale admin console<br/>ACL edits, route approval, onboarding<br/>not gated by ACLs — always the way back"]
+  end
+
+  subgraph Z2["Zone 2 — administrator + internal developer"]
+    GW["Companion sshd, tcp/22<br/>serial consoles (tio + tmux)<br/>the only way back when the PHY wedges"]
+  end
+
+  subgraph Z1["Zone 1 — all three tiers"]
+    BOARD["X5H board, tcp/22 only<br/>192.168.0.20 · root by key<br/>reboot, build, run, CR52 slot update"]
+  end
+
+  ADMIN ==> BOARD
+  ADMIN ==> GW
+  ADMIN ==> REST
+  ADMIN ==> TAILNET
+  ADMIN ==> CONSOLE
+  DEV ==> BOARD
+  DEV ==> GW
+  DEV -. "no grant" .-> REST
+  EXT ==> BOARD
+  EXT -. "refused — verified from a real tag:x5h-ext node" .-> GW
+  EXT -. "refused — board's other ports too" .-> REST
+  ADMIN -. "ACL allows it, nftables still drops it<br/>interface decides, not address<br/>reach it by ssh to the companion first" .-> RESCUE
+
+  classDef admin fill:#e8f0fe,stroke:#1a73e8,stroke-width:2px,color:#111
+  classDef dev fill:#e6f4ea,stroke:#188038,stroke-width:2px,color:#111
+  classDef ext fill:#fef7e0,stroke:#b06000,stroke-width:2px,color:#111
+  classDef target fill:#f8f9fa,stroke:#5f6368,color:#111
+  classDef blocked fill:#fce8e6,stroke:#d93025,color:#111
+  class ADMIN admin
+  class DEV dev
+  class EXT ext
+  class BOARD,GW,REST,TAILNET,CONSOLE target
+  class RESCUE blocked
+
+  linkStyle 0,1,2,3,4 stroke:#1a73e8,stroke-width:2px,color:#1a73e8
+  linkStyle 5,6 stroke:#188038,stroke-width:2px,color:#188038
+  linkStyle 7 stroke:#9aa0a6,stroke-width:1px,color:#9aa0a6
+  linkStyle 8 stroke:#b06000,stroke-width:2px,color:#b06000
+  linkStyle 9,10 stroke:#d93025,stroke-width:1.5px,color:#d93025
+  linkStyle 11 stroke:#d93025,stroke-width:1.5px,color:#d93025
+```
+
+Zone 0 is the one worth staring at: **not even the administrator's `dst: *`
+reaches TFTP, NFS or mountd over the tailnet**, because the firewall matches
+on the interface a packet arrived on rather than on its address. The
+administrator gets at those services by opening an SSH session to the
+companion first. That is what makes a mistake in the ACL survivable.
+
+The middle tier is optional. Two tiers are enough if everyone who is not
+external is an administrator; add `group:x5h-dev` when someone needs the
+serial consoles — which is to say, needs to recover a board whose network
+has wedged — without getting the rest of the tailnet. The bench services
+stay out of reach at either setting, since Zone 0 is enforced by the
+firewall and not by identity.
+
+Read the current policy before writing anything. **The policy file replaces
+the tailnet's defaults rather than adding to them**, so a merge that only
+adds the x5h rules removes the default "allow all your own devices" grant
+along the way. Match the syntax already in the file: newer tailnets use
+`grants`, older ones `acls`, and mixing them is avoidable work.
+
+```jsonc
+{
+  "groups": {
+    // Identities are whatever the tailnet's identity provider issues. A
+    // GitHub-backed tailnet uses GitHub logins, not e-mail addresses, and an
+    // address that does not exist here yields an empty group and an admin
+    // rule that grants nothing.
+    "group:x5h-admin": ["<admin-login>"],
+    "group:x5h-ext":   [],   // external developer logins land here
+    // Optional middle tier: internal developers who need the board and the
+    // gateway's serial consoles, but not the rest of the tailnet. Omit the
+    // group and its grant below if two tiers are enough.
+    "group:x5h-dev":   [],
+  },
+  "tagOwners": {
+    "tag:x5h-gw":  ["autogroup:admin"],
+    "tag:x5h-ext": ["autogroup:admin"],
+  },
+  "grants": [
+    // Administrators keep unrestricted access. Do not narrow this to the
+    // gateway and the bench subnet: with the default allow-all grant removed,
+    // that is what cuts you off from every other machine on your own tailnet.
+    {"src": ["group:x5h-admin"], "dst": ["*"], "ip": ["*"]},
+    // Optional internal tier: the board plus the gateway's SSH, so they can
+    // drive the serial consoles. Name the gateway by its tag; if it is not
+    // tagged, use its node name instead.
+    {"src": ["group:x5h-dev"], "dst": ["192.168.0.20", "tag:x5h-gw"], "ip": ["tcp:22"]},
+    // External tier. In grants syntax the port restriction lives in "ip",
+    // not appended to "dst".
+    {"src": ["group:x5h-ext", "tag:x5h-ext"], "dst": ["192.168.0.20"], "ip": ["tcp:22"]},
+  ],
+  "autoApprovers": {
+    "routes": {"192.168.0.0/24": ["tag:x5h-gw", "group:x5h-admin"]},
+  },
+}
+```
+
+Keep the admin console open after saving and confirm you can still reach your
+own machines before considering it done. ACLs do not gate console access, so
+the console is always the way back.
+
+The board's own sshd is key-only (`PasswordAuthentication no`,
+`PermitRootLogin prohibit-password`), so the well-known development root
+password is not a network credential. It still works on the serial
+console, which is deliberate — that is the recovery path.
+
+### Device key expiry on the gateway
+
+A user-owned node's device key expires (180 days by default). When it does,
+the subnet router stops routing and someone has to re-authenticate
+interactively — a scheduled outage for an unattended gateway. Check it with
+`tailscale status --json` (`Self.KeyExpiry`) and pick one:
+
+- **Disable key expiry** for the device in the admin console. Least
+  invasive, and enough on its own.
+- **Tag it** `tag:x5h-gw`. Tagged devices have no key expiry and let
+  `autoApprovers` re-approve the route by itself, at the cost of
+  re-authentication and of no longer matching user-based rules. The admin
+  grant above is `dst: ["*"]`, so tagging can be decided independently and
+  later.
+
+### Onboarding an external developer
+
+1. Add their login to `group:x5h-ext`.
+2. Append their public key to `/etc/ssh/authorized_keys.d/root` on the
+   board — or to `config/x5h-authorized-keys` if it should survive an
+   image rebuild.
+3. Verify with the checks below, from their node.
+
+Offboarding is the reverse; remember the key on the board outlives the
+tailnet removal.
+
+## 7. Verification
+
+### Reboot drill
+
+Set the BIOS to power on after AC loss, then `sudo reboot` and check from
+elsewhere on the tailnet:
+
+```sh
+ssh <companion> 'tailscale status | head -3 \
+  && ip -4 addr show <BIF> | grep -q 192.168.0.1 \
+  && showmount -e localhost \
+  && ss -uln | grep -q ":69 " \
+  && systemctl is-active nftables tftpd-hpa nfs-kernel-server' \
+  && echo COMPANION_REBOOT_PASS
+```
+
+Use `grep -q`, not `sed -n /:69/p`: `sed` exits 0 whether or not it matched,
+so as a link in an `&&` chain it can never fail and the check silently proves
+nothing.
+
+### Access tiers
+
+From an admin node:
+
+```sh
+tailscale ping <companion> && ssh <companion> true && ssh root@192.168.0.20 true \
+  && echo ACL_ADMIN_OK
+```
+
+If the admin key has a passphrase, run this with the key loaded into an
+agent. Without one, ssh cannot produce a signature and reports
+`Permission denied (publickey)` — while the server-side log and `ssh -vv`
+both show `Server accepts key`. The failure is local; the key is fine.
+
+From a node joined with a `tag:x5h-ext` auth key, using a key authorised on
+the board. Confirm the node is really tag-owned before believing any of it:
+
+```sh
+tailscale status --json | grep -A2 '"Tags"'   # must list tag:x5h-ext
+```
+
+A node that joined user-owned matches `group:x5h-admin`, is granted
+`dst: ["*"]`, and will therefore reach *everything* — which reads as a broken
+ACL rather than a broken test. Tags come from the auth key, so the key has to
+be created with the tag selected; alternatively a tag owner can self-assign
+it with `tailscale up --advertise-tags=tag:x5h-ext --force-reauth`. Use one
+mechanism or the other, not both.
+
+Then probe, from that node:
+
+| destination | expected | what it isolates |
+|---|---|---|
+| `192.168.0.20:22` | reachable | the tier still does its job; positive control |
+| `192.168.0.20:2049` | blocked | the ACL restricts the *port*, not just the host |
+| `<companion tailnet IP>:22` | blocked | the ACL alone — nftables admits tcp/22 on `tailscale0` |
+| `192.168.0.1:2049` | blocked | both layers at once |
+
+Both layers **drop** rather than reject, so a blocked probe does not fail
+fast — it hangs until whatever timeout you imposed. With
+`timeout 6 tailscale nc <host> <port> </dev/null`, exit 0 means the
+connection was established and closed on our EOF, and exit 124 means the
+handshake never completed. Getting that mapping backwards turns a working
+boundary into a reported failure, so assert that the permitted destination
+and a blocked one land on *different* exit statuses before reporting a
+verdict at all. Note also that a bare "no bytes received" is not evidence of
+blocking: NFS sends no banner on connect. For the positive control, hold
+stdin open and read the SSH banner as payload proof.
+
+UDP 69 is not worth probing directly: a UDP connect test cannot distinguish
+"filtered" from "no reply". It sits in the same nftables rule and the same
+interface scope as udp/2049, so the NFS result covers it by construction.
+
+### Netboot rescue through the companion
+
+One-shot boots from the U-Boot prompt; neither writes the environment, so
+the board returns to UFS self-boot on the next reset with nothing to undo.
+`printenv` first, as always.
+
+```
+=> printenv bootcmd bootcmd_yocto bootcmd_autosd
+=> ping 192.168.0.1            # host is alive -> the bench path works
+=> run bootcmd_yocto           # TFTP kernel+dtb, NFS root /export/rfs
+=> run bootcmd_autosd          # TFTP kernel+dtb, NFS root /export/rfs-autosd
+```
+
+Confirm on the booted system that the root really is the companion's export,
+rather than trusting that the command ran:
+
+```sh
+findmnt -n -o SOURCE,FSTYPE /                    # 192.168.0.1:/export/... nfs
+findmnt -n -o OPTIONS / | tr ',' '\n' | grep -E 'vers|mount'
+```
+
+The second command is the one that proves the mountd rule earns its place:
+`mountvers=3` and `mountproto=tcp` mean the client talked to `rpc.mountd`
+over TCP, which the original 69/111/2049 ruleset would have dropped.
+
+Two expected results that are not faults: the netbooted AutoSD root is the
+pre-self-boot image and has **no sshd**, so verify it over serial; and
+podman logs overlayfs complaints there because its store cannot sit on NFS,
+which is exactly why self-boot uses a btrfs partition instead.
+
+### Remote workday rehearsal
+
+From off-bench, over the tailnet only: smoke, remote reset, wait, smoke.
+
+```sh
+ssh root@192.168.0.20 sh /usr/local/bin/selfboot-smoke.sh   # boot A
+ssh root@192.168.0.20 reboot
+# wait for it to answer again, then
+ssh root@192.168.0.20 sh /usr/local/bin/selfboot-smoke.sh   # boot B
+```
+
+**`selfboot-smoke.sh` passes once per boot.** The CR52 announces its RPMsg
+endpoint exactly once per SoC reset, so a second run in the same boot fails
+on `service_timeout` no matter how long it waits — a failure that looks like
+a regression in whatever you last changed. Budget one smoke per boot and put
+a reset between the tiers you verify. `rpmsg-smoke.sh --check` is read-only
+and can be run as often as you like; `dmesg | grep -c 'creating channel'`
+returning 0 says the current boot's session is still unused.
+
+Comparing `/proc/sys/kernel/random/boot_id` either side of the reset is a
+cheap way to prove the board actually reset rather than merely stayed up.
+
+## Failure modes paid for in hardware
+
+**The bench link can come up unusable after returning from a netboot
+rescue.** Symptom: the board boots fine from UFS and the console is healthy,
+but the Ethernet switch driver logs a register-wait timeout, the PHY fails
+master/slave resolution, and the PHY state machine halts with a WARNING
+backtrace. The trap is that **the board then reports its interface as `UP`
+with `LOWER_UP` and its address assigned** while being completely
+unreachable, because the driver reports carrier optimistically. Nothing on
+the board looks wrong from the board.
+
+Another `reboot` clears it. Since the network is what is broken, that reboot
+has to be issued over serial — which is the concrete reason the companion
+holds the consoles rather than merely being near the board.
+
+**Do not treat a timeout as a dead board.** A good reset answers again in
+about 30 seconds; a link that fails to negotiate can leave the board silent
+for minutes and then recover on its own. Polling for 155 seconds and
+concluding failure has already produced one wrong diagnosis. Look at the
+serial console before deciding.
+
+**The board's `tsn5` MAC address is randomised on every boot.** Anything
+built on a stable MAC — DHCP reservations, MAC filtering, static ARP entries
+— will not work.
+
+**The board has no RTC or NTP on the bench LAN**, so its log timestamps are
+wrong by days. Correlate against the companion's clock, not the board's.
+
+## Related
+
+- [UFS self-boot](selfboot.md) — why the board no longer depends on this
+  host, and the rescue commands that still do.
+- [CR52 slot update](cr52-slot-update.md) — the remote firmware workflow
+  this host makes reachable.

--- a/platforms/autosd/x5h/config/50-x5h-sshd.conf
+++ b/platforms/autosd/x5h/config/50-x5h-sshd.conf
@@ -1,0 +1,7 @@
+# X5H bench: the tailnet is shared with external developers, so the known
+# dev root password must not be a network credential. Keys only over SSH;
+# the password remains usable on the serial console.
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitRootLogin prohibit-password
+AuthorizedKeysFile .ssh/authorized_keys /etc/ssh/authorized_keys.d/%u

--- a/platforms/autosd/x5h/config/50-x5h-tsn5-unmanaged.conf
+++ b/platforms/autosd/x5h/config/50-x5h-tsn5-unmanaged.conf
@@ -1,0 +1,4 @@
+# tsn5 is configured by the kernel ip= argument (same as netboot); keep
+# NetworkManager from re-running DHCP on it after a UFS-root boot.
+[keyfile]
+unmanaged-devices=interface-name:tsn5

--- a/platforms/autosd/x5h/config/80-x5h.preset
+++ b/platforms/autosd/x5h/config/80-x5h.preset
@@ -1,0 +1,1 @@
+enable sshd.service

--- a/platforms/autosd/x5h/config/x5h-authorized-keys
+++ b/platforms/autosd/x5h/config/x5h-authorized-keys
@@ -1,0 +1,6 @@
+# Admin key(s) for root@autosd-x5h. Add your own public key here before
+# building the image; the sshd drop-in is key-only, so an image built with
+# this file as-is has no SSH access at all until a key is appended -- either
+# here (image rebuild) or onto the live UFS rootfs at
+# /etc/ssh/authorized_keys.d/root, which is also how external developers are
+# granted access (see companion-host.md).

--- a/platforms/autosd/x5h/config/x5h-resolv.conf
+++ b/platforms/autosd/x5h/config/x5h-resolv.conf
@@ -1,0 +1,4 @@
+# Static resolvers: the board reaches the internet through the companion
+# PC's masquerade; nothing on 192.168.0.0/24 serves DNS.
+nameserver 1.1.1.1
+nameserver 8.8.8.8

--- a/platforms/autosd/x5h/config/x5h-rpmsg-diag.conf
+++ b/platforms/autosd/x5h/config/x5h-rpmsg-diag.conf
@@ -1,0 +1,3 @@
+# Keep the in-tree sample driver from stealing the CR52's RPMsg channel
+# (udev MODALIAS auto-loads it on every channel announce otherwise).
+blacklist rpmsg_client_sample

--- a/platforms/autosd/x5h/cr52-slot-update.md
+++ b/platforms/autosd/x5h/cr52-slot-update.md
@@ -1,0 +1,181 @@
+# Updating the CR52 realtime firmware from Linux
+
+The realtime core does not load its payload from Linux. As described in
+[rpmsg-dualboot.md](rpmsg-dualboot.md), the payload is flashed into a boot
+slot and started by the boot firmware before Linux exists; on this SoC
+remoteproc's `.load` and `.stop` are no-ops. So "update the CR52 firmware"
+means "change what is in that slot", and until now that meant putting the
+board into its serial download mode and running the vendor flash tool —
+a procedure that needs physical access to the board.
+
+That slot is a region of a UFS logical unit. Linux can write it directly.
+This document is the procedure for doing that; combined with the fact that
+a plain `reboot` cold-resets the SoC (see [selfboot.md](selfboot.md)), it
+makes realtime firmware updates a fully remote operation.
+
+> **Numbers live elsewhere.** The slot's device, offset, extent and the
+> certificate parameters come from the vendor SDK and are not reproduced
+> in this repository. Take them from the vendor SDK and your site's own
+> record of this work; the procedure below is written to be followed with
+> those values to hand.
+
+## Before you write anything
+
+**Stage the vendor restore path first.** Have the vendor flash tool, its
+restore configuration and the original payload present and hash-verified
+*before* the first write. If a write leaves the boot firmware unable to
+start the realtime core, that tooling and physical access to the board are
+the way back. It was not needed during validation, but it is the only
+recovery route, so it is not optional.
+
+Keep an operator at the board for the first write on any new board or
+after any change to the slot geometry.
+
+## 1. Locate the slot, read-only
+
+Decode the vendor's update image (an SREC) into a flat binary, then find
+where that binary already lives on the board's storage by comparing bytes.
+Nothing is written in this phase.
+
+```python
+# S3 records only; addresses are absolute load addresses
+def decode(srec, out):
+    segs = []
+    for line in open(srec):
+        line = line.strip()
+        if not line.startswith('S3'):
+            continue
+        count = int(line[2:4], 16)
+        addr = int(line[4:12], 16)
+        segs.append((addr, bytes.fromhex(line[12:12 + 2 * (count - 5)])))
+    segs.sort()
+    start, end = segs[0][0], max(a + len(p) for a, p in segs)
+    img = bytearray(b'\xff' * (end - start))
+    for a, p in segs:
+        img[a - start:a - start + len(p)] = p
+    open(out, 'wb').write(img)
+```
+
+Stage a short prefix of the decoded image onto the board, then compare it
+against each candidate device at the documented offset. Express the offset
+in 4 KiB units — these LUNs use 4096-byte logical sectors:
+
+```sh
+# skip = <offset> / 4096
+for d in /dev/disk/by-path/platform-*ufs*; do
+  case $d in *-part*) continue ;; esac
+  dd if=$d bs=4096 skip=<skip> count=16 2>/dev/null \
+    | cmp -s - /var/tmp/slot-prefix.bin && echo "HIT $d"
+done
+```
+
+**Exactly one device must hit.** Before believing it, cross-check: read the
+same offset on another controller and confirm it differs. A useful sanity
+signal is that the first bytes of a Cortex-R52 image are an exception
+vector table — a run of identical `ldr pc, [pc, #…]` instructions — so a
+hit should look like code, not like filesystem data.
+
+If nothing hits, do not widen the write blindly. Dump the candidate
+devices and search for the prefix offline to find the true offset, or stop
+and keep using the vendor tool.
+
+## 2. Capture a pristine baseline
+
+Read the **whole slot extent** — not just the payload length — to a file
+and keep it off-board:
+
+```sh
+dd if=<dev> bs=4096 skip=<skip> count=<extent-sectors> of=/var/tmp/slot-orig.bin
+```
+
+This is what you restore to, and it is strictly better than restoring the
+decoded payload: the payload is shorter than the extent, and the bytes
+past its end are not necessarily what a zero-fill would produce. On this
+board they are erased flash (`0xff`), so a restore that zero-filled the
+tail would not return the region to how it was found.
+
+Confirm the baseline's leading bytes equal the decoded current payload
+before trusting it.
+
+## 3. Write
+
+```sh
+dd if=<new-payload> of=<dev> bs=4096 seek=<skip> conv=notrunc,fsync
+blockdev --flushbufs <dev>
+dd if=<dev> bs=4096 skip=<skip> count=<extent-sectors> iflag=direct 2>/dev/null \
+  | head -c <payload-bytes> | cmp - <new-payload> && echo WRITE_VERIFIED
+```
+
+Three details matter:
+
+- **Erase the extent first** when the new payload is shorter than the old
+  one, so no tail of the previous image survives inside the region the
+  boot firmware loads.
+- **`oflag=direct` only works on sector-aligned transfers.** A payload
+  whose length is not a multiple of 4096 will fail with O_DIRECT on its
+  final partial block. Write buffered with `conv=fsync` instead.
+- **`blockdev --flushbufs` before reading back.** Without it the
+  verification read can be served from the page cache, in which case it
+  confirms nothing about what reached the media. Read back with
+  `iflag=direct`.
+
+## 4. Restart the realtime core and verify
+
+```sh
+reboot
+```
+
+That is the whole reset step. The reboot is a PSCI `SYSTEM_RESET` which
+the firmware implements as a cold reset, so the realtime core restarts and
+the boot firmware re-loads the slot. Watch the realtime console: a working
+RPMsg payload reprints its OpenAMP banner ending in `creating remoteproc
+virtio`.
+
+Then confirm the round trip from Linux:
+
+```sh
+sh /usr/local/bin/rpmsg-smoke.sh -f rpmsg-echo-cr52.elf -s rpmsg-client-sample -n 100
+```
+
+Expect `RPMSG_SMOKE_PASS`. The discriminating kernel line is
+
+```
+virtio_rpmsg_bus virtio0: creating channel rpmsg-client-sample addr 0x400
+```
+
+If the slot content is not an RPMsg payload, that line never appears and
+the smoke ends in `RPMSG_SMOKE_FAIL … reason=service_timeout`. Note that
+remoteproc will still report the processor "up" and will still log
+"Booting fw image" — it is describing the ELF Linux staged, not what the
+core is executing. Only the channel announce and the round trip are
+evidence.
+
+## Validating the write path on a board
+
+Prove the mechanism before relying on it, in three steps:
+
+1. **Write the current payload over itself.** Byte-identical, so the
+   content risk is zero, and a passing smoke afterwards proves the write
+   path and the read-back verification work.
+2. **Write a different, known-bootable payload.** The expected result is
+   that the realtime console stays silent and the smoke fails with
+   `service_timeout`. That failure is the evidence the write took effect —
+   a successful swap that changed nothing would prove nothing. Linux must
+   still boot normally; a slot the realtime core cannot use does not stop
+   the application cores.
+3. **Restore the pristine baseline** and confirm the smoke passes again.
+
+This was run on 2026-08-07. All three steps passed, across three reboots,
+and the vendor restore path was never needed. No certificate regeneration
+was required for either payload — the boot firmware accepted both a
+payload written by the vendor tool and one written directly from Linux. If
+a future board or SDK version rejects a directly-written payload, expect
+the failure at boot firmware stage, recover with the vendor tool, and
+treat certificate generation as the next thing to investigate.
+
+## Related
+
+- [CR52 dual boot + RPMsg](rpmsg-dualboot.md) — what the payload does and
+  why Linux cannot load it.
+- [UFS self-boot](selfboot.md) — the reset semantics this relies on, and
+  why the board comes back by itself afterwards.

--- a/platforms/autosd/x5h/rpmsg-dualboot.md
+++ b/platforms/autosd/x5h/rpmsg-dualboot.md
@@ -140,9 +140,14 @@ across.
 RPMsg endpoint exactly once per reset. After the smoke's closing `stop`,
 a further `start` brings the Linux vdev back up but the channel is never
 re-announced, so a second cycle can only ever end in `service_timeout`.
-That is why `-c` defaults to 1; running the smoke again needs a hardware
-reset or power cycle, not a `stop`/`start`. A soft `reboot` of Linux does
-*not* reset the realtime core.
+That is why `-c` defaults to 1: what a second run needs is a reset of the
+realtime core, and a `stop`/`start` is not one (see the first bullet under
+Notes). It does **not** need physical access, though — a plain `reboot`
+from Linux is enough. Linux issues PSCI `SYSTEM_RESET`, the firmware
+implements it as a graceful cold reset, and the CR52 restarts and re-loads
+its flashed payload along with the APU; that was observed on every warm
+reboot from both Yocto and AutoSD. See
+[selfboot.md](selfboot.md#reset-behaviour-and-what-restarts-the-realtime-core).
 
 ## Notes
 

--- a/platforms/autosd/x5h/scripts/make-ufs-rootfs.sh
+++ b/platforms/autosd/x5h/scripts/make-ufs-rootfs.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# make-ufs-rootfs.sh — derive a dd-able ext4 rootfs image from the aib CI tar.
+# Same reassembly the CI gate uses: xattrs must survive (capabilities,
+# selinux labels), so plain `tar xf` is wrong here.
+#
+# The aib tar does NOT contain the rebuilt kernel's modules -- CI ships those
+# as a separate modules-<release>.tar and injects them into the ext4 export as
+# its own step. An image without them boots (ext4 and the essential drivers
+# are built in) but silently loses everything modular: btrfs, so the container
+# store cannot mount; overlay, so podman falls back; and rpmsg_client_sample,
+# so the CR52 smoke fails. So this script injects them too, defaulting to the
+# modules tar sitting next to the rootfs tar -- which is how they arrive when
+# you download a CI run's bundle.
+#
+# Usage: make-ufs-rootfs.sh <x5h-rootfs.tar> <out.ext4> [size (default 6G)]
+#   X5H_MODULES_TAR=<path>  override module tar autodetection
+#   X5H_MODULES_TAR=none    build without modules (QEMU gate parity only)
+set -euo pipefail
+tar_in=$1 out=$2 size=${3:-6G}
+[ -s "$tar_in" ] || { echo "FATAL: tar not found: $tar_in" >&2; exit 1; }
+
+mod_tar=${X5H_MODULES_TAR:-$(ls "$(dirname "$tar_in")"/modules-*.tar 2>/dev/null | head -1 || true)}
+if [ "$mod_tar" = none ]; then
+  mod_tar=
+elif [ -z "$mod_tar" ]; then
+  echo "FATAL: no modules-*.tar beside $tar_in; pass X5H_MODULES_TAR=<path>," >&2
+  echo "       or X5H_MODULES_TAR=none to deliberately build without modules." >&2
+  exit 1
+elif [ ! -s "$mod_tar" ]; then
+  echo "FATAL: modules tar not found: $mod_tar" >&2; exit 1
+fi
+
+truncate -s "$size" "$out"
+# -F: a rerun leaves the previous superblock in the (same-size) file and
+# mkfs would stop to ask about it — this script must run unattended.
+mkfs.ext4 -q -F -L x5h-root "$out"
+mnt=$(mktemp -d)
+trap 'sudo umount "$mnt" 2>/dev/null || true; rmdir "$mnt"' EXIT
+sudo mount -o loop "$out" "$mnt"
+sudo tar --xattrs --xattrs-include='*.*' -xf "$tar_in" -C "$mnt"
+if [ -n "$mod_tar" ]; then
+  # The modules tar roots at lib/modules/...; extract under /usr so it lands
+  # in /usr/lib/modules without depending on the /lib -> usr/lib symlink.
+  sudo tar -xf "$mod_tar" -C "$mnt/usr"
+  echo "MODULES_INJECTED $(basename "$mod_tar")"
+fi
+sudo test -x "$mnt/usr/bin/podman" || { echo "FATAL: podman missing in image" >&2; exit 1; }
+sudo test -x "$mnt/usr/sbin/sshd" || { echo "FATAL: sshd missing in image" >&2; exit 1; }
+if [ -n "$mod_tar" ]; then
+  sudo test -e "$mnt/usr/lib/modules/$(basename "$mod_tar" .tar | sed 's/^modules-//')/kernel/fs/btrfs/btrfs.ko" \
+    || { echo "FATAL: btrfs.ko missing after module injection" >&2; exit 1; }
+fi
+sudo umount "$mnt"
+echo "MAKE_UFS_ROOTFS_OK $out"

--- a/platforms/autosd/x5h/scripts/selfboot-smoke.sh
+++ b/platforms/autosd/x5h/scripts/selfboot-smoke.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# selfboot-smoke.sh — board-side proof the UFS self-boot is the real thing.
+#
+# Run this after the board has come up on its own (no host TFTP/NFS in the
+# path) to confirm that what booted is the UFS rootfs, that the pieces baked
+# into the image are present and active, and that the CR52 round trip still
+# works. Markers: SELFBOOT_SMOKE_PASS / SELFBOOT_SMOKE_FAIL reason=<...>
+set -u
+
+ROOT_PARTUUID=7c94f5e2-9e2b-4c31-8f0a-1a2b3c4d5e02
+STORE_PARTUUID=7c94f5e2-9e2b-4c31-8f0a-1a2b3c4d5e03
+
+fail() { echo "SELFBOOT_SMOKE_FAIL reason=$1"; exit 1; }
+
+# --- root identity -----------------------------------------------------
+# UFS device letters move between boots, so /dev/sdX says nothing about
+# which partition we are on. Resolve the mounted root back to its PARTUUID
+# and compare against the one the bootargs asked for; that is the only
+# check that actually proves we booted the intended partition.
+rootsrc=$(findmnt -n -o SOURCE /) || fail nofindmnt
+case "$rootsrc" in
+  *nfs*|*:/*) fail "root_is_nfs src=$rootsrc" ;;
+esac
+rootuuid=$(blkid -s PARTUUID -o value "$rootsrc" 2>/dev/null)
+[ "$rootuuid" = "$ROOT_PARTUUID" ] || fail "root_partuuid=${rootuuid:-unknown} src=$rootsrc"
+
+# --- content baked by the aib manifest ---------------------------------
+command -v mkfs.ext4 >/dev/null || fail e2fsprogs_missing
+test -f /etc/ssh/sshd_config.d/50-x5h.conf || fail sshd_dropin_missing
+test -f /etc/ssh/authorized_keys.d/root || fail authorized_keys_missing
+test -f /etc/modprobe.d/x5h-rpmsg-diag.conf || fail rpmsg_blacklist_missing
+systemctl is-active sshd >/dev/null 2>&1 || fail sshd_inactive
+
+# --- container runtime + its store -------------------------------------
+podman info >/dev/null 2>&1 || fail podman
+if mountpoint -q /var/lib/containers; then
+  storeuuid=$(blkid -s PARTUUID -o value "$(findmnt -n -o SOURCE /var/lib/containers)" 2>/dev/null)
+  [ "$storeuuid" = "$STORE_PARTUUID" ] || echo "SELFBOOT_NOTE containers-store partuuid=$storeuuid (expected $STORE_PARTUUID)"
+else
+  echo "SELFBOOT_NOTE containers-store not mounted"
+fi
+
+# --- CR52 round trip ---------------------------------------------------
+sh /usr/local/bin/rpmsg-smoke.sh -f rpmsg-echo-cr52.elf -s rpmsg-client-sample -n 100 || fail rpmsg
+
+echo "SELFBOOT_SMOKE_PASS root=$rootsrc partuuid=$rootuuid"

--- a/platforms/autosd/x5h/selfboot.md
+++ b/platforms/autosd/x5h/selfboot.md
@@ -1,0 +1,352 @@
+# X5H UFS self-boot: unattended AutoSD from onboard storage
+
+Boots AutoSD on the X5H from the board's own UFS storage, with no TFTP
+server and no NFS root in the path. Power the board on and it reaches a
+login prompt by itself.
+
+Until this, the board netbooted: U-Boot pulled the kernel over TFTP and the
+kernel mounted its root over NFS from a specific host on the bench LAN. That
+makes the board unusable without that host, and unusable remotely. Self-boot
+removes both dependencies; the netboot paths are kept as named rescue
+commands rather than deleted.
+
+## Status on real hardware
+
+Validated on the board on 2026-08-07 on the rebuilt `6.1.102-autosd`
+kernel. Root is the UFS partition, with no NFS mount anywhere, and the
+board reaches its login prompt unattended:
+
+```
+findmnt -n -o SOURCE,FSTYPE /   → /dev/sdc2 ext4
+blkid -s PARTUUID …             → 7c94f5e2-9e2b-4c31-8f0a-1a2b3c4d5e02
+mount | grep -c nfs             → 0
+nproc                           → 32
+```
+
+## Storage layout
+
+The board exposes several UFS logical units. Two of them are 32 GiB and
+look alike; the one this layout uses is the one carrying the
+`autosd-store` partition label. **Address disks by `/dev/disk/by-path/`
+and partitions by partlabel or PARTUUID** — the `/dev/sdX` letters are
+assigned in probe order and move between boots, so a device letter that
+was right last boot can name a different LUN this boot.
+
+The data LUN is partitioned as:
+
+| # | partlabel | size | fs | PARTUUID | contents |
+|---|---|---|---|---|---|
+| 1 | `x5h-boot` | 1 GiB | ext4 | `7c94f5e2-9e2b-4c31-8f0a-1a2b3c4d5e01` | `Image-autosd`, dtb, `selfboot-env.txt` |
+| 2 | `x5h-root` | 12 GiB | ext4 | `7c94f5e2-9e2b-4c31-8f0a-1a2b3c4d5e02` | AutoSD rootfs |
+| 3 | `autosd-store` | rest | btrfs | `7c94f5e2-9e2b-4c31-8f0a-1a2b3c4d5e03` | `/var/lib/containers` |
+
+The PARTUUIDs are fixed constants, not generated. They appear in three
+places that must agree: the partition table, `bootargs_autosd_ufs`, and
+`selfboot-smoke.sh`. Changing one means changing all three.
+
+`/var/lib/containers` is a separate partition because the container store
+is the one thing on the board that grows without bound, and keeping it off
+the root filesystem means filling it cannot make the system unbootable. It
+is mounted `nofail` so a damaged store still yields a usable shell.
+
+## Boot flow
+
+`bootcmd` runs `bootcmd_autosd_ufs`, which is:
+
+```
+ufs init; scsi rescan;
+ext4load scsi 2:1 ${kernel_addr_r} Image-autosd;
+ext4load scsi 2:1 ${fdt_addr_r} r8a78000-ironhide-uio-autosd.dtb;
+setenv bootargs ${bootargs_autosd_ufs};
+booti ${kernel_addr_r} - ${fdt_addr_r}
+```
+
+`ufs init` brings up both UFS controllers and `scsi rescan` enumerates
+their logical units; without both, no `scsi` device exists to load from.
+
+The kernel finds its root by PARTUUID, so `bootargs` never names a
+`/dev/sdX`:
+
+```
+root=PARTUUID=7c94f5e2-9e2b-4c31-8f0a-1a2b3c4d5e02 rootwait rw
+```
+
+`rootwait` matters: UFS probing is not complete when the kernel first
+looks for the root device.
+
+### About that `scsi 2:1`
+
+This U-Boot has **no `part` command**, so there is no way to list
+partitions across devices and pick the right one programmatically. The
+index is confirmed by looking at the contents instead:
+
+```
+=> ext4ls scsi 2:1 /
+```
+
+The correct device lists `Image-autosd` and the dtb. On this board the
+neighbouring index is a different 32 GiB LUN holding unrelated data, and
+it is immediately obvious which is which from the file listing. Re-check
+this after any change to the storage complement rather than trusting the
+number.
+
+## Installing or reinstalling the environment
+
+The multi-command values contain semicolons. If you are driving U-Boot
+over a serial console through `tmux`, **semicolons do not survive
+`send-keys`** — they are consumed as tmux's own command separator. So the
+environment is delivered as a file and imported, never typed:
+
+```
+=> ufs init
+=> scsi rescan
+=> ext4load scsi 2:1 ${loadaddr} selfboot-env.txt
+=> env import -t ${loadaddr} ${filesize}
+=> saveenv
+```
+
+`selfboot-env.txt` (in `uboot/`) is kept on the boot partition rather than
+served over TFTP, so restoring the boot environment needs no host at all —
+which is the point of a self-booting board. Copy it to p1 whenever you
+update it:
+
+```
+mount /dev/disk/by-partlabel/x5h-boot /mnt
+cp selfboot-env.txt /mnt/ && umount /mnt
+```
+
+## Rescue paths
+
+Both netboot commands are preserved and still work; they need the bench
+host's TFTP and NFS services.
+
+```
+=> run bootcmd_yocto     # BSP Yocto reference boot (the original default)
+=> run bootcmd_autosd    # AutoSD on NFS root
+```
+
+To make netboot the default again:
+
+```
+=> setenv bootcmd run bootcmd_yocto
+=> saveenv
+```
+
+and to return to self-boot:
+
+```
+=> setenv bootcmd run bootcmd_autosd_ufs
+=> saveenv
+```
+
+Catching the U-Boot prompt on a warm reboot needs an Enter roughly every
+80 ms — the countdown is about 2.5 s and a slower cadence misses it.
+
+## Populating the partitions
+
+The rootfs written to p2 is the **same tar the CI pipeline builds and the
+QEMU gate validates**, reassembled into a filesystem image:
+
+```
+scripts/make-ufs-rootfs.sh x5h-rootfs.tar x5h-rootfs.ext4 [size]
+dd if=x5h-rootfs.ext4 of=/dev/disk/by-partlabel/x5h-root bs=4M conv=fsync
+```
+
+The reassembly must preserve extended attributes — file capabilities and
+SELinux labels live there, and a plain `tar xf` silently drops them,
+producing an image that boots but misbehaves. `make-ufs-rootfs.sh` uses
+the same xattr-preserving recipe as the gate. Verify a built image without
+mounting it:
+
+```
+debugfs -R "ea_list /usr/bin/newgidmap" x5h-rootfs.ext4
+# expect security.selinux and security.capability
+```
+
+**The rootfs tar contains no kernel modules.** The rebuilt kernel's modules
+are a separate `modules-<release>.tar` in the same CI bundle, and they have
+to be unpacked into the image too — `make-ufs-rootfs.sh` picks up the one
+sitting beside the rootfs tar automatically.
+
+An image without them still boots, because ext4 and the essential drivers
+are built in, so the mistake is silent. What breaks is everything modular:
+`btrfs` (the container store will not mount, even though `mkfs.btrfs`
+succeeded — mkfs is userspace and the mount is not), `overlay` (podman
+storage), and `rpmsg_client_sample` (the CR52 smoke). If a freshly written
+board is missing modules, note that the image cannot be patched in place:
+this rootfs ships no `tar`, only `cpio` and `gzip`. Rebuild the image
+instead.
+
+### Why a script instead of a CI artifact
+
+The spec listed a raw image as a CI deliverable; it is derived on the host
+instead. The recipe is byte-for-byte the one CI already runs for the gate,
+so the result is the same bytes CI validated, and publishing a multi-GiB
+mostly-empty filesystem image from CI would only re-encode the tar that is
+already the artifact.
+
+Note the image is smaller than the partition, so grow the filesystem after
+writing it:
+
+```
+resize2fs /dev/disk/by-partlabel/x5h-root
+```
+
+`e2fsprogs` is installed in the image for exactly this reason — it is not
+in the AutoSD base package set.
+
+### The boot partition
+
+**Use the board kernel, not the CI kernel.** The kernel is built twice from
+one source: the CI/QEMU-gate image with `CONFIG_EXTRA_FIRMWARE=""`, and the
+board image that additionally embeds the MP-PHY firmware blob. That blob
+comes from the vendor SDK, so CI cannot produce the board image — *both*
+artifacts a CI run publishes are the gate variant.
+
+Booting the gate kernel on the board leaves the TSN interface entirely
+absent: no `tsn5`, no network, no SSH. The symptom looks like a
+configuration problem and is not.
+
+Take `Image-autosd` from the locally built board kernel (the one the TFTP
+netboot serves, built with `--firmware`). The dtb is identical in both. The
+two builds share source SHA, toolchain and fragments — the only permitted
+config delta is the `CONFIG_EXTRA_FIRMWARE` pair — so the modules from a CI
+run pair correctly with the board kernel.
+
+The boot partition can be built without root using `mkfs.ext4 -d`, which
+populates an image from a directory with no loop mount:
+
+```
+mkfs.ext4 -q -F -L x5h-boot -d <dir-with-kernel-dtb-env> x5h-boot.ext4
+```
+
+### First boot
+
+Format the container store once:
+
+```
+mkfs.btrfs -f -L autosd-store /dev/disk/by-partlabel/autosd-store
+```
+
+**Mount it with an explicit unit, not `/etc/fstab`.** On this image
+systemd's fstab generator does not run at boot — `/run/systemd/generator/`
+comes up with no mount units, even though invoking
+`/usr/lib/systemd/system-generators/systemd-fstab-generator` by hand
+parses the very same `/etc/fstab` and emits a correct unit. A `nofail`
+entry therefore fails *silently*: no mount, no error, and podman quietly
+uses the root filesystem instead.
+
+Write `/etc/systemd/system/var-lib-containers.mount` (the filename must
+match the mount point) and enable it:
+
+```
+[Unit]
+Description=X5H container store (UFS partition autosd-store)
+After=local-fs-pre.target
+DefaultDependencies=no
+
+[Mount]
+What=/dev/disk/by-partuuid/7c94f5e2-9e2b-4c31-8f0a-1a2b3c4d5e03
+Where=/var/lib/containers
+Type=btrfs
+Options=defaults,nofail
+
+[Install]
+WantedBy=local-fs.target
+```
+
+```
+systemctl daemon-reload && systemctl enable --now var-lib-containers.mount
+```
+
+### Enabling sshd
+
+The `enable sshd.service` preset in the image is **not** applied at build
+time — osbuild never runs `systemctl preset`, so nothing links the unit
+into `multi-user.target`. Create the symlink explicitly when staging the
+image, or sshd will not start and the board will have no remote access:
+
+```
+ln -sf /usr/lib/systemd/system/sshd.service \
+       <mnt>/etc/systemd/system/multi-user.target.wants/sshd.service
+```
+
+The sshd drop-in is key-only, and `config/x5h-authorized-keys` ships with no
+key in it, so a freshly built image has no way in over the network. Put your
+own public key there before building, or append it to
+`<mnt>/etc/ssh/authorized_keys.d/root` while staging; the root password
+remains a serial-console credential either way.
+
+### A podman gotcha after adding modules
+
+containers/storage caches the result of its overlay-support probe. If
+podman ever ran while `overlay.ko` was missing, it keeps reporting
+`kernel does not support overlay fs` even after the module is installed
+and loaded — the debug log gives it away with "Cached value indicated that
+overlay is not supported". The cache lives in the tmpfs runroot, so a
+reboot clears it.
+
+`btrfs-progs` is in the image but **not** in the BSP Yocto rootfs, so do
+this from AutoSD. Conversely `mkfs.ext4` and `resize2fs` are in the Yocto
+rootfs and were missing from AutoSD before `e2fsprogs` was added. The two
+systems have complementary tooling; check before assuming a tool is there.
+
+### A trap when staging files into the image
+
+The rootfs is ostree-structured and ships `/usr/local` as a symlink to
+`../var/usrlocal`, while `/var` in a freshly written image is empty. So
+installing into `<mnt>/usr/local/bin/` fails until the target exists:
+
+```
+mkdir -p <mnt>/var/usrlocal/bin <mnt>/var/lib/containers
+```
+
+## Verifying a self-boot
+
+```
+sh /usr/local/bin/selfboot-smoke.sh
+```
+
+Expect `SELFBOOT_SMOKE_PASS root=… partuuid=…`. The script resolves the
+mounted root back to its PARTUUID rather than trusting `/dev/sdX`, rejects
+an NFS root outright, checks the pieces baked into the image, confirms
+`sshd` is running and `podman` works, and finishes with the CR52 RPMsg
+round trip. Anything else prints `SELFBOOT_SMOKE_FAIL reason=<what>`.
+
+Run it over SSH rather than the serial console when you want to prove the
+remote path works too.
+
+## Reset behaviour, and what restarts the realtime core
+
+A plain `reboot` from Linux is a **full SoC reset**, not just an APU
+restart. Linux issues PSCI `SYSTEM_RESET`, and the firmware implements it
+as a cold reset — the realtime console prints
+
+```
+SM: I [system_notification:101] PSCI (BL31) has transited to graceful coldreset with timeout 0 ms
+```
+
+and the CR52 restarts and re-loads its flashed payload. Observed on every
+warm reboot from both Yocto and AutoSD.
+
+This matters in two directions:
+
+- **It is the remote reset mechanism.** Restarting the realtime core needs
+  no switch, no power cycle and no serial access — `ssh root@<board>
+  reboot` is enough, and because `bootcmd` now self-boots, the board comes
+  back on its own with a fresh realtime payload. See
+  [cr52-slot-update.md](cr52-slot-update.md).
+- **A warm reboot is not a way to keep the realtime core running.** If you
+  need the CR52 to survive, do not reboot Linux.
+
+Earlier notes in this repo claimed a soft reboot does not reset the
+realtime core and that a physical switch was required. That is wrong and
+has been retired; it was measured four times across both operating
+systems, plus the reset used in each slot-update cycle.
+
+## Related
+
+- [CR52 dual boot + RPMsg](rpmsg-dualboot.md) — the realtime payload and
+  the RPMsg round trip the smoke script exercises.
+- [CR52 slot update](cr52-slot-update.md) — updating the realtime
+  firmware from Linux, which self-boot makes remotely reachable.

--- a/platforms/autosd/x5h/uboot/selfboot-env.txt
+++ b/platforms/autosd/x5h/uboot/selfboot-env.txt
@@ -1,0 +1,3 @@
+bootcmd_yocto=tftp 0x9e680000 Image && tftp 0x9e600000 r8a78000-ironhide-uio.dtb && booti 0x9e680000 - 0x9e600000
+bootargs_autosd_ufs=pd_ignore_unused clk_ignore_unused root=PARTUUID=7c94f5e2-9e2b-4c31-8f0a-1a2b3c4d5e02 rootwait rw ip=192.168.0.20::192.168.0.1:255.255.255.0:autosd-x5h:tsn5:none enforcing=0
+bootcmd_autosd_ufs=ufs init; scsi rescan; ext4load scsi 2:1 ${kernel_addr_r} Image-autosd; ext4load scsi 2:1 ${fdt_addr_r} r8a78000-ironhide-uio-autosd.dtb; setenv bootargs ${bootargs_autosd_ufs}; booti ${kernel_addr_r} - ${fdt_addr_r}


### PR DESCRIPTION
Converts the X5H from host-tethered netboot to unattended UFS self-boot, and makes the realtime firmware updatable from Linux — which together turn a board that needed someone in the room into one that can be driven remotely.

Stacked on #123 (CR52 dual boot + RPMsg), which is stacked on #122 and #121. Review the parent PRs first; this one's diff is only the self-boot delta.

## What changes

The board's 32 GiB UFS data LUN is repartitioned into a boot partition (kernel + dtb + the U-Boot env payload), a 12 GiB root, and a btrfs container store, addressed by fixed PARTUUIDs everywhere so the partition table, the kernel command line and the verification script cannot drift apart. U-Boot gains `bootcmd_autosd_ufs` and it becomes the default `bootcmd`; both netboots are preserved as named rescue commands (`bootcmd_yocto`, `bootcmd_autosd`) rather than replaced. The rootfs stays exactly the tar the image pipeline builds and the QEMU gate validates — `make-ufs-rootfs.sh` reassembles it into a dd-able filesystem using the same xattr-preserving recipe, so the bytes on the board are the bytes the gate checked.

## Verified on hardware, 2026-08-07

| verdict | meaning |
|---|---|
| `COLDBOOT_PASS boot=unattended smoke=ssh` | SW7 off → on, hands off; U-Boot's countdown expires untouched, kernel and dtb load from UFS, and the board is verified over SSH — not the serial console |
| `SELFBOOT_SMOKE_PASS root=/dev/sdc2 partuuid=…5e02` | root is the UFS partition, zero NFS mounts, baked config present, sshd active, podman up, CR52 RPMsg round trip green |
| `SOFTRESET_PASS method=warm-reboot runs=2` | a plain `reboot` restarts the realtime core too |
| `SLOT_WRITE_IDENT_PASS` / `SLOT_SWAP_PASS sequence=A,B,A` | realtime firmware written from Linux, swapped, and restored, with read-back verification at each step |

The end-to-end remote loop is proven: `ssh root@<board> reboot` returns a fully reset board — application cores *and* realtime core — in about 65 seconds, with no serial interaction and nobody at the bench.

## The reset finding

A plain Linux `reboot` is not just an APU restart. Linux issues PSCI `SYSTEM_RESET`, the firmware performs it as a cold reset, and the realtime core restarts and re-loads its flashed payload. The RT console says so explicitly (`PSCI (BL31) has transited to graceful coldreset`), and it held 4/4 times across both operating systems. This **retires the earlier claim in this repository** that a soft reboot does not reset the realtime core and that a physical switch is required — that note was wrong, and it was the thing making remote realtime work look impossible. Usefully, the same log line also distinguishes a warm reboot from a true power cycle after the fact, since a cold power-on has nothing for the firmware to announce.

## Defects this branch fixes

- **No SSH server in the image.** The rootfs baked a key-only sshd drop-in, an `authorized_keys` file and an `enable sshd.service` preset, but nothing ever installed `openssh-server` — three pieces of configuration for a service that could not exist. The pre-existing netboot rootfs has the same gap, which is why it went unnoticed.
- **The rootfs image shipped with no kernel modules.** The aib tar carries none for the rebuilt kernel; the pipeline ships `modules-<release>.tar` in a separate step that the host-side derivation never replicated. The image still boots, so the omission is silent — but btrfs, overlay and `rpmsg_client_sample` are all modular, so the container store could not mount (despite `mkfs.btrfs` succeeding — mkfs is userspace, the mount is not), podman storage would fall back, and the CR52 smoke would fail. `make-ufs-rootfs.sh` now injects them and refuses to emit an image missing podman, sshd or `btrfs.ko`.
- **`e2fsprogs` was missing** from the board image, so the filesystem could not be grown or checked on the board.

Two more were found that are documented rather than patched, because they are properties of the base image: the `enable sshd.service` preset is never applied at build time (osbuild does not run `systemctl preset`), so the unit symlink must be created explicitly when staging; and `/etc/fstab` is not honoured at boot at all — systemd's fstab generator emits nothing, though invoking it by hand parses the same file correctly — so a `nofail` entry fails silently and the container store needs an explicit `.mount` unit.

## SSH access is opt-in

The sshd drop-in is key-only — the dev root password stays a serial-console-only credential — and `config/x5h-authorized-keys` ships with no key in it. Whoever builds the image puts their own public key there before building, or appends it to `/etc/ssh/authorized_keys.d/root` while staging the rootfs; `selfboot.md` says so next to the sshd-enable step. An image built as-is has no network way in, by design.

## Docs

`selfboot.md` covers the layout, boot flow, rescue paths, env restore, how to build and populate the partitions, and the reset semantics. `cr52-slot-update.md` is the vendor-blob-free procedure for rewriting the realtime firmware from Linux instead of the vendor serial-download tool. `companion-host.md` is the bench-gateway runbook, and as of 2026-08-10 it is a record rather than a plan: the procedure has been run end to end on a companion host, and every place where reality differed from the draft is corrected in place with the reason kept next to the command. Vendor-specific values stay out of this repository, as everywhere else on this platform.

## Companion host, executed 2026-08-10

The bench now has an always-on gateway. It owns `192.168.0.1` — the address the board's kernel command line already names as its gateway, so nothing on the board changed when the cables moved — routes a tailnet into the bench LAN, serves the netboot rescue paths, holds the serial consoles, and scopes who can reach what.

| verdict | meaning |
|---|---|
| `COMPANION_REBOOT_PASS` | rebooted and came back serving everything, verified from a different tailnet node: bench address held, both NFS exports listed, tftpd listening, all three services active |
| `ACL_ADMIN_OK` | administrators reach the gateway and the board's SSH port through the subnet route |
| `RESCUE_NETBOOT_YOCTO_PASS` | booted with root on `192.168.0.1:/export/rfs` over NFSv3, kernel and dtb pulled from the companion by TFTP |
| `RESCUE_NETBOOT_AUTOSD_PASS` | same for `/export/rfs-autosd`; neither path writes the U-Boot environment, so the board returns to UFS self-boot on the next reset with nothing to undo |
| `NEGATIVE_ACCESS_PASS` | from a real external-tier node: the board's sshd answers, and the board's other ports, the companion's SSH and the companion's NFS are all refused |
| `REMOTE_REHEARSAL_PASS` | smoke, remote reset, smoke — two boots, off-bench, over the tailnet only, board back in 31 s |

## What the companion runbook got wrong

The draft was written without hardware, and three of its gaps would each have stopped the bench from working at all.

**Subnet routes are not accepted by default on Linux.** Every consuming node needs `tailscale set --accept-routes`; without it the node never installs the advertised `192.168.0.0/24` and sends bench traffic to its own default gateway instead. The board is simply unreachable, and because nothing on the gateway or in the policy looks wrong, the symptom reads as a firewall or ACL fault for as long as you let it.

**`rpc.mountd` was neither pinned nor opened.** The rescue netboot mounts with `nfsvers=3`, so opening 69, 111 and 2049 is not enough, and mountd's default port is random so there is nothing stable to open. Both rescue paths would have failed at the mount. The fix is confirmed by the mount options on the booted rescue root: `mountvers=3`, `mountproto=tcp`.

**The access-tier policy would have locked the administrator out.** It named an identity that does not exist in a GitHub-backed tailnet, and because a policy file replaces the tailnet's defaults rather than adding to them, its admin rule — scoped to the gateway and the bench subnet — removes reachability to every other machine the administrator owns. The admin grant has to be `dst: ["*"]`.

Also corrected: `flush ruleset` destroys the iptables-nft tables Docker installs, and a drop policy in one `inet` table vetoes packets another table accepted; tftpd needs `--secure`, mode 644 payloads, and must keep listening on `:69` rather than the bench address, which does not exist while the board is powered off; NetworkManager's autoconnect priority has to be computed from the profiles actually present or the wrong profile wins a carrier event and U-Boot fails with ARP retries; Ubuntu 24.04 socket-activates sshd, so `systemctl reload ssh` is a no-op and a bare `sshd -t` fails on the missing privilege separation directory, with a `&&` chain hiding both; and `selfboot-smoke.sh` passes once per boot, because the CR52 announces its RPMsg endpoint once per SoC reset, so verifications need a reset between them.

## Two failure modes found while executing

**Returning from a netboot rescue can leave the bench link unusable.** The board boots fine from UFS and its console is healthy, but the Ethernet switch driver times out waiting on a register, the PHY fails master/slave resolution, and its state machine halts. The trap is that the board then reports its interface up, with carrier and its address assigned, while being completely unreachable — nothing looks wrong from the board. Another reboot clears it, and since the network is what is broken, that reboot has to be issued over serial. This is the concrete reason the companion holds the consoles rather than merely sitting next to the board.

**A timeout is not evidence of a dead board.** A good reset answers again in about 30 seconds, but a link that fails to negotiate can leave the board silent for minutes and then recover unaided. Polling for 155 seconds and concluding failure already produced one wrong diagnosis. The earlier "about 65 seconds" figure is a typical value, not a bound.

Two smaller notes now in the runbook: the board's `tsn5` MAC address is randomised on every boot, so nothing may depend on a stable MAC; and the board has no RTC or NTP on the bench LAN, so its log timestamps are wrong by days and have to be correlated against the companion's clock.

## Remaining caveat

The board's current p2 had its kernel modules installed live over SSH rather than coming from a script-built image, because the operator was away at the time. The file content is identical and the script now asserts the result, but a clean re-dd from a script-built image would be tidier and is worth doing next session.
