### PR TITLE
feat(x5h): add the rpmsg-eth bridge for IP over RPMsg to the CR52

### DIFF
--- a/platforms/autosd/x5h/README.md
+++ b/platforms/autosd/x5h/README.md
@@ -23,7 +23,9 @@ answered before board time.
 
 - [CR52 dual boot + RPMsg](rpmsg-dualboot.md) — run FreeRTOS on the
   realtime core under AutoSD; remoteproc `start` publishes RPMsg state to
-  a CR52 that is already executing, it does not load or release it.
+  a CR52 that is already executing, it does not load or release it. Also
+  covers `rpmsg-eth`, the IP-over-RPMsg TAP bridge daemon (`rpmsg-eth/`)
+  that gives the CR52 a normal Ethernet link to Linux.
 - [UFS self-boot](selfboot.md) — boot AutoSD unattended from the board's
   own storage, with both netboots kept as named rescue commands; also the
   reset semantics, including why a warm `reboot` restarts the CR52.
@@ -48,6 +50,9 @@ answered before board time.
   only permitted config delta is the `CONFIG_EXTRA_FIRMWARE` pair (see "One
   build, two images")
 - `scripts/`: QEMU gate harness and board staging/smoke scripts
+- `rpmsg-eth/`: the IP-over-RPMsg TAP bridge daemon (source, Makefile, and
+  its own pty-mock unit test) — see [rpmsg-dualboot.md](rpmsg-dualboot.md)
+  for cross-compile, staging, prerequisites and smoke
 - `uboot/`: `bootcmd_autosd` template (site values are filled at session
   time, not committed), and `selfboot-env.txt` — the `env import -t` payload
   defining the UFS self-boot plus both netboot rescue commands
@@ -337,6 +342,8 @@ reused — GATE6 and GATE7 are new, not GATE5's successor under a new name.
 | `GATE7_SELINUX_BOOLS_OK` | `selinux-bools.service` did not fail. It failed under the BSP/retired-mimic kernel's absent SELinux (see the Troubleshooting row) — with SELinux present it must now come up clean. | yes |
 | `GATE7_SELINUX_BOOLS_FAILED` | `selinux-bools.service` failed even with SELinux present — a real regression, not the benign BSP-kernel failure the Troubleshooting row documents. | no |
 | `GATE7_SELINUX_BOOLS_ABSENT` | `selinux-bools.service`'s `LoadState` reads `not-found` — the unit is missing from this image entirely. Disambiguates from `GATE7_SELINUX_BOOLS_OK`: `systemctl is-failed` alone exits nonzero both for "healthy" and for "does not exist", so without this check a dropped unit could otherwise print `_OK`. | no |
+| `GATE_RPMSG_ETH_UNIT_PASS` | GATE8: the `rpmsg-eth` TAP bridge daemon's own unit test (`rpmsg-eth/test-rpmsg-eth.sh`) passed inside its dedicated Fedora test container — real tap0 on the guest kernel under test, a mock endpoint (socat pty), `--network=none`. Requires both a zero `podman run` exit status and a literal `TEST_PASS` in its output (see `gate-guest.sh`'s GATE8 comment for why exit-status-alone is not sufficient). | yes |
+| `GATE_RPMSG_ETH_UNIT_FAIL` | The `rpmsg-eth` unit test failed — either the container/build step itself failed, or `test-rpmsg-eth.sh` ran and reported a `TEST_FAIL`. Not part of the pass path. | no |
 | `GATE_DONE` | `gate-guest.sh` reached the end of its run. | yes |
 
 `qemu-gate.exp` exits 0 only if every "Required: yes" marker above is present

--- a/platforms/autosd/x5h/README.md
+++ b/platforms/autosd/x5h/README.md
@@ -481,7 +481,7 @@ disk, which is what `stage-nfs-rootfs.sh` consumes at board time.
 
 The replay needs three inputs: the rootfs tar, the rebuilt kernel's output
 directory (`Image-autosd`, `modules-6.1.102-autosd.tar` and
-`kernelrelease.txt` all come from it), and the two test-image tars. Build
+`kernelrelease.txt` all come from it), and the three test-image tars. Build
 them from source (below) or download a bundle CI already produced. **Neither
 route needs the NDA R-Car xOS SDK or any credential-gated download** — the
 rootfs resolves from public AutoSD 10 and EPEL 10 repos, the kernel builds
@@ -526,10 +526,11 @@ sudo bash ./auto-image-builder.sh build --tar \
 #    only (see "Board deployment" above), never to the gate.
 kernel/build-bsp-kernel.sh /tmp/x5h-kernel
 
-# 3. The two test images. make-test-images.sh also verifies the captest
+# 3. The three test images. make-test-images.sh also verifies the captest
 #    archive really carries a security.capability PAX record, so an xattr
 #    silently dropped at build time cannot reach the gate disguised as a
-#    GATE2 finding.
+#    GATE2 finding. The third, rpmsg-eth-docker.tar, carries the daemon
+#    source and its pty-mock unit test for GATE8 to run in-guest.
 scripts/make-test-images.sh /tmp/x5h-testimages
 ```
 
@@ -580,6 +581,7 @@ gh run download --repo youtalk/openadkit -n x5h-gate-bundle -D /tmp/x5h-bundle \
 #   Image-autosd  r8a78000-ironhide-uio-autosd.dtb  modules-6.1.102-autosd.tar
 #   kernelrelease.txt  config-autosd.txt  x5h-rootfs.tar  x5h-gate.log
 #   testimages/busybox-oci.tar  testimages/captest-docker.tar
+#   testimages/rpmsg-eth-docker.tar
 # There is no ext4 export in it: it is reproducible and large, so the replay
 # rebuilds it from the tar, the same way the CI workflow's own "Derive the
 # ext4 export from the tar" step does.
@@ -655,7 +657,7 @@ sudo umount "$mnt"
 rmdir "$mnt"
 
 # 2. Inject the test payload. Use the script, not a hand-copy: besides the
-#    two test tars and gate-guest.sh, it also neutralizes /etc/fstab
+#    three test tars and gate-guest.sh, it also neutralizes /etc/fstab
 #    (preserving the original as fstab.image) — skip that and the guest
 #    reboot-loops on the stock fstab's ESP entry (see Troubleshooting) —
 #    and now also extracts the rebuilt kernel's module tree from its third
@@ -718,7 +720,7 @@ board-safety invariants; do not reorder it.
 
 The two inputs come from wherever "Running locally" above got them — built from source, or
 unpacked from a CI bundle. The bundle is flat but not entirely flat: the tarball sits at the
-top level while the two test images sit one level down, under `testimages/`. Resolve both by
+top level while the three test images sit one level down, under `testimages/`. Resolve both by
 lookup rather than by assuming a fixed path:
 
 ```bash

--- a/platforms/autosd/x5h/aib/x5h-rootfs.aib.yml
+++ b/platforms/autosd/x5h/aib/x5h-rootfs.aib.yml
@@ -20,6 +20,19 @@ content:
     # a service that cannot exist. Board-verified 2026-08-07: no /usr/sbin/sshd
     # and no sshd.service unit in the built rootfs.
     - openssh-server
+    # rpmsg-eth-smoke.sh's only end-to-end assertion is an ICMP round trip to
+    # the CR52 side (172.16.52.2), and `ping` lives in iputils -- `iproute`
+    # above provides `ip`, not `ping`. Without this the smoke test can only
+    # report reason=no_ping, so the board gate would prove the tap is
+    # configured and never that IP actually round-trips over RPMsg.
+    #
+    # busybox is NOT a substitute even though a busybox OCI image is already
+    # staged on the board by stage-nfs-rootfs.sh: busybox prints
+    # "N packets transmitted, N packets received", while the smoke script's
+    # summary parser requires ", N received" (iputils' wording). Busybox would
+    # therefore produce a false reason=ping_loss -- precisely the misleading
+    # failure that parser was written to avoid.
+    - iputils
   # add_files (org.osbuild.copy) does not create parent directories, and
   # nothing else in the pipeline creates /etc/containers/containers.conf.d
   # (init_rootfs_dirs_stage creates /etc itself, but not this subtree).

--- a/platforms/autosd/x5h/config/cr52-remoteproc.service
+++ b/platforms/autosd/x5h/config/cr52-remoteproc.service
@@ -1,0 +1,40 @@
+# cr52-remoteproc.service -- publish the CR52's RPMsg vdev at boot.
+#
+# Neither the rpmsg module loads nor the `start` write survive a reboot, so
+# without this the CR52 link had to be brought up by hand after every boot (see
+# scripts/cr52-rproc-up.sh for what `start` actually does -- it parses the
+# resource table and publishes the vrings; it does NOT load the CR52 payload,
+# which already runs from its flashed UFS slot).
+#
+# Type=oneshot + RemainAfterExit=yes because this is a one-time state change, not
+# a daemon: the vdev stays published once it is up, and `systemctl status` should
+# keep reporting the result rather than going inactive immediately.
+#
+# Before=rpmsg-eth.service is an optimisation, not a requirement, and the
+# direction matters: the dependency is declared HERE rather than as an After= in
+# rpmsg-eth.service, so that unit keeps its reviewed start-order independence.
+# rpmsg-eth's own endpoint-wait loop retries and logs why it is waiting, so it
+# copes fine if this unit is absent, skipped, or slow -- ordering merely spares
+# it the wait. rpmsg-eth.service is also not part of the image (its daemon has to
+# be cross-compiled and staged), and Before= on a unit that does not exist is a
+# no-op, so this stays correct on an image where only this unit is installed.
+#
+# The modprobes live in modules-load.d rather than here (see
+# config/x5h-rpmsg-modules.conf) so that the module load is not tied to this
+# unit's success, and so `lsmod` is explainable without reading a unit file.
+[Unit]
+Description=Publish the CR52 RPMsg vdev (remoteproc start)
+Documentation=file:///usr/share/doc/x5h/rpmsg-dualboot.md
+After=systemd-modules-load.service
+Wants=systemd-modules-load.service
+Before=rpmsg-eth.service
+ConditionPathExists=/sys/class/remoteproc/remoteproc0
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=-/etc/default/cr52-remoteproc
+ExecStart=/usr/local/sbin/cr52-rproc-up.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/platforms/autosd/x5h/config/rpmsg-eth.service
+++ b/platforms/autosd/x5h/config/rpmsg-eth.service
@@ -28,7 +28,11 @@
 Description=RPMsg-to-TAP Ethernet bridge (CR52 link)
 
 [Service]
-ExecStartPre=/usr/local/sbin/rpmsg-eth-ifup.sh
+# tap0 appears in both lines below on purpose, not by accident: it is
+# passed as $1 to rpmsg-eth-ifup.sh so the interface name lives in one
+# place (this unit file) instead of also being hardcoded inside the ifup
+# script independently of what ExecStart actually binds to.
+ExecStartPre=/usr/local/sbin/rpmsg-eth-ifup.sh tap0
 ExecStart=/usr/local/bin/rpmsg-eth -s rpmsg-eth -t tap0
 Restart=on-failure
 RestartSec=1

--- a/platforms/autosd/x5h/config/rpmsg-eth.service
+++ b/platforms/autosd/x5h/config/rpmsg-eth.service
@@ -26,6 +26,23 @@
 #   systemctl enable --now rpmsg-eth.service
 [Unit]
 Description=RPMsg-to-TAP Ethernet bridge (CR52 link)
+# StartLimitIntervalSec=0 disables systemd's default start-rate limit (5
+# starts within a 10s window) outright, rather than leaving it in effect
+# or merely resizing it. Without an explicit override here, that default
+# would apply: the deadline path added to rpmsg-eth.c takes >=
+# RPMSG_ETH_EPT_PROGRESS_TIMEOUT_S (>= 10s, default 10) per failed cycle,
+# so one restart every 10s+ never trips a 5-in-10s limit today -- but that
+# headroom is an artifact of *that one* fatal path's timing, not a
+# guarantee covering every fatal path this daemon has (e.g. a fast
+# tap_open() failure right after RestartSec=1). Hitting the default limit
+# puts the unit in a permanent "failed" state that Restart= no longer
+# acts on at all -- systemd reporting the unit stopped while the link is
+# dead, the exact inverse of the "active (running) while the link is
+# dead" problem this daemon's deadline/exit-code work exists to fix.
+# Disabled outright rather than sized to a specific burst/interval: this
+# daemon already retries indefinitely by design elsewhere (open_endpoint()),
+# and Restart=on-failure here is meant to have that same no-give-up shape.
+StartLimitIntervalSec=0
 
 [Service]
 # tap0 appears in both lines below on purpose, not by accident: it is

--- a/platforms/autosd/x5h/config/rpmsg-eth.service
+++ b/platforms/autosd/x5h/config/rpmsg-eth.service
@@ -1,0 +1,37 @@
+# rpmsg-eth.service -- bridges the CR52's rpmsg-eth endpoint to a Linux TAP
+# device (tap0), giving the safety island a normal IP link to the A-core
+# side (see platforms/autosd/x5h/rpmsg-eth/rpmsg-eth.c).
+#
+# Plain host unit, not a Quadlet container: the daemon needs direct access
+# to /dev/net/tun, the CR52's /dev/rpmsg_ctrl*/rpmsg<N> chardevs, and the
+# sysfs rpmsg bus (/sys/bus/rpmsg/devices) to discover its endpoint --
+# containerising it would mean punching all three through the container's
+# device cgroup for zero isolation benefit, since this process's entire job
+# IS to bridge two host-level network primitives. The DDS peers that sit on
+# top of this link (domain 2) are containers; this unit is the link-layer
+# plumbing underneath them, deliberately kept off the container path.
+#
+# No After=/Wants= on a specific rpmsg device unit: the daemon's own
+# open_endpoint() retry loop (rpmsg-eth.c) already waits for the CR52's
+# endpoint to appear via inotify on /dev, so an ordering dependency here
+# would be redundant, not load-bearing.
+#
+# Not installed by aib/x5h-rootfs.aib.yml today -- see rpmsg-dualboot.md for
+# the same manual install-to-/usr/local pattern already used for
+# rpmsg-ping/rpmsg-smoke.sh. Install alongside the daemon binary and this
+# unit's ifup helper:
+#   install -m0755 rpmsg-eth /usr/local/bin/rpmsg-eth
+#   install -m0755 rpmsg-eth-ifup.sh /usr/local/sbin/rpmsg-eth-ifup.sh
+#   install -m0644 rpmsg-eth.service /etc/systemd/system/rpmsg-eth.service
+#   systemctl enable --now rpmsg-eth.service
+[Unit]
+Description=RPMsg-to-TAP Ethernet bridge (CR52 link)
+
+[Service]
+ExecStartPre=/usr/local/sbin/rpmsg-eth-ifup.sh
+ExecStart=/usr/local/bin/rpmsg-eth -s rpmsg-eth -t tap0
+Restart=on-failure
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target

--- a/platforms/autosd/x5h/config/x5h-rpmsg-modules.conf
+++ b/platforms/autosd/x5h/config/x5h-rpmsg-modules.conf
@@ -1,0 +1,17 @@
+# Load the RPMsg character-device stack at boot.
+#
+# Neither module is autoloaded on this platform: nothing probes them until a
+# channel is announced, and the announcement cannot be seen until the vdev is
+# published -- which needs rpmsg_ctrl/rpmsg_char already present. Without this
+# file the two modprobes had to be repeated by hand after every reboot before
+# the CR52 link would come up.
+#
+# rpmsg_ctrl pulls in rpmsg_char as a dependency, but both are listed so that
+# `lsmod` matching this file is obvious to a reader, and so a future kernel that
+# splits the dependency does not silently drop rpmsg_char.
+#
+# Note this is deliberately NOT the same file as modprobe.d/x5h-rpmsg-diag.conf,
+# which blacklists rpmsg_client_sample to stop it stealing the CR52's channel.
+# That one controls what must never load; this one controls what must.
+rpmsg_ctrl
+rpmsg_char

--- a/platforms/autosd/x5h/rpmsg-dualboot.md
+++ b/platforms/autosd/x5h/rpmsg-dualboot.md
@@ -204,3 +204,96 @@ reboot from both Yocto and AutoSD. See
 - Recovery from any wedge: power cycle. This procedure modifies no boot
   path and writes no flash; the only persistent state it creates is the
   staged files and the blacklist on the target rootfs.
+
+## rpmsg-eth: IP-over-RPMsg bridge
+
+`rpmsg-eth/` (source `rpmsg-eth.c`, `Makefile`, `test-rpmsg-eth.sh`) bridges
+the CR52's `rpmsg-eth` rpmsg channel to a Linux TAP device (`tap0`), one
+Ethernet frame per RPMsg message in both directions — a normal IP link to
+the safety island, on top of the same remoteproc/RPMsg stack described
+above. Frozen wire constants: service name `rpmsg-eth`; MTU **462** / max
+frame 476 (see `scripts/rpmsg-eth-ifup.sh`); Linux side `172.16.52.1/24`,
+MAC `02:5c:52:00:00:01`; CR52 side `172.16.52.2/24`, MAC
+`02:5c:52:00:00:02`; DDS domain 2. The CR52 uses lwIP's `etharp`
+(`NETIF_FLAG_ETHARP`) and resolves peers dynamically, so ARP passes
+through untouched — neither side needs a static peer table.
+
+### Building (cross-compile)
+
+The board image ships no compiler (see the AutoSD rootfs manifest,
+`aib/x5h-rootfs.aib.yml` — no `gcc`/`make`), so `rpmsg-eth` is built on the
+host and staged as a binary, the same pattern as `scripts/rpmsg-ping.c`.
+`rpmsg-eth/Makefile` defaults to `CC ?= cc` with `LDFLAGS ?= -static`
+(static so the one binary runs unmodified on both the BSP Yocto and the
+AutoSD NFS rootfs); override `CC` for an aarch64 target from an x86_64 dev
+host, e.g. with a distro `aarch64-linux-gnu-gcc` cross toolchain and its
+static libc package installed:
+
+```
+cd rpmsg-eth
+CC=aarch64-linux-gnu-gcc make
+```
+
+This is a plain host build, unrelated to and independent from the pinned
+ARM GNU 13.2 toolchain used for the *kernel* rebuild above — that pin
+exists because of a board-specific boot-time layout bug in the kernel
+Image; it has no bearing on a static userspace binary. (CI instead builds
+`rpmsg-eth` natively inside an `arm64`-platform Fedora container — see
+`scripts/make-test-images.sh` — because that container also needs to run
+the binary it builds, on the same architecture, for `test-rpmsg-eth.sh`;
+that path is CI-only and not a stand-in for a documented cross-compile
+invocation for staging onto the board.)
+
+### Staging
+
+Not installed by `aib/x5h-rootfs.aib.yml` today — same manual
+install-to-`/usr/local` pattern as `rpmsg-ping`/`rpmsg-smoke.sh` above.
+Stage the daemon, its `ifup` helper and its unit onto the NFS export (see
+"Staging the assets" above for why `/var/tmp`, not `/tmp`, is the export
+path to use), then install on the target:
+
+```
+install -m0755 rpmsg-eth rpmsg-eth-ifup.sh <export>/var/tmp/rpmsg/
+install -m0644 rpmsg-eth.service            <export>/var/tmp/rpmsg/
+```
+
+```
+install -m0755 /var/tmp/rpmsg/rpmsg-eth /usr/local/bin/rpmsg-eth
+install -m0755 /var/tmp/rpmsg/rpmsg-eth-ifup.sh /usr/local/sbin/rpmsg-eth-ifup.sh
+install -m0644 /var/tmp/rpmsg/rpmsg-eth.service /etc/systemd/system/rpmsg-eth.service
+systemctl daemon-reload
+```
+
+### Prerequisites
+
+`rpmsg-eth.service` has no `After=`/`Wants=` on a specific rpmsg device
+unit — the daemon's own endpoint-wait loop already retries until the
+CR52's channel appears (logging its progress; see `rpmsg-eth.c`) — but it
+does **not** load the rpmsg modules or start `remoteproc0` for you. Both
+must already be done, exactly as in the Procedure above:
+
+```
+modprobe rpmsg_ctrl && modprobe rpmsg_char
+echo start > /sys/class/remoteproc/remoteproc0/state
+```
+
+Starting the unit before either of those has happened is not an error —
+the daemon waits and retries rather than failing — but it means the link
+will never come up until they are done, so do them first rather than
+relying on the retry to eventually paper over a skipped step.
+
+```
+systemctl enable --now rpmsg-eth.service
+```
+
+### Smoke
+
+```
+scripts/rpmsg-eth-smoke.sh
+```
+
+Asserts the channel is on the rpmsg bus, `rpmsg-eth.service` is active,
+`tap0` is up with the frozen address/MAC/MTU, then round-trip pings the
+CR52 side requiring 100% reply. `-n` skips the rpmsg-bus channel assertion
+for a bench run against a manually wired peer with no CR52 attached. See
+the script's own header for the full `reason=` vocabulary on failure.

--- a/platforms/autosd/x5h/rpmsg-dualboot.md
+++ b/platforms/autosd/x5h/rpmsg-dualboot.md
@@ -282,6 +282,47 @@ the daemon waits and retries rather than failing — but it means the link
 will never come up until they are done, so do them first rather than
 relying on the retry to eventually paper over a skipped step.
 
+**Neither of those two steps survives a reboot**, which was board-confirmed
+during the Stage 2 session: after a warm reboot the modules were unloaded and
+`remoteproc0` was back to `offline`, so the link stayed down (with the daemon
+correctly logging `no channel named 'rpmsg-eth' on the rpmsg bus yet`) until
+both were repeated by hand. Install the two helpers below to make the link come
+up on its own, and the manual commands above become a description of what they
+do rather than something to remember:
+
+```
+install -m0755 cr52-rproc-up.sh          <export>/var/tmp/rpmsg/
+install -m0644 cr52-remoteproc.service   <export>/var/tmp/rpmsg/
+install -m0644 x5h-rpmsg-modules.conf    <export>/var/tmp/rpmsg/
+```
+
+```
+install -m0755 /var/tmp/rpmsg/cr52-rproc-up.sh /usr/local/sbin/cr52-rproc-up.sh
+install -m0644 /var/tmp/rpmsg/cr52-remoteproc.service /etc/systemd/system/cr52-remoteproc.service
+install -m0644 /var/tmp/rpmsg/x5h-rpmsg-modules.conf /etc/modules-load.d/x5h-rpmsg.conf
+# Point remoteproc at the ELF matching what is flashed in the Core1 slot. The
+# staged ELF MUST match the flashed image: `start` parses the resource table out
+# of it to publish the vrings, so a mismatch yields a link that looks configured
+# and passes nothing.
+install -m0644 <the flashed firmware>.elf /lib/firmware/
+printf 'CR52_FIRMWARE=%s\n' "<the flashed firmware>.elf" > /etc/default/cr52-remoteproc
+systemctl daemon-reload
+systemctl enable --now cr52-remoteproc.service
+```
+
+Leaving `CR52_FIRMWARE` unset is also valid: the driver's stock name is
+`rproc-cr52_1-fw`, so a symlink at `/lib/firmware/rproc-cr52_1-fw` works just as
+well. Either way the unit reports what it did — `CR52_RPROC_UP name=… firmware=…`,
+or `CR52_RPROC_SKIP reason=no_firmware path=…` on a board where the ELF has not
+been staged yet, which is the expected state on a freshly imaged board and is
+deliberately not treated as a failure.
+
+Like the daemon, these three files are **not** installed by
+`aib/x5h-rootfs.aib.yml`. That is intentional rather than an omission: the unit's
+`ExecStart` is a script that ships in this repo, not in the image, so baking the
+unit in while the script was absent would leave every first boot with a failed
+unit and nothing gained. The whole `rpmsg-eth` stack is staged together.
+
 ```
 systemctl enable --now rpmsg-eth.service
 ```

--- a/platforms/autosd/x5h/rpmsg-eth/Makefile
+++ b/platforms/autosd/x5h/rpmsg-eth/Makefile
@@ -3,6 +3,13 @@
 # same binary runs on both the BSP Yocto rootfs and the AutoSD NFS rootfs
 # (matching scripts/rpmsg-ping.c); override LDFLAGS if the host toolchain
 # has no static libc.
+#
+# The board image ships no compiler (see aib/x5h-rootfs.aib.yml), so this
+# is built on a host and staged as a binary -- override CC for an aarch64
+# target from an x86_64 dev host, e.g.:
+#   CC=aarch64-linux-gnu-gcc make
+# See ../rpmsg-dualboot.md's "rpmsg-eth: IP-over-RPMsg bridge" section for
+# the full build/stage/prerequisites/smoke sequence.
 CC ?= cc
 CFLAGS ?= -O2 -Wall -Wextra
 LDFLAGS ?= -static

--- a/platforms/autosd/x5h/rpmsg-eth/Makefile
+++ b/platforms/autosd/x5h/rpmsg-eth/Makefile
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# Build the rpmsg-eth TAP bridge daemon. Static-linked by default so the
+# same binary runs on both the BSP Yocto rootfs and the AutoSD NFS rootfs
+# (matching scripts/rpmsg-ping.c); override LDFLAGS if the host toolchain
+# has no static libc.
+CC ?= cc
+CFLAGS ?= -O2 -Wall -Wextra
+LDFLAGS ?= -static
+
+rpmsg-eth: rpmsg-eth.c
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+
+clean:
+	rm -f rpmsg-eth
+
+.PHONY: clean

--- a/platforms/autosd/x5h/rpmsg-eth/rpmsg-eth.c
+++ b/platforms/autosd/x5h/rpmsg-eth/rpmsg-eth.c
@@ -13,7 +13,10 @@
  * reset, so this daemon does not fail fast when the channel is absent: it
  * waits (woken by inotify on /dev, so it isn't a busy-poll) and retries,
  * both at startup and whenever the endpoint goes away later (another CR52
- * reset) -- start-order independence in both directions.
+ * reset) -- start-order independence in both directions. tap is kept
+ * drained during that wait so a reset on the CR52 side doesn't also wedge
+ * Linux -> CR52 traffic; frames that arrive with no endpoint to relay them
+ * to are counted and dropped rather than silently lost.
  *
  * -d bypasses discovery and opens a device path directly. It exists as a
  * test seam: test-rpmsg-eth.sh points it at one end of a socat pty pair
@@ -21,7 +24,9 @@
  *
  * usage: rpmsg-eth [-s rpmsg-eth] [-t tap0] [-d /dev/rpmsgN]
  * Bridges frames both ways until SIGTERM/SIGINT, then closes both fds,
- * logs relay counters to stderr, and exits 0.
+ * logs relay counters to stderr, and exits 0 -- including when the signal
+ * arrives while still waiting for the first endpoint, which is a clean
+ * shutdown, not a failure.
  */
 #include <dirent.h>
 #include <errno.h>
@@ -43,7 +48,8 @@ struct rpmsg_endpoint_info {
 	uint32_t src;
 	uint32_t dst;
 };
-#define RPMSG_CREATE_EPT_IOCTL _IOW(0xb5, 0x1, struct rpmsg_endpoint_info)
+#define RPMSG_CREATE_EPT_IOCTL  _IOW(0xb5, 0x1, struct rpmsg_endpoint_info)
+#define RPMSG_DESTROY_EPT_IOCTL _IO(0xb5, 0x2)
 #define RPMSG_ADDR_ANY 0xFFFFFFFF
 
 /*
@@ -183,24 +189,77 @@ static int create_ept(const char *service)
 	return open(devpath, O_RDWR);
 }
 
-/* Block up to 1s for a /dev change, so a pending discovery/reconnect wakes
- * promptly instead of busy-polling. The timeout also re-checks
- * periodically in case the channel appears without a /dev event we're
- * watching for. */
-static void wait_for_dev_change(int inotify_fd)
+/* Tear down a char endpoint the way scripts/rpmsg-ping.c does: destroy the
+ * ept explicitly before closing, rather than relying on release-time
+ * teardown. Harmless (and ignored) on the -d test seam's pty, which isn't
+ * an rpmsg ept and just returns ENOTTY. No-op on a negative fd. */
+static void close_ept(int fd)
 {
-	struct pollfd pfd = { .fd = inotify_fd, .events = POLLIN };
-	char buf[1024];
-
-	if (poll(&pfd, 1, 1000) > 0 && read(inotify_fd, buf, sizeof(buf)) < 0)
+	if (fd < 0)
 		return;
+	ioctl(fd, RPMSG_DESTROY_EPT_IOCTL);
+	close(fd);
+}
+
+/* Write the whole buffer, retrying on a short write (a real possibility on
+ * the pty the test stands the endpoint in with, and cheap insurance on the
+ * real chardev too). Returns 1 on success, 0 on a hard error (errno set by
+ * the failing write()). Counts (but does not fail on) every short write. */
+static int write_full(int fd, const char *buf, size_t len, unsigned long *short_writes)
+{
+	size_t off = 0;
+
+	while (off < len) {
+		ssize_t w = write(fd, buf + off, len - off);
+		if (w < 0) {
+			if (errno == EINTR)
+				continue;
+			return 0;
+		}
+		off += (size_t)w;
+		if (off < len)
+			(*short_writes)++;
+	}
+	return 1;
+}
+
+/* Block up to 1s waiting for either a /dev change (a pending endpoint
+ * discovery/reconnect) or a frame arriving on tap while there is no
+ * endpoint to relay it to. tap frames seen here are counted via
+ * *tap_dropped_no_endpoint and dropped: there is nowhere to put them until
+ * the CR52 comes back, but the drop must be visible rather than silent. */
+static void wait_for_dev_or_tap(int inotify_fd, int tap_fd,
+				 unsigned long *tap_dropped_no_endpoint)
+{
+	struct pollfd pfd[2] = {
+		{ .fd = inotify_fd, .events = POLLIN },
+		{ .fd = tap_fd, .events = POLLIN },
+	};
+	char ibuf[1024], fbuf[BUF_LEN];
+
+	if (poll(pfd, 2, 1000) <= 0)
+		return;
+	if (pfd[0].revents & POLLIN) {
+		if (read(inotify_fd, ibuf, sizeof(ibuf)) < 0 &&
+		    errno != EINTR && errno != EAGAIN)
+			return;
+	}
+	if (pfd[1].revents & POLLIN) {
+		ssize_t n = read(tap_fd, fbuf, sizeof(fbuf));
+		if (n > 0)
+			(*tap_dropped_no_endpoint)++;
+	}
 }
 
 /* Open the endpoint: `device` directly if given (test seam), else wait for
  * the CR52 to announce `service` and bind it. Retries indefinitely (until
  * a signal arrives), so the daemon is start-order independent and survives
- * the endpoint going away and coming back across a CR52 reset. */
-static int open_endpoint(const char *device, const char *service, int inotify_fd)
+ * the endpoint going away and coming back across a CR52 reset. tap is kept
+ * drained (see wait_for_dev_or_tap) while this blocks. Returns -1 only
+ * when g_stop was set (a signal arrived); callers should treat that as a
+ * clean-shutdown request, not an error. */
+static int open_endpoint(const char *device, const char *service, int inotify_fd,
+			  int tap_fd, unsigned long *tap_dropped_no_endpoint)
 {
 	for (;;) {
 		int fd = device ? open(device, O_RDWR) : create_ept(service);
@@ -208,7 +267,7 @@ static int open_endpoint(const char *device, const char *service, int inotify_fd
 			return fd;
 		if (g_stop)
 			return -1;
-		wait_for_dev_change(inotify_fd);
+		wait_for_dev_or_tap(inotify_fd, tap_fd, tap_dropped_no_endpoint);
 	}
 }
 
@@ -233,6 +292,8 @@ int main(int argc, char **argv)
 {
 	const char *service = "rpmsg-eth", *tap_name = "tap0", *device = NULL;
 	unsigned long tap_to_ept = 0, ept_to_tap = 0, dropped_oversize = 0;
+	unsigned long tap_dropped_no_endpoint = 0;
+	unsigned long tap_write_errors = 0, ept_write_errors = 0, short_writes = 0;
 	int opt, tap, ept, inotify_fd;
 	struct sigaction sa;
 
@@ -272,20 +333,29 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	ept = open_endpoint(device, service, inotify_fd);
-	if (ept < 0) {
+	ept = open_endpoint(device, service, inotify_fd, tap, &tap_dropped_no_endpoint);
+	if (ept < 0 && !g_stop) {
+		/* open_endpoint() only gives up when g_stop is set; this is
+		 * defensive, not a path we expect to hit. */
 		fprintf(stderr, "rpmsg-eth: stopped waiting for endpoint\n");
 		close(tap);
+		close(inotify_fd);
 		return 1;
 	}
 
-	while (!g_stop) {
+	/* If a signal arrived while still waiting above, ept is -1 and
+	 * g_stop is set: fall straight through to the shared shutdown path
+	 * below (skipping the loop) so this is exit 0, the same as a signal
+	 * during the loop -- "exit 0 on clean SIGTERM" holds regardless of
+	 * when the signal lands. */
+	while (!g_stop && ept >= 0) {
 		struct pollfd pfd[2] = {
 			{ .fd = tap, .events = POLLIN },
 			{ .fd = ept, .events = POLLIN },
 		};
 		char buf[BUF_LEN];
 		ssize_t n;
+		int reconnected = 0;
 
 		if (poll(pfd, 2, -1) < 0) {
 			if (errno == EINTR)
@@ -296,34 +366,66 @@ int main(int argc, char **argv)
 
 		if (pfd[0].revents & POLLIN) {
 			n = read(tap, buf, sizeof(buf));
-			if (n > MAX_FRAME_LEN)
+			if (n > MAX_FRAME_LEN) {
 				dropped_oversize++;
-			else if (n > 0 && write(ept, buf, (size_t)n) == n)
-				tap_to_ept++;
+			} else if (n > 0) {
+				if (write_full(ept, buf, (size_t)n, &short_writes)) {
+					tap_to_ept++;
+				} else {
+					tap_write_errors++;
+					fprintf(stderr,
+						"rpmsg-eth: write(ept) failed: %s\n",
+						strerror(errno));
+					/* A write error on the endpoint is as
+					 * good a signal as a read EOF that the
+					 * CR52 is gone: rebind now instead of
+					 * waiting for the read side to notice.
+					 * pfd[1].revents below described the
+					 * *old* ept fd, so it must not be
+					 * consulted against the new one. */
+					close_ept(ept);
+					ept = open_endpoint(device, service, inotify_fd,
+							     tap, &tap_dropped_no_endpoint);
+					reconnected = 1;
+				}
+			}
 		}
 
-		if (pfd[1].revents & (POLLIN | POLLHUP | POLLERR)) {
+		if (!reconnected && ept >= 0 &&
+		    (pfd[1].revents & (POLLIN | POLLHUP | POLLERR))) {
 			n = read(ept, buf, sizeof(buf));
 			if (n > 0) {
-				if (write(tap, buf, (size_t)n) == n)
+				if (write_full(tap, buf, (size_t)n, &short_writes)) {
 					ept_to_tap++;
+				} else {
+					ept_write_errors++;
+					fprintf(stderr,
+						"rpmsg-eth: write(tap) failed: %s\n",
+						strerror(errno));
+				}
+			} else if (n < 0 && (errno == EINTR || errno == EAGAIN)) {
+				/* Transient; not a disconnect. Retry next
+				 * poll iteration instead of tearing down a
+				 * live endpoint. */
 			} else {
-				/* Endpoint closed: CR52 reset. Rebind and
-				 * keep going rather than exiting. */
-				close(ept);
-				ept = open_endpoint(device, service, inotify_fd);
-				if (ept < 0)
-					break;
+				/* n == 0 (EOF) or a genuine read error:
+				 * CR52 reset. Rebind and keep going rather
+				 * than exiting. */
+				close_ept(ept);
+				ept = open_endpoint(device, service, inotify_fd,
+						     tap, &tap_dropped_no_endpoint);
 			}
 		}
 	}
 
 	close(tap);
-	if (ept >= 0)
-		close(ept);
+	close_ept(ept);
 	close(inotify_fd);
 	fprintf(stderr,
-		"rpmsg-eth: exiting tap_to_ept=%lu ept_to_tap=%lu dropped_oversize=%lu\n",
-		tap_to_ept, ept_to_tap, dropped_oversize);
+		"rpmsg-eth: exiting tap_to_ept=%lu ept_to_tap=%lu dropped_oversize=%lu "
+		"tap_dropped_no_endpoint=%lu tap_write_errors=%lu ept_write_errors=%lu "
+		"short_writes=%lu\n",
+		tap_to_ept, ept_to_tap, dropped_oversize, tap_dropped_no_endpoint,
+		tap_write_errors, ept_write_errors, short_writes);
 	return 0;
 }

--- a/platforms/autosd/x5h/rpmsg-eth/rpmsg-eth.c
+++ b/platforms/autosd/x5h/rpmsg-eth/rpmsg-eth.c
@@ -11,12 +11,22 @@
  * `dst`, and create the char endpoint via /dev/rpmsg_ctrl* +
  * RPMSG_CREATE_EPT_IOCTL. The CR52 announces its channel exactly once per
  * reset, so this daemon does not fail fast when the channel is absent: it
- * waits (woken by inotify on /dev, so it isn't a busy-poll) and retries,
- * both at startup and whenever the endpoint goes away later (another CR52
- * reset) -- start-order independence in both directions. tap is kept
- * drained during that wait so a reset on the CR52 side doesn't also wedge
- * Linux -> CR52 traffic; frames that arrive with no endpoint to relay them
- * to are counted and dropped rather than silently lost.
+ * waits (paced by the 1s poll() timeout in wait_for_dev_or_tap(), woken
+ * early by inotify on /dev when a device node changes, so it isn't a
+ * busy-poll either way) and retries, both at startup and whenever the
+ * endpoint goes away later (another CR52 reset) -- start-order independence
+ * in both directions. tap is kept drained during that wait so a reset on
+ * the CR52 side doesn't also wedge Linux -> CR52 traffic; frames that
+ * arrive with no endpoint to relay them to are counted and dropped rather
+ * than silently lost.
+ *
+ * Every retry loop iteration is logged: once on entering the wait, once on
+ * the first occurrence of each distinct failure reason (with strerror()
+ * where the failure has one), every ~30 retries thereafter so a stuck wait
+ * is visible on a console with no scrollback, and once on every successful
+ * (re)bind and every endpoint loss. A daemon that retries forever by design
+ * must not be silent about it -- the observable difference between "still
+ * working as designed" and "wedged" is exactly this log output.
  *
  * -d bypasses discovery and opens a device path directly. It exists as a
  * test seam: test-rpmsg-eth.sh points it at one end of a socat pty pair
@@ -26,7 +36,12 @@
  * Bridges frames both ways until SIGTERM/SIGINT, then closes both fds,
  * logs relay counters to stderr, and exits 0 -- including when the signal
  * arrives while still waiting for the first endpoint, which is a clean
- * shutdown, not a failure.
+ * shutdown, not a failure. SIGUSR1 dumps the same counters without
+ * stopping the service, for inspecting a live daemon over a serial console
+ * without destroying the state you wanted to inspect. A poll() failure or
+ * a fatal tap condition (see POLLERR/POLLHUP/POLLNVAL handling below) exits
+ * nonzero instead, so the unit's Restart=on-failure policy actually fires
+ * rather than leaving systemd thinking a broken relay exited cleanly.
  */
 #include <dirent.h>
 #include <errno.h>
@@ -68,11 +83,18 @@ struct rpmsg_endpoint_info {
 #define BUF_LEN 2048
 
 static volatile sig_atomic_t g_stop;
+static volatile sig_atomic_t g_dump;
 
 static void on_signal(int sig)
 {
 	(void)sig;
 	g_stop = 1;
+}
+
+static void on_dump_signal(int sig)
+{
+	(void)sig;
+	g_dump = 1;
 }
 
 /* --- rpmsg endpoint discovery: same approach as scripts/rpmsg-ping.c --- */
@@ -91,15 +113,23 @@ static int read_sysfs(const char *path, char *buf, size_t len)
 	return 0;
 }
 
-/* Find the rpmsg device announcing `service`; return its dst address. */
-static int find_service(const char *service, uint32_t *dst)
+/* Find the rpmsg device announcing `service`; return its dst address.
+ * `opendir_errno` is set to the errno from a failed opendir() (the rpmsg
+ * bus itself isn't there -- e.g. remoteproc0 was never started), or to 0
+ * when the bus exists but no channel named `service` is on it yet (the
+ * ordinary "CR52 hasn't announced yet" case). Callers use this to log a
+ * more specific reason than a bare "not found". */
+static int find_service(const char *service, uint32_t *dst, int *opendir_errno)
 {
 	DIR *d = opendir("/sys/bus/rpmsg/devices");
 	struct dirent *e;
 	char path[512], val[64];
 
-	if (!d)
+	*opendir_errno = 0;
+	if (!d) {
+		*opendir_errno = errno;
 		return -1;
+	}
 	while ((e = readdir(d))) {
 		if (e->d_name[0] == '.')
 			continue;
@@ -153,40 +183,101 @@ static int open_ctrl(void)
 	return -1;
 }
 
+/* The five distinct ways create_ept() can fail to bind an endpoint. Kept
+ * as an enum (rather than folding everything into one -1) so the caller
+ * can log a first-occurrence-per-reason message instead of one opaque
+ * "still waiting" line that never says what it's waiting *on*. */
+enum ept_wait_reason {
+	EPT_WAIT_NO_BUS,        /* no /sys/bus/rpmsg/devices, or no channel
+				 * named `service` on it yet */
+	EPT_WAIT_NO_CTRL,       /* no /dev/rpmsg_ctrl* node */
+	EPT_WAIT_CREATE_FAIL,   /* RPMSG_CREATE_EPT_IOCTL failed */
+	EPT_WAIT_NO_EPTDEV,     /* ioctl succeeded but no new /dev/rpmsgN
+				 * showed up under /sys/class/rpmsg */
+	EPT_WAIT_OPEN_FAIL,     /* open() of the new eptdev failed */
+};
+
 /* Create and open the char endpoint bound to `service`'s announced
  * channel. Returns the open fd, or -1 if the channel isn't announced (yet)
- * or endpoint creation failed. */
-static int create_ept(const char *service)
+ * or endpoint creation failed -- either way, *reason identifies which of
+ * the five steps failed and errbuf carries a human-readable detail
+ * (strerror() where the failure has an errno; a fixed string otherwise). */
+static int create_ept(const char *service, enum ept_wait_reason *reason,
+		       char *errbuf, size_t errbuf_len)
 {
 	struct rpmsg_endpoint_info info;
 	uint32_t dst;
 	uint64_t before, after;
 	char devpath[64];
-	int ctrl, i;
+	int ctrl, fd, i, opendir_errno;
 
-	if (find_service(service, &dst))
+	if (find_service(service, &dst, &opendir_errno)) {
+		*reason = EPT_WAIT_NO_BUS;
+		if (opendir_errno)
+			snprintf(errbuf, errbuf_len,
+				 "opendir(/sys/bus/rpmsg/devices): %s",
+				 strerror(opendir_errno));
+		else
+			snprintf(errbuf, errbuf_len,
+				 "no channel named '%s' on the rpmsg bus yet",
+				 service);
 		return -1;
+	}
 	ctrl = open_ctrl();
-	if (ctrl < 0)
+	if (ctrl < 0) {
+		*reason = EPT_WAIT_NO_CTRL;
+		snprintf(errbuf, errbuf_len, "open(/dev/rpmsg_ctrl*): %s",
+			 strerror(errno));
 		return -1;
+	}
 	memset(&info, 0, sizeof(info));
 	snprintf(info.name, sizeof(info.name), "%s", service);
 	info.src = RPMSG_ADDR_ANY;
 	info.dst = dst;
 	before = eptdev_snapshot();
 	if (ioctl(ctrl, RPMSG_CREATE_EPT_IOCTL, &info)) {
+		*reason = EPT_WAIT_CREATE_FAIL;
+		snprintf(errbuf, errbuf_len, "RPMSG_CREATE_EPT_IOCTL: %s",
+			 strerror(errno));
 		close(ctrl);
 		return -1;
 	}
 	close(ctrl);
 	after = eptdev_snapshot() & ~before;
-	if (!after)
+	if (!after) {
+		*reason = EPT_WAIT_NO_EPTDEV;
+		snprintf(errbuf, errbuf_len,
+			 "ioctl created an endpoint but no new /dev/rpmsgN appeared");
 		return -1;
+	}
 	for (i = 0; i < 64; i++)
 		if (after & (1ULL << i))
 			break;
 	snprintf(devpath, sizeof(devpath), "/dev/rpmsg%d", i);
-	return open(devpath, O_RDWR);
+	fd = open(devpath, O_RDWR);
+	if (fd < 0) {
+		*reason = EPT_WAIT_OPEN_FAIL;
+		snprintf(errbuf, errbuf_len, "open(%s): %s", devpath,
+			 strerror(errno));
+		/* The RPMSG_CREATE_EPT_IOCTL above already created this
+		 * endpoint; failing to open it must not leak it (one
+		 * eptdev leaked per retry, at 1Hz, otherwise). Destroying
+		 * it needs an open fd on the eptdev itself -- there is no
+		 * destroy-by-address path via the ctrl fd -- so make a
+		 * best-effort read-only open purely to issue the destroy.
+		 * If even that fails (e.g. the node race that produced
+		 * EPT_WAIT_NO_EPTDEV, or a permissions problem so total
+		 * that O_RDONLY fails too), there is genuinely no fd to
+		 * destroy it with and the next retry will find it already
+		 * gone or will create another; nothing further to do here. */
+		fd = open(devpath, O_RDONLY);
+		if (fd >= 0) {
+			ioctl(fd, RPMSG_DESTROY_EPT_IOCTL);
+			close(fd);
+		}
+		return -1;
+	}
+	return fd;
 }
 
 /* Tear down a char endpoint the way scripts/rpmsg-ping.c does: destroy the
@@ -204,7 +295,11 @@ static void close_ept(int fd)
 /* Write the whole buffer, retrying on a short write (a real possibility on
  * the pty the test stands the endpoint in with, and cheap insurance on the
  * real chardev too). Returns 1 on success, 0 on a hard error (errno set by
- * the failing write()). Counts (but does not fail on) every short write. */
+ * the failing write()). Counts (but does not fail on) every short write.
+ * A write() returning exactly 0 for a nonzero-length request is treated as
+ * a hard error rather than retried: it is not a short write (no progress
+ * was made at all) and looping on it would spin unbounded rather than
+ * making forward progress. */
 static int write_full(int fd, const char *buf, size_t len, unsigned long *short_writes)
 {
 	size_t off = 0;
@@ -214,6 +309,10 @@ static int write_full(int fd, const char *buf, size_t len, unsigned long *short_
 		if (w < 0) {
 			if (errno == EINTR)
 				continue;
+			return 0;
+		}
+		if (w == 0) {
+			errno = EIO;
 			return 0;
 		}
 		off += (size_t)w;
@@ -227,7 +326,12 @@ static int write_full(int fd, const char *buf, size_t len, unsigned long *short_
  * discovery/reconnect) or a frame arriving on tap while there is no
  * endpoint to relay it to. tap frames seen here are counted via
  * *tap_dropped_no_endpoint and dropped: there is nowhere to put them until
- * the CR52 comes back, but the drop must be visible rather than silent. */
+ * the CR52 comes back, but the drop must be visible rather than silent.
+ * This 1s poll() timeout, not the inotify watch, is what paces the retry
+ * loop at roughly 1Hz: inotify only wakes it early when a device node
+ * actually changes under /dev, and a channel announcement need not create
+ * anything there at all (the new node appears under /sys/class/rpmsg,
+ * which this function does not watch). */
 static void wait_for_dev_or_tap(int inotify_fd, int tap_fd,
 				 unsigned long *tap_dropped_no_endpoint)
 {
@@ -251,22 +355,76 @@ static void wait_for_dev_or_tap(int inotify_fd, int tap_fd,
 	}
 }
 
+static const char *ept_wait_reason_str(enum ept_wait_reason reason)
+{
+	switch (reason) {
+	case EPT_WAIT_NO_BUS:      return "no rpmsg bus / channel not announced";
+	case EPT_WAIT_NO_CTRL:     return "no /dev/rpmsg_ctrl* node";
+	case EPT_WAIT_CREATE_FAIL: return "endpoint creation ioctl failed";
+	case EPT_WAIT_NO_EPTDEV:   return "no new eptdev appeared";
+	case EPT_WAIT_OPEN_FAIL:   return "open() of the new eptdev failed";
+	}
+	return "unknown";
+}
+
 /* Open the endpoint: `device` directly if given (test seam), else wait for
  * the CR52 to announce `service` and bind it. Retries indefinitely (until
  * a signal arrives), so the daemon is start-order independent and survives
  * the endpoint going away and coming back across a CR52 reset. tap is kept
  * drained (see wait_for_dev_or_tap) while this blocks. Returns -1 only
  * when g_stop was set (a signal arrived); callers should treat that as a
- * clean-shutdown request, not an error. */
+ * clean-shutdown request, not an error.
+ *
+ * Logs once on entering the wait (naming what is being waited for), once
+ * on the first occurrence of each distinct failure reason, every ~30
+ * retries thereafter regardless of reason (so a wait stuck on the same
+ * reason for minutes still produces console output), and once on every
+ * successful bind. A silent 1Hz-forever retry is indistinguishable from a
+ * hang on a serial console with no way to inspect process state; these
+ * lines are the only thing that tells the two apart. */
 static int open_endpoint(const char *device, const char *service, int inotify_fd,
 			  int tap_fd, unsigned long *tap_dropped_no_endpoint)
 {
+	unsigned long attempt = 0;
+	int have_last_reason = 0;
+	enum ept_wait_reason last_reason = EPT_WAIT_NO_BUS;
+
+	fprintf(stderr, "rpmsg-eth: waiting for endpoint (%s)...\n",
+		device ? device : service);
+
 	for (;;) {
-		int fd = device ? open(device, O_RDWR) : create_ept(service);
-		if (fd >= 0)
+		enum ept_wait_reason reason = EPT_WAIT_NO_BUS;
+		char errbuf[160];
+		int fd;
+
+		errbuf[0] = '\0';
+		if (device) {
+			fd = open(device, O_RDWR);
+			if (fd < 0)
+				snprintf(errbuf, sizeof(errbuf), "open(%s): %s",
+					 device, strerror(errno));
+		} else {
+			fd = create_ept(service, &reason, errbuf, sizeof(errbuf));
+		}
+
+		if (fd >= 0) {
+			fprintf(stderr, "rpmsg-eth: endpoint bound (%s)\n",
+				device ? device : service);
 			return fd;
+		}
 		if (g_stop)
 			return -1;
+
+		attempt++;
+		if (!have_last_reason || reason != last_reason ||
+		    attempt % 30 == 0) {
+			fprintf(stderr,
+				"rpmsg-eth: still waiting for endpoint after %lu attempt(s): %s\n",
+				attempt,
+				errbuf[0] ? errbuf : ept_wait_reason_str(reason));
+			last_reason = reason;
+			have_last_reason = 1;
+		}
 		wait_for_dev_or_tap(inotify_fd, tap_fd, tap_dropped_no_endpoint);
 	}
 }
@@ -288,13 +446,27 @@ static int tap_open(const char *name)
 	return fd;
 }
 
+static void print_counters(const char *prefix, unsigned long tap_to_ept,
+			    unsigned long ept_to_tap, unsigned long dropped_oversize,
+			    unsigned long tap_dropped_no_endpoint,
+			    unsigned long tap_write_errors, unsigned long ept_write_errors,
+			    unsigned long short_writes)
+{
+	fprintf(stderr,
+		"rpmsg-eth: %s tap_to_ept=%lu ept_to_tap=%lu dropped_oversize=%lu "
+		"tap_dropped_no_endpoint=%lu tap_write_errors=%lu ept_write_errors=%lu "
+		"short_writes=%lu\n",
+		prefix, tap_to_ept, ept_to_tap, dropped_oversize, tap_dropped_no_endpoint,
+		tap_write_errors, ept_write_errors, short_writes);
+}
+
 int main(int argc, char **argv)
 {
 	const char *service = "rpmsg-eth", *tap_name = "tap0", *device = NULL;
 	unsigned long tap_to_ept = 0, ept_to_tap = 0, dropped_oversize = 0;
 	unsigned long tap_dropped_no_endpoint = 0;
 	unsigned long tap_write_errors = 0, ept_write_errors = 0, short_writes = 0;
-	int opt, tap, ept, inotify_fd;
+	int opt, tap, ept, inotify_fd, fatal_error = 0;
 	struct sigaction sa;
 
 	while ((opt = getopt(argc, argv, "s:t:d:")) != -1) {
@@ -314,6 +486,10 @@ int main(int argc, char **argv)
 	sa.sa_handler = on_signal;
 	sigaction(SIGTERM, &sa, NULL);
 	sigaction(SIGINT, &sa, NULL);
+
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = on_dump_signal;
+	sigaction(SIGUSR1, &sa, NULL);
 
 	inotify_fd = inotify_init1(IN_NONBLOCK);
 	if (inotify_fd < 0) {
@@ -363,10 +539,45 @@ int main(int argc, char **argv)
 		ssize_t n;
 		int reconnected = 0;
 
+		if (g_dump) {
+			g_dump = 0;
+			print_counters("counters", tap_to_ept, ept_to_tap, dropped_oversize,
+					tap_dropped_no_endpoint, tap_write_errors,
+					ept_write_errors, short_writes);
+		}
+
 		if (poll(pfd, 2, -1) < 0) {
 			if (errno == EINTR)
 				continue;
 			fprintf(stderr, "rpmsg-eth: poll: %s\n", strerror(errno));
+			fatal_error = 1;
+			break;
+		}
+
+		/* POLLERR is delivered regardless of requested events, and
+		 * tun_chr_poll() returns it once the tun device this fd
+		 * refers to stops being a live, registered netdevice --
+		 * which is exactly what `ip link del tap0` does to a
+		 * persistent tap the daemon still holds open (confirmed
+		 * against the 6.1 tun.c: tun_get() failing, or
+		 * dev->reg_state != NETREG_REGISTERED, both return
+		 * EPOLLERR). Without this check the loop would spin on a
+		 * dead tap forever -- POLLIN never sets again, but poll()
+		 * keeps returning immediately with POLLERR set and nothing
+		 * read, sleeps, logs or exits -- a pegged core and a dead
+		 * link while the unit still reads "active (running)". Treat
+		 * it as fatal, matching the endpoint side's existing
+		 * POLLERR/POLLHUP handling below. */
+		if (pfd[0].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+			fprintf(stderr,
+				"rpmsg-eth: tap %s reported a fatal poll condition "
+				"(POLLERR=%d POLLHUP=%d POLLNVAL=%d) -- exiting so the "
+				"service manager can restart us\n",
+				tap_name,
+				!!(pfd[0].revents & POLLERR),
+				!!(pfd[0].revents & POLLHUP),
+				!!(pfd[0].revents & POLLNVAL));
+			fatal_error = 1;
 			break;
 		}
 
@@ -389,6 +600,8 @@ int main(int argc, char **argv)
 					 * pfd[1].revents below described the
 					 * *old* ept fd, so it must not be
 					 * consulted against the new one. */
+					fprintf(stderr,
+						"rpmsg-eth: endpoint lost (write failed), rebinding\n");
 					close_ept(ept);
 					ept = open_endpoint(device, service, inotify_fd,
 							     tap, &tap_dropped_no_endpoint);
@@ -417,6 +630,8 @@ int main(int argc, char **argv)
 				/* n == 0 (EOF) or a genuine read error:
 				 * CR52 reset. Rebind and keep going rather
 				 * than exiting. */
+				fprintf(stderr,
+					"rpmsg-eth: endpoint lost (EOF/read error), rebinding\n");
 				close_ept(ept);
 				ept = open_endpoint(device, service, inotify_fd,
 						     tap, &tap_dropped_no_endpoint);
@@ -427,11 +642,8 @@ int main(int argc, char **argv)
 	close(tap);
 	close_ept(ept);
 	close(inotify_fd);
-	fprintf(stderr,
-		"rpmsg-eth: exiting tap_to_ept=%lu ept_to_tap=%lu dropped_oversize=%lu "
-		"tap_dropped_no_endpoint=%lu tap_write_errors=%lu ept_write_errors=%lu "
-		"short_writes=%lu\n",
-		tap_to_ept, ept_to_tap, dropped_oversize, tap_dropped_no_endpoint,
-		tap_write_errors, ept_write_errors, short_writes);
-	return 0;
+	print_counters("exiting", tap_to_ept, ept_to_tap, dropped_oversize,
+			tap_dropped_no_endpoint, tap_write_errors, ept_write_errors,
+			short_writes);
+	return fatal_error ? 1 : 0;
 }

--- a/platforms/autosd/x5h/rpmsg-eth/rpmsg-eth.c
+++ b/platforms/autosd/x5h/rpmsg-eth/rpmsg-eth.c
@@ -329,6 +329,39 @@ static void close_ept(int fd)
 	close(fd);
 }
 
+static void print_counters(const char *prefix, unsigned long tap_to_ept,
+			    unsigned long ept_to_tap, unsigned long dropped_oversize,
+			    unsigned long tap_dropped_no_endpoint,
+			    unsigned long tap_write_errors, unsigned long ept_write_errors,
+			    unsigned long short_writes)
+{
+	fprintf(stderr,
+		"rpmsg-eth: %s tap_to_ept=%lu ept_to_tap=%lu dropped_oversize=%lu "
+		"tap_dropped_no_endpoint=%lu tap_write_errors=%lu ept_write_errors=%lu "
+		"short_writes=%lu\n",
+		prefix, tap_to_ept, ept_to_tap, dropped_oversize, tap_dropped_no_endpoint,
+		tap_write_errors, ept_write_errors, short_writes);
+}
+
+/* Pointers to every relay counter, bundled so write_full() can hand them
+ * straight to print_counters() when a SIGUSR1 dump lands while it is
+ * retrying a write against the progress deadline (see the g_dump check in
+ * write_full()'s deadline branch below). Pointers, not a value snapshot
+ * taken at call time, so a dump prints the counters as they stand at the
+ * moment of the signal. short_writes lives here too, rather than as its
+ * own parameter (the shape write_full() used before this task): write_full()
+ * is the only function that ever increments it, and it belongs in every
+ * dump anyway. */
+struct relay_counters {
+	unsigned long *tap_to_ept;
+	unsigned long *ept_to_tap;
+	unsigned long *dropped_oversize;
+	unsigned long *tap_dropped_no_endpoint;
+	unsigned long *tap_write_errors;
+	unsigned long *ept_write_errors;
+	unsigned long *short_writes;
+};
+
 /* write_full()'s four-way return: WRITE_FULL_OK on success (all of `len`
  * written), 0 on a hard I/O error (errno set by the failing write()), or
  * one of these two sentinels -- kept named, not a second use of plain
@@ -360,8 +393,15 @@ static void close_ept(int fd)
  * deadline_s > 0 enables the bounded-progress path this task adds, used
  * only for writes to the rpmsg endpoint (the tap fd stays blocking and is
  * always called with deadline_s == 0, which reproduces the old behaviour
- * exactly: EAGAIN can't happen on a blocking fd, so that branch is simply
- * never taken for tap writes).
+ * exactly: EAGAIN/EWOULDBLOCK can't happen on a blocking fd, and the retry
+ * branch's ENOMEM case is itself gated on deadline_s > 0 (see that branch's
+ * own comment for why), so that branch is simply never taken for tap
+ * writes).
+ *
+ * counters bundles pointers to every relay counter (see its own comment):
+ * short_writes is incremented directly through it, and the retry loop's
+ * g_dump check hands the whole set to print_counters() so a SIGUSR1 dump
+ * requested mid-stall is answered without waiting for this call to return.
  *
  * With the endpoint opened O_NONBLOCK, a CR52 that has stopped returning
  * TX buffers makes write() return EAGAIN/EWOULDBLOCK instead of blocking.
@@ -388,12 +428,16 @@ static void close_ept(int fd)
  *      stuck, which hands control back to the clock check above. Cheap
  *      insurance the very next loop iteration either way: on the expected
  *      path this fires only as a wakeup for an already-EAGAIN-ing fd. */
-static int write_full(int fd, const char *buf, size_t len, unsigned long *short_writes,
+static int write_full(int fd, const char *buf, size_t len, struct relay_counters *counters,
 		       int deadline_s, double *elapsed_s_out)
 {
 	size_t off = 0;
 	struct timespec start = { 0 };
 	int have_deadline = deadline_s > 0;
+	/* See the "Logged once per write_full() call" comment at the retry
+	 * branch below: local (not static), so this resets every call --
+	 * once per frame, not once per process. */
+	int retry_logged = 0;
 
 	if (have_deadline) {
 		clock_gettime(CLOCK_MONOTONIC, &start);
@@ -407,6 +451,44 @@ static int write_full(int fd, const char *buf, size_t len, unsigned long *short_
 		if (have_deadline) {
 			struct timespec now;
 			double elapsed;
+
+			/* Checked ahead of g_stop and the deadline itself: an
+			 * operator reaching for SIGUSR1 during a stall is
+			 * precisely the moment a counter dump is wanted, and
+			 * this loop can otherwise sit through the entire -T
+			 * deadline without ever answering it -- the caller's
+			 * own g_dump handling at the top of the relay loop
+			 * doesn't run again until this call returns, which
+			 * for a genuinely wedged endpoint is up to deadline_s
+			 * seconds away. Printing it here instead, gated the
+			 * same as g_stop below (only reached when
+			 * have_deadline is true, which is never the case for
+			 * the tap write -- EAGAIN/EWOULDBLOCK can't happen on
+			 * that blocking fd, and the retry branch's ENOMEM case
+			 * is separately gated on have_deadline too, see that
+			 * branch's own comment -- so the tap write cannot be
+			 * sitting in this retry loop at all), keeps the dump
+			 * within this loop's own 1s poll() bound (see below)
+			 * instead of the -T one.
+			 * Checked before g_stop, not after, so a dump pending
+			 * at the same moment as a stop still prints: once
+			 * WRITE_FULL_STOPPED is returned below, the caller
+			 * breaks out of the relay loop without ever reaching
+			 * its own top-of-loop g_dump check again. This does
+			 * not change g_stop's own precedence -- it still
+			 * takes priority over waiting out the deadline, and a
+			 * dump here can add at most one fprintf() before that
+			 * check runs, not a wait of any length. */
+			if (g_dump) {
+				g_dump = 0;
+				print_counters("counters", *counters->tap_to_ept,
+						*counters->ept_to_tap,
+						*counters->dropped_oversize,
+						*counters->tap_dropped_no_endpoint,
+						*counters->tap_write_errors,
+						*counters->ept_write_errors,
+						*counters->short_writes);
+			}
 
 			/* Checked ahead of the deadline itself: a clean stop
 			 * takes priority over a wedge report, and must not
@@ -436,8 +518,80 @@ static int write_full(int fd, const char *buf, size_t len, unsigned long *short_
 
 		w = write(fd, buf + off, len - off);
 		if (w < 0) {
-			if (errno == EAGAIN || errno == EWOULDBLOCK) {
+			/* ENOMEM is treated the same as EAGAIN/EWOULDBLOCK,
+			 * not the hard-error path below: upstream
+			 * rpmsg_char.c's rpmsg_trysendto() maps a full TX
+			 * vring's -ENOMEM to -EAGAIN, but only inside the
+			 * `filp->f_flags & O_NONBLOCK` branch -- exactly the
+			 * branch this ept fd takes (see O_NONBLOCK's own
+			 * comment where the fd is opened). This board does
+			 * not run that upstream kernel -- it runs an R-Car
+			 * BSP kernel, and this project has already recorded
+			 * elsewhere that the CI kernel is not the board
+			 * kernel. If that remap is absent, backported
+			 * differently, or simply patched out on this vendor
+			 * tree, a full vring surfaces here as a bare ENOMEM
+			 * instead of EAGAIN. Without this line, write_full()
+			 * would take the hard-error path below, count it as
+			 * a real write failure, and rebind -- silently
+			 * disabling the entire progress-deadline mechanism
+			 * this file exists to add, on the one kernel it has
+			 * to actually work on. The test suite cannot catch
+			 * that regression: the pty this daemon is tested
+			 * against always returns plain EAGAIN and has no way
+			 * to produce ENOMEM instead. Same class of
+			 * not-betting-on-an-unverified-kernel-behaviour as
+			 * the SIGALRM backstop in this function's own
+			 * comment above; it just was not applied to this
+			 * errno too.
+			 *
+			 * `&& have_deadline` is load-bearing, not decoration:
+			 * unlike EAGAIN/EWOULDBLOCK (which genuinely cannot
+			 * happen on a blocking fd), ENOMEM has nothing to do
+			 * with readiness -- the tun/tap write path can return
+			 * it on plain skb allocation failure under memory
+			 * pressure, independent of whether the fd would block.
+			 * An earlier version of this fix accepted ENOMEM
+			 * unconditionally, which reached the tap write too
+			 * (deadline_s == 0): poll(POLLOUT) cannot wait for an
+			 * allocator condition -- tun reports POLLOUT from
+			 * link/socket-writability, not allocator health -- so
+			 * it returns ready immediately and the loop re-writes
+			 * at once, with no alarm, no clock check and no g_stop
+			 * check (all three are gated on have_deadline, further
+			 * below), reproducing this exact family's original
+			 * defect -- an unbounded, SIGTERM-deaf spin -- on the
+			 * tap fd instead of the endpoint. Gating on
+			 * have_deadline keeps a bare ENOMEM on the tap write
+			 * exactly where it was before this fix: the hard-error
+			 * path, a counted, logged, recoverable rebind. */
+			if (errno == EAGAIN || errno == EWOULDBLOCK ||
+			    (errno == ENOMEM && have_deadline)) {
 				struct pollfd pfd = { .fd = fd, .events = POLLOUT };
+
+				/* Logged once per write_full() call (one call
+				 * == one frame), the first time that frame's
+				 * write has to retry -- not every poll() cycle,
+				 * which would otherwise flood the console for
+				 * the entire length of a genuine wedge. This is
+				 * the only place a stall becomes visible before
+				 * either the progress deadline or a SIGUSR1 dump
+				 * fires, and it answers a question the CI seam
+				 * cannot: strerror(errno) here names ENOMEM
+				 * specifically when the vendor kernel's
+				 * TX-vring-full path above is what is actually
+				 * being hit on the board, versus the ordinary
+				 * EAGAIN/EWOULDBLOCK a pty always produces.
+				 * test-rpmsg-eth.sh's SIGUSR1-during-a-stall case
+				 * also waits on this line rather than guessing at
+				 * buffer-fill timing with a fixed sleep. */
+				if (!retry_logged) {
+					retry_logged = 1;
+					fprintf(stderr,
+						"rpmsg-eth: write(fd=%d) not ready (%s), "
+						"retrying\n",
+						fd, strerror(errno));
+				}
 
 				/* Bounded: 1s when a deadline applies (so the
 				 * clock is rechecked periodically even if the
@@ -465,7 +619,7 @@ static int write_full(int fd, const char *buf, size_t len, unsigned long *short_
 		}
 		off += (size_t)w;
 		if (off < len)
-			(*short_writes)++;
+			(*counters->short_writes)++;
 	}
 	if (have_deadline)
 		alarm(0);
@@ -649,20 +803,6 @@ static int tap_open(const char *name)
 	return fd;
 }
 
-static void print_counters(const char *prefix, unsigned long tap_to_ept,
-			    unsigned long ept_to_tap, unsigned long dropped_oversize,
-			    unsigned long tap_dropped_no_endpoint,
-			    unsigned long tap_write_errors, unsigned long ept_write_errors,
-			    unsigned long short_writes)
-{
-	fprintf(stderr,
-		"rpmsg-eth: %s tap_to_ept=%lu ept_to_tap=%lu dropped_oversize=%lu "
-		"tap_dropped_no_endpoint=%lu tap_write_errors=%lu ept_write_errors=%lu "
-		"short_writes=%lu\n",
-		prefix, tap_to_ept, ept_to_tap, dropped_oversize, tap_dropped_no_endpoint,
-		tap_write_errors, ept_write_errors, short_writes);
-}
-
 /* Parse -T's argument: a strictly positive base-10 integer count of
  * seconds. Rejects <= 0 and anything non-numeric (trailing garbage,
  * empty string, overflow) -- a silently-clamped or silently-zero deadline
@@ -687,6 +827,19 @@ int main(int argc, char **argv)
 	unsigned long tap_to_ept = 0, ept_to_tap = 0, dropped_oversize = 0;
 	unsigned long tap_dropped_no_endpoint = 0;
 	unsigned long tap_write_errors = 0, ept_write_errors = 0, short_writes = 0;
+	/* See struct relay_counters's own comment: this is what lets
+	 * write_full() answer a SIGUSR1 dump itself while retrying a write
+	 * against the progress deadline, instead of only at the top of the
+	 * relay loop below. */
+	struct relay_counters counters = {
+		.tap_to_ept = &tap_to_ept,
+		.ept_to_tap = &ept_to_tap,
+		.dropped_oversize = &dropped_oversize,
+		.tap_dropped_no_endpoint = &tap_dropped_no_endpoint,
+		.tap_write_errors = &tap_write_errors,
+		.ept_write_errors = &ept_write_errors,
+		.short_writes = &short_writes,
+	};
 	int ept_progress_timeout_s = RPMSG_ETH_EPT_PROGRESS_TIMEOUT_S;
 	int opt, tap, ept, inotify_fd, fatal_error = 0;
 	struct sigaction sa;
@@ -836,7 +989,7 @@ int main(int argc, char **argv)
 				dropped_oversize++;
 			} else if (n > 0) {
 				double stalled_s = 0;
-				int wr = write_full(ept, buf, (size_t)n, &short_writes,
+				int wr = write_full(ept, buf, (size_t)n, &counters,
 						     ept_progress_timeout_s, &stalled_s);
 
 				if (wr == WRITE_FULL_OK) {
@@ -863,11 +1016,15 @@ int main(int argc, char **argv)
 						"so the service manager can restart us\n",
 						device ? device : service, stalled_s,
 						ept_progress_timeout_s);
-					print_counters("counters", tap_to_ept, ept_to_tap,
-							dropped_oversize, tap_dropped_no_endpoint,
-							tap_write_errors, ept_write_errors,
-							short_writes);
 					fatal_error = 1;
+					/* No print_counters() call here: the
+					 * shared shutdown path at the bottom
+					 * of main() prints them once this
+					 * break falls through to it. Printing
+					 * them here too would put the same
+					 * line on a slow serial console twice
+					 * during exactly the incident someone
+					 * is reading it to diagnose. */
 					break;
 				} else if (wr == WRITE_FULL_STOPPED) {
 					/* g_stop was set while this write was
@@ -911,9 +1068,12 @@ int main(int argc, char **argv)
 			if (n > 0) {
 				/* No deadline on this write: it targets tap,
 				 * which stays a blocking fd (see tap_open()),
-				 * so write_full() never sees EAGAIN here and
-				 * this call behaves exactly as it always has. */
-				if (write_full(tap, buf, (size_t)n, &short_writes, 0, NULL) ==
+				 * so write_full() never sees EAGAIN/EWOULDBLOCK
+				 * here, and its ENOMEM case is itself gated on
+				 * deadline_s > 0 (see write_full()'s retry
+				 * branch), so this call behaves exactly as it
+				 * always has. */
+				if (write_full(tap, buf, (size_t)n, &counters, 0, NULL) ==
 				    WRITE_FULL_OK) {
 					ept_to_tap++;
 				} else {

--- a/platforms/autosd/x5h/rpmsg-eth/rpmsg-eth.c
+++ b/platforms/autosd/x5h/rpmsg-eth/rpmsg-eth.c
@@ -347,7 +347,13 @@ int main(int argc, char **argv)
 	 * g_stop is set: fall straight through to the shared shutdown path
 	 * below (skipping the loop) so this is exit 0, the same as a signal
 	 * during the loop -- "exit 0 on clean SIGTERM" holds regardless of
-	 * when the signal lands. */
+	 * when the signal lands. Otherwise both fds are open and we are
+	 * about to enter the poll loop: print a readiness marker so a
+	 * caller (test-rpmsg-eth.sh, under QEMU TCG in CI, cannot assume a
+	 * fixed startup latency) can wait on it instead of guessing. */
+	if (ept >= 0)
+		fprintf(stderr, "rpmsg-eth: ready\n");
+
 	while (!g_stop && ept >= 0) {
 		struct pollfd pfd[2] = {
 			{ .fd = tap, .events = POLLIN },

--- a/platforms/autosd/x5h/rpmsg-eth/rpmsg-eth.c
+++ b/platforms/autosd/x5h/rpmsg-eth/rpmsg-eth.c
@@ -32,20 +32,31 @@
  * test seam: test-rpmsg-eth.sh points it at one end of a socat pty pair
  * standing in for the real endpoint chardev.
  *
- * usage: rpmsg-eth [-s rpmsg-eth] [-t tap0] [-d /dev/rpmsgN]
+ * The endpoint fd is opened O_NONBLOCK (the tap fd is not). A CR52 that
+ * stops draining its vring must never be able to park this daemon inside
+ * a blocking read()/write() on the endpoint -- that is exactly the board
+ * defect this guards against (100% system time, zero context switches,
+ * unit reporting "active (running)" forever). write_full() pairs the
+ * nonblocking write with a bounded progress deadline (-T, default
+ * RPMSG_ETH_EPT_PROGRESS_TIMEOUT_S) so a wedged remote is noticed and
+ * treated as fatal rather than spinning silently.
+ *
+ * usage: rpmsg-eth [-s rpmsg-eth] [-t tap0] [-d /dev/rpmsgN] [-T seconds]
  * Bridges frames both ways until SIGTERM/SIGINT, then closes both fds,
  * logs relay counters to stderr, and exits 0 -- including when the signal
  * arrives while still waiting for the first endpoint, which is a clean
  * shutdown, not a failure. SIGUSR1 dumps the same counters without
  * stopping the service, for inspecting a live daemon over a serial console
- * without destroying the state you wanted to inspect. A poll() failure or
- * a fatal tap condition (see POLLERR/POLLHUP/POLLNVAL handling below) exits
- * nonzero instead, so the unit's Restart=on-failure policy actually fires
- * rather than leaving systemd thinking a broken relay exited cleanly.
+ * without destroying the state you wanted to inspect. A poll() failure, a
+ * fatal tap condition (see POLLERR/POLLHUP/POLLNVAL handling below), or the
+ * endpoint making no write progress within -T seconds exits nonzero
+ * instead, so the unit's Restart=on-failure policy actually fires rather
+ * than leaving systemd thinking a broken relay exited cleanly.
  */
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <linux/if.h>
 #include <linux/if_tun.h>
 #include <poll.h>
@@ -56,6 +67,7 @@
 #include <string.h>
 #include <sys/inotify.h>
 #include <sys/ioctl.h>
+#include <time.h>
 #include <unistd.h>
 
 struct rpmsg_endpoint_info {
@@ -82,8 +94,22 @@ struct rpmsg_endpoint_info {
  * captured whole and counted, rather than silently truncated. */
 #define BUF_LEN 2048
 
+/*
+ * How long write_full() tolerates the endpoint making no write progress
+ * before treating it as wedged (see write_full()'s comment). The kernel's
+ * own rpmsg_ctrl driver logs "timeout waiting for a tx buffer" every 15s
+ * once a vring fills and nothing drains it; this must fire before that --
+ * the daemon has to notice the stall itself, not just relay the kernel's
+ * own warning to the console a cycle late. Overridable with -T, chiefly so
+ * the test suite can use a deadline short enough to run quickly.
+ */
+#define RPMSG_ETH_EPT_PROGRESS_TIMEOUT_S 10
+
 static volatile sig_atomic_t g_stop;
 static volatile sig_atomic_t g_dump;
+/* Set by on_ept_deadline() when write_full()'s SIGALRM backstop fires (see
+ * that function). Not touched anywhere else. */
+static volatile sig_atomic_t g_ept_deadline_expired;
 
 static void on_signal(int sig)
 {
@@ -95,6 +121,12 @@ static void on_dump_signal(int sig)
 {
 	(void)sig;
 	g_dump = 1;
+}
+
+static void on_ept_deadline(int sig)
+{
+	(void)sig;
+	g_ept_deadline_expired = 1;
 }
 
 /* --- rpmsg endpoint discovery: same approach as scripts/rpmsg-ping.c --- */
@@ -254,7 +286,12 @@ static int create_ept(const char *service, enum ept_wait_reason *reason,
 		if (after & (1ULL << i))
 			break;
 	snprintf(devpath, sizeof(devpath), "/dev/rpmsg%d", i);
-	fd = open(devpath, O_RDWR);
+	/* O_NONBLOCK: see the header comment at the top of this file and
+	 * write_full()'s comment below. Without it, a CR52 that stops
+	 * draining its vring parks a write() on this fd inside the kernel
+	 * forever; the relay loop's read() tolerates the resulting EAGAIN
+	 * the same way it already tolerates EINTR (see its comment). */
+	fd = open(devpath, O_RDWR | O_NONBLOCK);
 	if (fd < 0) {
 		*reason = EPT_WAIT_OPEN_FAIL;
 		snprintf(errbuf, errbuf_len, "open(%s): %s", devpath,
@@ -292,26 +329,137 @@ static void close_ept(int fd)
 	close(fd);
 }
 
+/* write_full()'s four-way return: WRITE_FULL_OK on success (all of `len`
+ * written), 0 on a hard I/O error (errno set by the failing write()), or
+ * one of these two sentinels -- kept named, not a second use of plain
+ * 0/-1, so callers can't fold distinct outcomes back into one case:
+ *   WRITE_FULL_DEADLINE_EXPIRED -- deadline_s > 0 and the fd made no
+ *     completing write progress within that many seconds. Fatal to the
+ *     caller (rebind would very likely just hit the same wedge again);
+ *     that distinction from a hard I/O error is the entire point of this
+ *     task.
+ *   WRITE_FULL_STOPPED -- g_stop was set (a signal arrived) while this
+ *     call was retrying. Not an error at all: the caller must treat it
+ *     the same as a clean shutdown noticed anywhere else, not log it or
+ *     count it as a failure. Exists so a SIGTERM arriving while the
+ *     endpoint is wedged is not silently absorbed by the EAGAIN retry
+ *     loop below until the unrelated progress deadline happens to expire
+ *     -- see that loop's own g_stop check for why that gap existed. */
+#define WRITE_FULL_OK (1)
+#define WRITE_FULL_DEADLINE_EXPIRED (-1)
+#define WRITE_FULL_STOPPED (-2)
+
 /* Write the whole buffer, retrying on a short write (a real possibility on
  * the pty the test stands the endpoint in with, and cheap insurance on the
- * real chardev too). Returns 1 on success, 0 on a hard error (errno set by
- * the failing write()). Counts (but does not fail on) every short write.
- * A write() returning exactly 0 for a nonzero-length request is treated as
- * a hard error rather than retried: it is not a short write (no progress
- * was made at all) and looping on it would spin unbounded rather than
- * making forward progress. */
-static int write_full(int fd, const char *buf, size_t len, unsigned long *short_writes)
+ * real chardev too). Counts (but does not fail on) every short write. A
+ * write() returning exactly 0 for a nonzero-length request is treated as a
+ * hard error rather than retried: it is not a short write (no progress was
+ * made at all) and looping on it would spin unbounded rather than making
+ * forward progress.
+ *
+ * deadline_s > 0 enables the bounded-progress path this task adds, used
+ * only for writes to the rpmsg endpoint (the tap fd stays blocking and is
+ * always called with deadline_s == 0, which reproduces the old behaviour
+ * exactly: EAGAIN can't happen on a blocking fd, so that branch is simply
+ * never taken for tap writes).
+ *
+ * With the endpoint opened O_NONBLOCK, a CR52 that has stopped returning
+ * TX buffers makes write() return EAGAIN/EWOULDBLOCK instead of blocking.
+ * The old code had no such case to handle at all; the fix is not to spin
+ * on it (that would just trade a blocking-syscall spin for a busy-poll
+ * spin -- the board evidence was 100% *system* time, but a userspace spin
+ * would show as 100% *user* time, an equally silent pegged core) but to
+ * block in poll() for POLLOUT and retry, bounded by deadline_s so a
+ * genuinely wedged remote is eventually reported instead of waited on
+ * forever.
+ *
+ * The bound is enforced two ways, deliberately redundant:
+ *   1. clock_gettime(CLOCK_MONOTONIC, ...) is checked before every write()
+ *      attempt; once elapsed >= deadline_s this returns
+ *      WRITE_FULL_DEADLINE_EXPIRED without attempting another write().
+ *   2. A SIGALRM is armed for deadline_s seconds around the whole call.
+ *      The clock check above only runs between syscalls, so it cannot
+ *      help if write() itself is what's stuck -- the board evidence (100%
+ *      system time, zero voluntary context switches) is consistent with a
+ *      blocking syscall, but does not by itself prove O_NONBLOCK is
+ *      honoured on this particular kernel path all the way down. SIGALRM,
+ *      handled without SA_RESTART (see main()), interrupts a blocking
+ *      write() or poll() with EINTR no matter which one turns out to be
+ *      stuck, which hands control back to the clock check above. Cheap
+ *      insurance the very next loop iteration either way: on the expected
+ *      path this fires only as a wakeup for an already-EAGAIN-ing fd. */
+static int write_full(int fd, const char *buf, size_t len, unsigned long *short_writes,
+		       int deadline_s, double *elapsed_s_out)
 {
 	size_t off = 0;
+	struct timespec start = { 0 };
+	int have_deadline = deadline_s > 0;
+
+	if (have_deadline) {
+		clock_gettime(CLOCK_MONOTONIC, &start);
+		g_ept_deadline_expired = 0;
+		alarm((unsigned int)deadline_s);
+	}
 
 	while (off < len) {
-		ssize_t w = write(fd, buf + off, len - off);
+		ssize_t w;
+
+		if (have_deadline) {
+			struct timespec now;
+			double elapsed;
+
+			/* Checked ahead of the deadline itself: a clean stop
+			 * takes priority over a wedge report, and must not
+			 * wait out however much of the deadline is left. Only
+			 * gated on have_deadline (i.e. only for the endpoint
+			 * write, never the tap write, which stays a plain
+			 * blocking fd and cannot be sitting in this retry
+			 * loop at all) -- see this sentinel's own comment
+			 * above for why. */
+			if (g_stop) {
+				alarm(0);
+				errno = EINTR;
+				return WRITE_FULL_STOPPED;
+			}
+
+			clock_gettime(CLOCK_MONOTONIC, &now);
+			elapsed = (double)(now.tv_sec - start.tv_sec) +
+				  (double)(now.tv_nsec - start.tv_nsec) / 1e9;
+			if (g_ept_deadline_expired || elapsed >= (double)deadline_s) {
+				alarm(0);
+				if (elapsed_s_out)
+					*elapsed_s_out = elapsed;
+				errno = ETIMEDOUT;
+				return WRITE_FULL_DEADLINE_EXPIRED;
+			}
+		}
+
+		w = write(fd, buf + off, len - off);
 		if (w < 0) {
+			if (errno == EAGAIN || errno == EWOULDBLOCK) {
+				struct pollfd pfd = { .fd = fd, .events = POLLOUT };
+
+				/* Bounded: 1s when a deadline applies (so the
+				 * clock is rechecked periodically even if the
+				 * SIGALRM above were somehow lost, rather than
+				 * trusting a single mechanism), or the classic
+				 * unbounded wait when it doesn't (tap writes;
+				 * matches the pre-O_NONBLOCK behaviour, which
+				 * never spun -- it blocked in write() itself).
+				 * Either way this always blocks in poll();
+				 * never busy-retries. */
+				poll(&pfd, 1, have_deadline ? 1000 : -1);
+				continue;
+			}
 			if (errno == EINTR)
 				continue;
+			if (have_deadline)
+				alarm(0);
 			return 0;
 		}
 		if (w == 0) {
+			if (have_deadline)
+				alarm(0);
 			errno = EIO;
 			return 0;
 		}
@@ -319,7 +467,9 @@ static int write_full(int fd, const char *buf, size_t len, unsigned long *short_
 		if (off < len)
 			(*short_writes)++;
 	}
-	return 1;
+	if (have_deadline)
+		alarm(0);
+	return WRITE_FULL_OK;
 }
 
 /* Block up to 1s waiting for either a /dev change (a pending endpoint
@@ -446,7 +596,11 @@ static int open_endpoint(const char *device, const char *service, int inotify_fd
 
 		errbuf[0] = '\0';
 		if (device) {
-			fd = open(device, O_RDWR);
+			/* O_NONBLOCK for the same reason as create_ept()'s
+			 * real-endpoint open above: this -d path is the test
+			 * seam, and the test's mock endpoint stands in for a
+			 * CR52 that can wedge exactly the same way. */
+			fd = open(device, O_RDWR | O_NONBLOCK);
 			if (fd < 0)
 				snprintf(errbuf, sizeof(errbuf), "open(%s): %s",
 					 device, strerror(errno));
@@ -509,23 +663,51 @@ static void print_counters(const char *prefix, unsigned long tap_to_ept,
 		tap_write_errors, ept_write_errors, short_writes);
 }
 
+/* Parse -T's argument: a strictly positive base-10 integer count of
+ * seconds. Rejects <= 0 and anything non-numeric (trailing garbage,
+ * empty string, overflow) -- a silently-clamped or silently-zero deadline
+ * would either never fire or fire immediately, both worse than refusing
+ * to start. Returns 0 and fills *out on success, -1 on a bad value. */
+static int parse_positive_seconds(const char *s, int *out)
+{
+	char *end;
+	long v;
+
+	errno = 0;
+	v = strtol(s, &end, 10);
+	if (end == s || *end != '\0' || errno == ERANGE || v <= 0 || v > INT_MAX)
+		return -1;
+	*out = (int)v;
+	return 0;
+}
+
 int main(int argc, char **argv)
 {
 	const char *service = "rpmsg-eth", *tap_name = "tap0", *device = NULL;
 	unsigned long tap_to_ept = 0, ept_to_tap = 0, dropped_oversize = 0;
 	unsigned long tap_dropped_no_endpoint = 0;
 	unsigned long tap_write_errors = 0, ept_write_errors = 0, short_writes = 0;
+	int ept_progress_timeout_s = RPMSG_ETH_EPT_PROGRESS_TIMEOUT_S;
 	int opt, tap, ept, inotify_fd, fatal_error = 0;
 	struct sigaction sa;
 
-	while ((opt = getopt(argc, argv, "s:t:d:")) != -1) {
+	while ((opt = getopt(argc, argv, "s:t:d:T:")) != -1) {
 		switch (opt) {
 		case 's': service = optarg; break;
 		case 't': tap_name = optarg; break;
 		case 'd': device = optarg; break;
+		case 'T':
+			if (parse_positive_seconds(optarg, &ept_progress_timeout_s)) {
+				fprintf(stderr,
+					"rpmsg-eth: invalid -T value '%s': must be a "
+					"positive integer number of seconds\n",
+					optarg);
+				return 1;
+			}
+			break;
 		default:
 			fprintf(stderr,
-				"usage: %s [-s service] [-t tap] [-d device]\n",
+				"usage: %s [-s service] [-t tap] [-d device] [-T seconds]\n",
 				argv[0]);
 			return 1;
 		}
@@ -539,6 +721,15 @@ int main(int argc, char **argv)
 	memset(&sa, 0, sizeof(sa));
 	sa.sa_handler = on_dump_signal;
 	sigaction(SIGUSR1, &sa, NULL);
+
+	/* No SA_RESTART (sa.sa_flags is 0 from the memset above, same as the
+	 * other handlers): write_full()'s progress-deadline backstop relies
+	 * on this SIGALRM interrupting a blocking write()/poll() with EINTR
+	 * rather than transparently resuming it -- see write_full()'s
+	 * comment. */
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = on_ept_deadline;
+	sigaction(SIGALRM, &sa, NULL);
 
 	inotify_fd = inotify_init1(IN_NONBLOCK);
 	if (inotify_fd < 0) {
@@ -621,8 +812,11 @@ int main(int argc, char **argv)
 		 * keeps returning immediately with POLLERR set and nothing
 		 * read, sleeps, logs or exits -- a pegged core and a dead
 		 * link while the unit still reads "active (running)". Treat
-		 * it as fatal, matching the endpoint side's existing
-		 * POLLERR/POLLHUP handling below. */
+		 * it as fatal: unlike the endpoint side (which funnels
+		 * POLLERR/POLLHUP into a read() and lets the read's result
+		 * decide -- see that branch's own EAGAIN-plus-latched-flags
+		 * handling below), tap has no rebind path to fall back to,
+		 * so there is nothing productive left to retry into. */
 		if (pfd[0].revents & (POLLERR | POLLHUP | POLLNVAL)) {
 			fprintf(stderr,
 				"rpmsg-eth: tap %s reported a fatal poll condition "
@@ -641,8 +835,51 @@ int main(int argc, char **argv)
 			if (n > MAX_FRAME_LEN) {
 				dropped_oversize++;
 			} else if (n > 0) {
-				if (write_full(ept, buf, (size_t)n, &short_writes)) {
+				double stalled_s = 0;
+				int wr = write_full(ept, buf, (size_t)n, &short_writes,
+						     ept_progress_timeout_s, &stalled_s);
+
+				if (wr == WRITE_FULL_OK) {
 					tap_to_ept++;
+				} else if (wr == WRITE_FULL_DEADLINE_EXPIRED) {
+					/* The endpoint took the whole
+					 * progress deadline without accepting
+					 * this frame -- a wedged CR52, the
+					 * defect this task exists to catch.
+					 * Fatal, not a rebind: unlike EOF/a
+					 * write error, nothing here tells us
+					 * the CR52 is gone and a fresh
+					 * endpoint would help: create_ept()
+					 * would very likely just bind the
+					 * same wedged channel again. Exiting
+					 * lets systemd apply its restart
+					 * policy and back off / alert instead
+					 * of this daemon silently retrying
+					 * into the same wall. */
+					fprintf(stderr,
+						"rpmsg-eth: endpoint %s did not finish "
+						"writing a frame within %.1fs (deadline "
+						"%ds) -- treating as wedged and exiting "
+						"so the service manager can restart us\n",
+						device ? device : service, stalled_s,
+						ept_progress_timeout_s);
+					print_counters("counters", tap_to_ept, ept_to_tap,
+							dropped_oversize, tap_dropped_no_endpoint,
+							tap_write_errors, ept_write_errors,
+							short_writes);
+					fatal_error = 1;
+					break;
+				} else if (wr == WRITE_FULL_STOPPED) {
+					/* g_stop was set while this write was
+					 * retrying (e.g. SIGTERM arrived while
+					 * the endpoint was wedged). Not an
+					 * error and not logged as one: fall out
+					 * of the relay loop the same way a
+					 * SIGTERM arriving between poll()
+					 * iterations already does, so a clean
+					 * stop still exits 0 through the single
+					 * exit path at the bottom of main(). */
+					break;
 				} else {
 					tap_write_errors++;
 					fprintf(stderr,
@@ -672,7 +909,12 @@ int main(int argc, char **argv)
 		    (pfd[1].revents & (POLLIN | POLLHUP | POLLERR))) {
 			n = read(ept, buf, sizeof(buf));
 			if (n > 0) {
-				if (write_full(tap, buf, (size_t)n, &short_writes)) {
+				/* No deadline on this write: it targets tap,
+				 * which stays a blocking fd (see tap_open()),
+				 * so write_full() never sees EAGAIN here and
+				 * this call behaves exactly as it always has. */
+				if (write_full(tap, buf, (size_t)n, &short_writes, 0, NULL) ==
+				    WRITE_FULL_OK) {
 					ept_to_tap++;
 				} else {
 					ept_write_errors++;
@@ -680,10 +922,59 @@ int main(int argc, char **argv)
 						"rpmsg-eth: write(tap) failed: %s\n",
 						strerror(errno));
 				}
-			} else if (n < 0 && (errno == EINTR || errno == EAGAIN)) {
-				/* Transient; not a disconnect. Retry next
-				 * poll iteration instead of tearing down a
-				 * live endpoint. */
+			} else if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK) &&
+				   (pfd[1].revents & (POLLHUP | POLLERR))) {
+				/* EAGAIN alone (the branch below) would be an
+				 * ordinary spurious/raced wakeup, safe to just
+				 * retry next poll(). But POLLHUP/POLLERR having
+				 * *also* latched on this fd means poll() will
+				 * keep reporting them on every following call
+				 * regardless of whether there is ever anything
+				 * to read -- with the endpoint's old blocking
+				 * fd that combination could not reach here at
+				 * all (the read would have delivered whatever
+				 * made those flags true instead of EAGAIN), but
+				 * O_NONBLOCK opens up exactly this gap: falling
+				 * into the plain-transient branch below would
+				 * return to poll(pfd, 2, -1) above, which
+				 * reports the same still-latched revents
+				 * immediately, forever -- an unbounded busy
+				 * loop (100% user time this time, not the
+				 * system time the board saw, but an equally
+				 * silent pegged core) on the very fd this task
+				 * exists to stop spinning on. Upstream
+				 * rpmsg_char is not known to produce this
+				 * combination (a destroyed ept gives EPIPE, a
+				 * hung-up chardev gives EIO or a 0-byte read,
+				 * both already handled by the branch further
+				 * below), but this daemon runs against a
+				 * vendor kernel, and betting a busy-loop on
+				 * that mapping holding is exactly the kind of
+				 * assumption write_full()'s SIGALRM backstop
+				 * exists to not make. Treat it the same as the
+				 * EOF/read-error branch further below: rebind
+				 * rather than trust the read side to notice on
+				 * its own. */
+				fprintf(stderr,
+					"rpmsg-eth: endpoint lost (EAGAIN with a latched "
+					"fatal poll condition), rebinding\n");
+				close_ept(ept);
+				ept = open_endpoint(device, service, inotify_fd,
+						     tap, tap_name,
+						     &tap_dropped_no_endpoint);
+				if (ept == OPEN_ENDPOINT_TAP_FATAL)
+					fatal_error = 1;
+			} else if (n < 0 && (errno == EINTR || errno == EAGAIN ||
+					      errno == EWOULDBLOCK)) {
+				/* Transient; not a disconnect. EAGAIN/
+				 * EWOULDBLOCK is expected now that the
+				 * endpoint is O_NONBLOCK: a POLLIN wakeup can
+				 * still race another consumer or be spurious.
+				 * Retry next poll iteration instead of
+				 * tearing down a live endpoint or counting
+				 * this as an error. (The POLLHUP/POLLERR
+				 * variant of this is handled separately above
+				 * -- it must not fall through to here.) */
 			} else {
 				/* n == 0 (EOF) or a genuine read error:
 				 * CR52 reset. Rebind and keep going rather

--- a/platforms/autosd/x5h/rpmsg-eth/rpmsg-eth.c
+++ b/platforms/autosd/x5h/rpmsg-eth/rpmsg-eth.c
@@ -331,9 +331,22 @@ static int write_full(int fd, const char *buf, size_t len, unsigned long *short_
  * loop at roughly 1Hz: inotify only wakes it early when a device node
  * actually changes under /dev, and a channel announcement need not create
  * anything there at all (the new node appears under /sys/class/rpmsg,
- * which this function does not watch). */
-static void wait_for_dev_or_tap(int inotify_fd, int tap_fd,
-				 unsigned long *tap_dropped_no_endpoint)
+ * which this function does not watch).
+ *
+ * Returns 1 if the tap fd reported POLLERR/POLLHUP/POLLNVAL -- the same
+ * fatal condition the steady-state relay loop below treats as fatal, and
+ * for the same reason: POLLERR is delivered regardless of requested
+ * events and latches once the tap stops being a live, registered
+ * netdevice (e.g. `ip link del tap0` under the daemon), so poll() would
+ * otherwise return immediately, forever, instead of waiting out its 1s
+ * timeout. That defeats the ~1Hz retry pacing this function exists to
+ * provide and turns the endpoint wait into a full-speed busy loop instead
+ * of a silent hang. Returns 0 otherwise (the ordinary 1s timeout, an
+ * inotify wakeup, or a tap frame drained above). The caller must treat a
+ * 1 as fatal and stop retrying -- there is no timeout left to pace a
+ * retry against once the tap fd itself is broken. */
+static int wait_for_dev_or_tap(int inotify_fd, int tap_fd, const char *tap_name,
+				unsigned long *tap_dropped_no_endpoint)
 {
 	struct pollfd pfd[2] = {
 		{ .fd = inotify_fd, .events = POLLIN },
@@ -342,17 +355,32 @@ static void wait_for_dev_or_tap(int inotify_fd, int tap_fd,
 	char ibuf[1024], fbuf[BUF_LEN];
 
 	if (poll(pfd, 2, 1000) <= 0)
-		return;
+		return 0;
+
+	if (pfd[1].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+		fprintf(stderr,
+			"rpmsg-eth: tap %s reported a fatal poll condition "
+			"(POLLERR=%d POLLHUP=%d POLLNVAL=%d) while waiting "
+			"for the endpoint -- exiting so the service manager "
+			"can restart us\n",
+			tap_name,
+			!!(pfd[1].revents & POLLERR),
+			!!(pfd[1].revents & POLLHUP),
+			!!(pfd[1].revents & POLLNVAL));
+		return 1;
+	}
+
 	if (pfd[0].revents & POLLIN) {
 		if (read(inotify_fd, ibuf, sizeof(ibuf)) < 0 &&
 		    errno != EINTR && errno != EAGAIN)
-			return;
+			return 0;
 	}
 	if (pfd[1].revents & POLLIN) {
 		ssize_t n = read(tap_fd, fbuf, sizeof(fbuf));
 		if (n > 0)
 			(*tap_dropped_no_endpoint)++;
 	}
+	return 0;
 }
 
 static const char *ept_wait_reason_str(enum ept_wait_reason reason)
@@ -367,13 +395,31 @@ static const char *ept_wait_reason_str(enum ept_wait_reason reason)
 	return "unknown";
 }
 
+/* open_endpoint()'s two ways of giving up without a bound endpoint. Kept
+ * as named negative sentinels, not a bare -1, precisely so a fatal tap
+ * condition can no longer be conflated with a clean-shutdown signal --
+ * that conflation was the bug this fixes. */
+#define OPEN_ENDPOINT_STOPPED   (-1)
+#define OPEN_ENDPOINT_TAP_FATAL (-2)
+
 /* Open the endpoint: `device` directly if given (test seam), else wait for
  * the CR52 to announce `service` and bind it. Retries indefinitely (until
- * a signal arrives), so the daemon is start-order independent and survives
- * the endpoint going away and coming back across a CR52 reset. tap is kept
- * drained (see wait_for_dev_or_tap) while this blocks. Returns -1 only
- * when g_stop was set (a signal arrived); callers should treat that as a
- * clean-shutdown request, not an error.
+ * a signal arrives or the tap fd hits a fatal condition), so the daemon is
+ * start-order independent and survives the endpoint going away and coming
+ * back across a CR52 reset. tap is kept drained (see wait_for_dev_or_tap)
+ * while this blocks.
+ *
+ * Returns the open fd (>= 0) on success, or one of two negative sentinels
+ * on giving up -- these must not be conflated, since only one of them is a
+ * clean shutdown:
+ *   OPEN_ENDPOINT_STOPPED    -- g_stop was set (a signal arrived); callers
+ *                                should treat this as a clean-shutdown
+ *                                request, not an error.
+ *   OPEN_ENDPOINT_TAP_FATAL  -- wait_for_dev_or_tap() saw POLLERR/POLLHUP/
+ *                                POLLNVAL on the tap fd (already logged
+ *                                there); callers must exit nonzero, the
+ *                                same as the steady-state relay loop's
+ *                                handling of the identical condition.
  *
  * Logs once on entering the wait (naming what is being waited for), once
  * on the first occurrence of each distinct failure reason, every ~30
@@ -383,7 +429,8 @@ static const char *ept_wait_reason_str(enum ept_wait_reason reason)
  * hang on a serial console with no way to inspect process state; these
  * lines are the only thing that tells the two apart. */
 static int open_endpoint(const char *device, const char *service, int inotify_fd,
-			  int tap_fd, unsigned long *tap_dropped_no_endpoint)
+			  int tap_fd, const char *tap_name,
+			  unsigned long *tap_dropped_no_endpoint)
 {
 	unsigned long attempt = 0;
 	int have_last_reason = 0;
@@ -413,7 +460,7 @@ static int open_endpoint(const char *device, const char *service, int inotify_fd
 			return fd;
 		}
 		if (g_stop)
-			return -1;
+			return OPEN_ENDPOINT_STOPPED;
 
 		attempt++;
 		if (!have_last_reason || reason != last_reason ||
@@ -425,7 +472,9 @@ static int open_endpoint(const char *device, const char *service, int inotify_fd
 			last_reason = reason;
 			have_last_reason = 1;
 		}
-		wait_for_dev_or_tap(inotify_fd, tap_fd, tap_dropped_no_endpoint);
+		if (wait_for_dev_or_tap(inotify_fd, tap_fd, tap_name,
+					 tap_dropped_no_endpoint))
+			return OPEN_ENDPOINT_TAP_FATAL;
 	}
 }
 
@@ -509,24 +558,30 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	ept = open_endpoint(device, service, inotify_fd, tap, &tap_dropped_no_endpoint);
-	if (ept < 0 && !g_stop) {
-		/* open_endpoint() only gives up when g_stop is set; this is
-		 * defensive, not a path we expect to hit. */
+	ept = open_endpoint(device, service, inotify_fd, tap, tap_name,
+			     &tap_dropped_no_endpoint);
+	if (ept == OPEN_ENDPOINT_TAP_FATAL) {
+		fatal_error = 1;
+	} else if (ept < 0 && !g_stop) {
+		/* open_endpoint() only gives up when g_stop is set or the
+		 * tap fd hit a fatal condition (OPEN_ENDPOINT_TAP_FATAL,
+		 * handled above); this remaining branch is defensive, not a
+		 * path we expect to hit. */
 		fprintf(stderr, "rpmsg-eth: stopped waiting for endpoint\n");
-		close(tap);
-		close(inotify_fd);
-		return 1;
+		fatal_error = 1;
 	}
 
-	/* If a signal arrived while still waiting above, ept is -1 and
-	 * g_stop is set: fall straight through to the shared shutdown path
-	 * below (skipping the loop) so this is exit 0, the same as a signal
-	 * during the loop -- "exit 0 on clean SIGTERM" holds regardless of
-	 * when the signal lands. Otherwise both fds are open and we are
-	 * about to enter the poll loop: print a readiness marker so a
-	 * caller (test-rpmsg-eth.sh, under QEMU TCG in CI, cannot assume a
-	 * fixed startup latency) can wait on it instead of guessing. */
+	/* If we are giving up here -- g_stop was set, or the tap fd hit a
+	 * fatal condition above -- ept is negative, so the while loop below
+	 * never runs and this falls straight through to the shared shutdown
+	 * path at the bottom, which returns fatal_error ? 1 : 0. That keeps
+	 * "exit 0 on a clean SIGTERM" true regardless of when the signal
+	 * lands, while a fatal tap condition still exits nonzero, exactly
+	 * like the steady-state relay loop's handling of the identical
+	 * condition. Otherwise both fds are open and we are about to enter
+	 * the poll loop: print a readiness marker so a caller
+	 * (test-rpmsg-eth.sh, under QEMU TCG in CI, cannot assume a fixed
+	 * startup latency) can wait on it instead of guessing. */
 	if (ept >= 0)
 		fprintf(stderr, "rpmsg-eth: ready\n");
 
@@ -604,7 +659,10 @@ int main(int argc, char **argv)
 						"rpmsg-eth: endpoint lost (write failed), rebinding\n");
 					close_ept(ept);
 					ept = open_endpoint(device, service, inotify_fd,
-							     tap, &tap_dropped_no_endpoint);
+							     tap, tap_name,
+							     &tap_dropped_no_endpoint);
+					if (ept == OPEN_ENDPOINT_TAP_FATAL)
+						fatal_error = 1;
 					reconnected = 1;
 				}
 			}
@@ -634,7 +692,10 @@ int main(int argc, char **argv)
 					"rpmsg-eth: endpoint lost (EOF/read error), rebinding\n");
 				close_ept(ept);
 				ept = open_endpoint(device, service, inotify_fd,
-						     tap, &tap_dropped_no_endpoint);
+						     tap, tap_name,
+						     &tap_dropped_no_endpoint);
+				if (ept == OPEN_ENDPOINT_TAP_FATAL)
+					fatal_error = 1;
 			}
 		}
 	}

--- a/platforms/autosd/x5h/rpmsg-eth/rpmsg-eth.c
+++ b/platforms/autosd/x5h/rpmsg-eth/rpmsg-eth.c
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * rpmsg-eth: bridges the CR52's rpmsg-eth endpoint chardev to a Linux TAP
+ * device, so the kernel network stack (and CycloneDDS above it) sees an
+ * ordinary Ethernet interface. One RPMsg message == one Ethernet frame in
+ * both directions; the endpoint chardev is datagram-oriented, so a single
+ * read() always returns exactly one frame.
+ *
+ * Endpoint discovery follows scripts/rpmsg-ping.c: scan
+ * /sys/bus/rpmsg/devices for the channel whose `name` matches -s, read its
+ * `dst`, and create the char endpoint via /dev/rpmsg_ctrl* +
+ * RPMSG_CREATE_EPT_IOCTL. The CR52 announces its channel exactly once per
+ * reset, so this daemon does not fail fast when the channel is absent: it
+ * waits (woken by inotify on /dev, so it isn't a busy-poll) and retries,
+ * both at startup and whenever the endpoint goes away later (another CR52
+ * reset) -- start-order independence in both directions.
+ *
+ * -d bypasses discovery and opens a device path directly. It exists as a
+ * test seam: test-rpmsg-eth.sh points it at one end of a socat pty pair
+ * standing in for the real endpoint chardev.
+ *
+ * usage: rpmsg-eth [-s rpmsg-eth] [-t tap0] [-d /dev/rpmsgN]
+ * Bridges frames both ways until SIGTERM/SIGINT, then closes both fds,
+ * logs relay counters to stderr, and exits 0.
+ */
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/if.h>
+#include <linux/if_tun.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/inotify.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+struct rpmsg_endpoint_info {
+	char name[32];
+	uint32_t src;
+	uint32_t dst;
+};
+#define RPMSG_CREATE_EPT_IOCTL _IOW(0xb5, 0x1, struct rpmsg_endpoint_info)
+#define RPMSG_ADDR_ANY 0xFFFFFFFF
+
+/*
+ * Largest Ethernet frame this bridge will relay tap -> endpoint: netif MTU
+ * 462 (frozen with the FreeRTOS side) + a 14-byte Ethernet header = 476.
+ * That equals the biggest frame the CR52 side is built to accept, and it
+ * sits comfortably under the 496-byte RPMsg payload budget. Anything
+ * larger is dropped here rather than handed to write(): a local drop is
+ * recoverable, but writing an oversize frame to the endpoint would just
+ * turn into a write() failure on the other side of the same trade-off.
+ * With MTU 462 enforced on the tap interface this must never trigger.
+ */
+#define MAX_FRAME_LEN 476
+/* Read buffer: comfortably above MAX_FRAME_LEN so an oversize frame is
+ * captured whole and counted, rather than silently truncated. */
+#define BUF_LEN 2048
+
+static volatile sig_atomic_t g_stop;
+
+static void on_signal(int sig)
+{
+	(void)sig;
+	g_stop = 1;
+}
+
+/* --- rpmsg endpoint discovery: same approach as scripts/rpmsg-ping.c --- */
+
+static int read_sysfs(const char *path, char *buf, size_t len)
+{
+	FILE *f = fopen(path, "r");
+	if (!f)
+		return -1;
+	if (!fgets(buf, (int)len, f)) {
+		fclose(f);
+		return -1;
+	}
+	fclose(f);
+	buf[strcspn(buf, "\n")] = '\0';
+	return 0;
+}
+
+/* Find the rpmsg device announcing `service`; return its dst address. */
+static int find_service(const char *service, uint32_t *dst)
+{
+	DIR *d = opendir("/sys/bus/rpmsg/devices");
+	struct dirent *e;
+	char path[512], val[64];
+
+	if (!d)
+		return -1;
+	while ((e = readdir(d))) {
+		if (e->d_name[0] == '.')
+			continue;
+		snprintf(path, sizeof(path),
+			 "/sys/bus/rpmsg/devices/%s/name", e->d_name);
+		if (read_sysfs(path, val, sizeof(val)))
+			continue;
+		if (strcmp(val, service))
+			continue;
+		snprintf(path, sizeof(path),
+			 "/sys/bus/rpmsg/devices/%s/dst", e->d_name);
+		if (read_sysfs(path, val, sizeof(val)))
+			continue;
+		*dst = (uint32_t)strtoul(val, NULL, 0);
+		closedir(d);
+		return 0;
+	}
+	closedir(d);
+	return -1;
+}
+
+/* Bitmap of /dev/rpmsgN minors that exist right now (N < 64). */
+static uint64_t eptdev_snapshot(void)
+{
+	uint64_t set = 0;
+	DIR *d = opendir("/sys/class/rpmsg");
+	struct dirent *e;
+
+	if (!d)
+		return 0;
+	while ((e = readdir(d))) {
+		unsigned n;
+		if (sscanf(e->d_name, "rpmsg%u", &n) == 1 && n < 64)
+			set |= 1ULL << n;
+	}
+	closedir(d);
+	return set;
+}
+
+static int open_ctrl(void)
+{
+	char path[64];
+	int i, fd;
+
+	for (i = 0; i < 8; i++) {
+		snprintf(path, sizeof(path), "/dev/rpmsg_ctrl%d", i);
+		fd = open(path, O_RDWR);
+		if (fd >= 0)
+			return fd;
+	}
+	return -1;
+}
+
+/* Create and open the char endpoint bound to `service`'s announced
+ * channel. Returns the open fd, or -1 if the channel isn't announced (yet)
+ * or endpoint creation failed. */
+static int create_ept(const char *service)
+{
+	struct rpmsg_endpoint_info info;
+	uint32_t dst;
+	uint64_t before, after;
+	char devpath[64];
+	int ctrl, i;
+
+	if (find_service(service, &dst))
+		return -1;
+	ctrl = open_ctrl();
+	if (ctrl < 0)
+		return -1;
+	memset(&info, 0, sizeof(info));
+	snprintf(info.name, sizeof(info.name), "%s", service);
+	info.src = RPMSG_ADDR_ANY;
+	info.dst = dst;
+	before = eptdev_snapshot();
+	if (ioctl(ctrl, RPMSG_CREATE_EPT_IOCTL, &info)) {
+		close(ctrl);
+		return -1;
+	}
+	close(ctrl);
+	after = eptdev_snapshot() & ~before;
+	if (!after)
+		return -1;
+	for (i = 0; i < 64; i++)
+		if (after & (1ULL << i))
+			break;
+	snprintf(devpath, sizeof(devpath), "/dev/rpmsg%d", i);
+	return open(devpath, O_RDWR);
+}
+
+/* Block up to 1s for a /dev change, so a pending discovery/reconnect wakes
+ * promptly instead of busy-polling. The timeout also re-checks
+ * periodically in case the channel appears without a /dev event we're
+ * watching for. */
+static void wait_for_dev_change(int inotify_fd)
+{
+	struct pollfd pfd = { .fd = inotify_fd, .events = POLLIN };
+	char buf[1024];
+
+	if (poll(&pfd, 1, 1000) > 0 && read(inotify_fd, buf, sizeof(buf)) < 0)
+		return;
+}
+
+/* Open the endpoint: `device` directly if given (test seam), else wait for
+ * the CR52 to announce `service` and bind it. Retries indefinitely (until
+ * a signal arrives), so the daemon is start-order independent and survives
+ * the endpoint going away and coming back across a CR52 reset. */
+static int open_endpoint(const char *device, const char *service, int inotify_fd)
+{
+	for (;;) {
+		int fd = device ? open(device, O_RDWR) : create_ept(service);
+		if (fd >= 0)
+			return fd;
+		if (g_stop)
+			return -1;
+		wait_for_dev_change(inotify_fd);
+	}
+}
+
+static int tap_open(const char *name)
+{
+	struct ifreq ifr;
+	int fd = open("/dev/net/tun", O_RDWR);
+
+	if (fd < 0)
+		return -1;
+	memset(&ifr, 0, sizeof(ifr));
+	ifr.ifr_flags = IFF_TAP | IFF_NO_PI;
+	snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", name);
+	if (ioctl(fd, TUNSETIFF, &ifr)) {
+		close(fd);
+		return -1;
+	}
+	return fd;
+}
+
+int main(int argc, char **argv)
+{
+	const char *service = "rpmsg-eth", *tap_name = "tap0", *device = NULL;
+	unsigned long tap_to_ept = 0, ept_to_tap = 0, dropped_oversize = 0;
+	int opt, tap, ept, inotify_fd;
+	struct sigaction sa;
+
+	while ((opt = getopt(argc, argv, "s:t:d:")) != -1) {
+		switch (opt) {
+		case 's': service = optarg; break;
+		case 't': tap_name = optarg; break;
+		case 'd': device = optarg; break;
+		default:
+			fprintf(stderr,
+				"usage: %s [-s service] [-t tap] [-d device]\n",
+				argv[0]);
+			return 1;
+		}
+	}
+
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = on_signal;
+	sigaction(SIGTERM, &sa, NULL);
+	sigaction(SIGINT, &sa, NULL);
+
+	inotify_fd = inotify_init1(IN_NONBLOCK);
+	if (inotify_fd < 0) {
+		fprintf(stderr, "rpmsg-eth: inotify_init1: %s\n", strerror(errno));
+		return 1;
+	}
+	if (inotify_add_watch(inotify_fd, "/dev", IN_CREATE) < 0) {
+		fprintf(stderr, "rpmsg-eth: inotify_add_watch(/dev): %s\n",
+			strerror(errno));
+		return 1;
+	}
+
+	tap = tap_open(tap_name);
+	if (tap < 0) {
+		fprintf(stderr, "rpmsg-eth: tap_open(%s): %s\n", tap_name,
+			strerror(errno));
+		return 1;
+	}
+
+	ept = open_endpoint(device, service, inotify_fd);
+	if (ept < 0) {
+		fprintf(stderr, "rpmsg-eth: stopped waiting for endpoint\n");
+		close(tap);
+		return 1;
+	}
+
+	while (!g_stop) {
+		struct pollfd pfd[2] = {
+			{ .fd = tap, .events = POLLIN },
+			{ .fd = ept, .events = POLLIN },
+		};
+		char buf[BUF_LEN];
+		ssize_t n;
+
+		if (poll(pfd, 2, -1) < 0) {
+			if (errno == EINTR)
+				continue;
+			fprintf(stderr, "rpmsg-eth: poll: %s\n", strerror(errno));
+			break;
+		}
+
+		if (pfd[0].revents & POLLIN) {
+			n = read(tap, buf, sizeof(buf));
+			if (n > MAX_FRAME_LEN)
+				dropped_oversize++;
+			else if (n > 0 && write(ept, buf, (size_t)n) == n)
+				tap_to_ept++;
+		}
+
+		if (pfd[1].revents & (POLLIN | POLLHUP | POLLERR)) {
+			n = read(ept, buf, sizeof(buf));
+			if (n > 0) {
+				if (write(tap, buf, (size_t)n) == n)
+					ept_to_tap++;
+			} else {
+				/* Endpoint closed: CR52 reset. Rebind and
+				 * keep going rather than exiting. */
+				close(ept);
+				ept = open_endpoint(device, service, inotify_fd);
+				if (ept < 0)
+					break;
+			}
+		}
+	}
+
+	close(tap);
+	if (ept >= 0)
+		close(ept);
+	close(inotify_fd);
+	fprintf(stderr,
+		"rpmsg-eth: exiting tap_to_ept=%lu ept_to_tap=%lu dropped_oversize=%lu\n",
+		tap_to_ept, ept_to_tap, dropped_oversize);
+	return 0;
+}

--- a/platforms/autosd/x5h/rpmsg-eth/test-rpmsg-eth.sh
+++ b/platforms/autosd/x5h/rpmsg-eth/test-rpmsg-eth.sh
@@ -1,7 +1,28 @@
 #!/usr/bin/env bash
 # Round-trips frames between a TAP device and a mock endpoint (socat pty).
-# Needs: unshared netns (no root on CI runners): run under 'unshare -rn'.
+#
+# Self-wrapping: this needs a private network namespace so tap0/ip commands
+# can't collide with other things on the box (no root required on CI
+# runners that allow unprivileged user namespaces). Rather than making
+# every caller remember an external 'unshare -rn' wrapper, re-exec
+# ourselves under it if we don't already have one. If a private netns
+# can't be created at all (e.g. a host policy denies unprivileged user
+# namespaces), fail loudly and distinctly -- never silently skip, never
+# exit 0.
 set -euo pipefail
+if [ -z "${RPMSG_ETH_TEST_UNSHARED:-}" ]; then
+	if ! command -v unshare >/dev/null 2>&1; then
+		echo "TEST_FAIL: unshare not available, cannot get a private netns" >&2
+		exit 1
+	fi
+	if ! err=$(unshare -rn true 2>&1); then
+		echo "TEST_FAIL: cannot create a private network namespace (unshare -rn): $err" >&2
+		exit 1
+	fi
+	export RPMSG_ETH_TEST_UNSHARED=1
+	exec unshare -rn "$0" "$@"
+fi
+
 cd "$(dirname "$0")"
 make
 PTY_DIR=$(mktemp -d)
@@ -14,12 +35,32 @@ sleep 0.3
 ping -c1 -W1 172.16.52.2 >/dev/null 2>&1 || true
 timeout 2 dd if="$PTY_DIR/epB" bs=600 count=1 2>/dev/null | xxd | grep -qi '0806' \
   || { echo "TEST_FAIL: no ARP frame relayed tap->endpoint"; exit 1; }
-# …and a frame written to epB must reach tap0 (checked via tcpdump on
-# tap0, filtered on the injected frame's own src MAC -- tap0 emits its own
-# ARP retries with its *own* auto-assigned MAC while unresolved, and an
-# unfiltered capture would count one of those as a false pass).
-timeout 2 tcpdump -c1 -i tap0 -w /dev/null 'ether src 02:5c:52:00:00:02' & TD=$!
+# …and a frame written to epB must reach tap0 *intact* (checked via
+# tcpdump on tap0, filtered on the injected frame's own src MAC -- tap0
+# emits its own ARP retries with its *own* auto-assigned MAC while
+# unresolved, and an unfiltered capture would count one of those as a
+# false pass). Checking the payload survived, not just that a
+# matching-source frame arrived, is what catches a truncated/short-written
+# relay that a mere presence check would miss.
+CAP="$PTY_DIR/cap.pcap"
+# -Z root on both tcpdump invocations below: under 'unshare -r' only uid 0
+# is mapped into the namespace, so tcpdump's default privilege-drop dance
+# (to its own service user for the live capture, chowning the savefile; to
+# the invoking user when re-reading it) targets a uid that doesn't exist
+# in here and errors out -- on the live capture before it captures
+# anything, on the re-read before it prints anything, in both cases
+# silently starving the grep below rather than failing loudly itself.
+# timeout's plain form only sends SIGTERM at the deadline: tcpdump's
+# libpcap capture loop checks for a pending signal between packets, so
+# when no matching packet ever arrives (the exact case this fault-check
+# exists for) tcpdump doesn't act on the SIGTERM and hangs past the
+# deadline, wedging this test instead of failing it. '-k 1' makes timeout
+# escalate to SIGKILL 1s after SIGTERM if tcpdump is still alive, so a
+# broken relay is reported as TEST_FAIL instead of hanging forever.
+timeout -k 1 2 tcpdump -Z root -c1 -i tap0 -w "$CAP" 'ether src 02:5c:52:00:00:02' & TD=$!
 sleep 0.3
 printf '\xff\xff\xff\xff\xff\xff\x02\x5c\x52\x00\x00\x02\x08\x06test' > "$PTY_DIR/epB"
 wait $TD || { echo "TEST_FAIL: no frame relayed endpoint->tap"; exit 1; }
+tcpdump -Z root -r "$CAP" -A -n 2>/dev/null | grep -q 'test' \
+  || { echo "TEST_FAIL: frame relayed endpoint->tap but payload truncated"; exit 1; }
 kill $DAEMON $SOCAT; echo "TEST_PASS"

--- a/platforms/autosd/x5h/rpmsg-eth/test-rpmsg-eth.sh
+++ b/platforms/autosd/x5h/rpmsg-eth/test-rpmsg-eth.sh
@@ -25,16 +25,73 @@ fi
 
 cd "$(dirname "$0")"
 make
+
+# wait_until DESC MAX_TRIES PREDICATE...
+# Polls PREDICATE every 0.1s until it succeeds, up to MAX_TRIES times.
+# Bounds below are generous because this test also runs inside the real
+# CI gate under QEMU TCG (no KVM) on top of a podman container on top of
+# this script's own unshare'd netns -- there, plain process startup
+# (fork+exec+dynamic-link, privilege drop, BPF filter compilation) has
+# been measured taking one to two orders of magnitude longer in real
+# seconds than on a dev box or a bare podman container. A fixed short
+# sleep tuned for the fast case is not a safe stand-in for "the thing we
+# are about to depend on is actually ready" -- it happened to be enough
+# on every machine this test was written and reviewed on, and then
+# wasn't, in the one environment that matters most. Every wait_until
+# failure below is worded distinctly from the relay-broke TEST_FAILs
+# further down, so a readiness timeout in CI is never misread as a
+# protocol/relay bug, or vice versa.
+wait_until() {
+	local desc="$1" max_tries="$2"
+	shift 2
+	local i=0
+	until "$@"; do
+		i=$((i + 1))
+		if [ "$i" -ge "$max_tries" ]; then
+			echo "TEST_FAIL: timed out waiting for $desc" >&2
+			exit 1
+		fi
+		sleep 0.1
+	done
+}
+
 PTY_DIR=$(mktemp -d)
+DAEMON_LOG="$PTY_DIR/daemon.log"
+TCPDUMP_LOG="$PTY_DIR/tcpdump.log"
+
+pty_pair_ready() {
+	[ -e "$PTY_DIR/epA" ] && [ -e "$PTY_DIR/epB" ]
+}
+
 socat -d PTY,raw,echo=0,link="$PTY_DIR/epA" PTY,raw,echo=0,link="$PTY_DIR/epB" & SOCAT=$!
-sleep 0.3
+wait_until "socat's pty pair to appear" 300 pty_pair_ready
+
 ip tuntap add dev tap0 mode tap && ip link set tap0 up && ip addr add 172.16.52.1/24 dev tap0
-./rpmsg-eth -t tap0 -d "$PTY_DIR/epA" & DAEMON=$!
-sleep 0.3
-# An ARP probe out of tap0 must appear on epB…
+
+# The daemon prints "rpmsg-eth: ready" (see rpmsg-eth.c) once it has both
+# the tap fd and the endpoint fd open and is about to enter its poll
+# loop -- that is the one thing that actually matters here, so wait for
+# it directly instead of guessing how long "fork, open two fds" takes.
+daemon_ready() {
+	if ! kill -0 "$DAEMON" 2>/dev/null; then
+		echo "TEST_FAIL: daemon exited before becoming ready" >&2
+		cat "$DAEMON_LOG" >&2 2>/dev/null || true
+		exit 1
+	fi
+	grep -q 'rpmsg-eth: ready' "$DAEMON_LOG" 2>/dev/null
+}
+
+./rpmsg-eth -t tap0 -d "$PTY_DIR/epA" >"$DAEMON_LOG" 2>&1 & DAEMON=$!
+wait_until "daemon to open both fds and become ready" 300 daemon_ready
+
+# An ARP probe out of tap0 must appear on epB. Bounded generously (see
+# wait_until's comment on why) rather than left at a couple of seconds;
+# the daemon is already confirmed ready above, so this is only timing
+# out on the actual relay, which is what should make it fail.
 ping -c1 -W1 172.16.52.2 >/dev/null 2>&1 || true
-timeout 2 dd if="$PTY_DIR/epB" bs=600 count=1 2>/dev/null | xxd | grep -qi '0806' \
+timeout 10 dd if="$PTY_DIR/epB" bs=600 count=1 2>/dev/null | xxd | grep -qi '0806' \
   || { echo "TEST_FAIL: no ARP frame relayed tap->endpoint"; exit 1; }
+
 # …and a frame written to epB must reach tap0 *intact* (checked via
 # tcpdump on tap0, filtered on the injected frame's own src MAC -- tap0
 # emits its own ARP retries with its *own* auto-assigned MAC while
@@ -54,13 +111,47 @@ CAP="$PTY_DIR/cap.pcap"
 # libpcap capture loop checks for a pending signal between packets, so
 # when no matching packet ever arrives (the exact case this fault-check
 # exists for) tcpdump doesn't act on the SIGTERM and hangs past the
-# deadline, wedging this test instead of failing it. '-k 1' makes timeout
-# escalate to SIGKILL 1s after SIGTERM if tcpdump is still alive, so a
+# deadline, wedging this test instead of failing it. '-k 2' makes timeout
+# escalate to SIGKILL 2s after SIGTERM if tcpdump is still alive, so a
 # broken relay is reported as TEST_FAIL instead of hanging forever.
-timeout -k 1 2 tcpdump -Z root -c1 -i tap0 -w "$CAP" 'ether src 02:5c:52:00:00:02' & TD=$!
-sleep 0.3
+#
+# The capture window is 5s (not the 2s this started at): once tcpdump is
+# confirmed live (below) the frame is injected immediately, so this
+# budget only has to cover the relay+capture itself, but it is kept
+# generous for the same TCG-is-much-slower reason as wait_until.
+timeout -k 2 5 tcpdump -Z root -c1 -i tap0 -w "$CAP" 'ether src 02:5c:52:00:00:02' \
+  >"$TCPDUMP_LOG" 2>&1 & TD=$!
+
+# tcpdump prints "... listening on tap0, ..." (to the log above) only
+# once pcap_activate() has actually attached the BPF filter to the
+# interface -- i.e. once the capture is genuinely live. This replaced a
+# fixed 'sleep 0.3' before injecting the frame: on this test's very
+# first real run under the CI gate's QEMU-TCG guest, tcpdump's own
+# fork+exec+dynamic-link+filter-compile startup took long enough (on the
+# order of a couple of real seconds, inferred from a ~2.6s gap between
+# tap0 becoming ready and tcpdump actually entering promiscuous mode,
+# plus tcpdump exiting well before the 2s SIGTERM deadline it was given
+# -- see task-9-report.md's CI-failure fix report for the full timeline)
+# that the frame was written to epB, and presumably relayed, before
+# tcpdump had attached at all -- the capture then correctly reported 0
+# packets, because there was nothing left to see by the time it started
+# watching.
+tcpdump_ready() {
+	if ! kill -0 "$TD" 2>/dev/null; then
+		echo "TEST_FAIL: tcpdump exited before its capture became live" >&2
+		cat "$TCPDUMP_LOG" >&2 2>/dev/null || true
+		exit 1
+	fi
+	grep -q 'listening on' "$TCPDUMP_LOG" 2>/dev/null
+}
+wait_until "tcpdump to attach and start capturing on tap0" 300 tcpdump_ready
+
 printf '\xff\xff\xff\xff\xff\xff\x02\x5c\x52\x00\x00\x02\x08\x06test' > "$PTY_DIR/epB"
-wait $TD || { echo "TEST_FAIL: no frame relayed endpoint->tap"; exit 1; }
+wait $TD || {
+	echo "TEST_FAIL: no frame relayed endpoint->tap"
+	cat "$TCPDUMP_LOG" >&2 2>/dev/null || true
+	exit 1
+}
 tcpdump -Z root -r "$CAP" -A -n 2>/dev/null | grep -q 'test' \
   || { echo "TEST_FAIL: frame relayed endpoint->tap but payload truncated"; exit 1; }
 kill $DAEMON $SOCAT; echo "TEST_PASS"

--- a/platforms/autosd/x5h/rpmsg-eth/test-rpmsg-eth.sh
+++ b/platforms/autosd/x5h/rpmsg-eth/test-rpmsg-eth.sh
@@ -60,6 +60,10 @@ DAEMON_LOG="$PTY_DIR/daemon.log"
 TCPDUMP_LOG="$PTY_DIR/tcpdump.log"
 
 pty_pair_ready() {
+	if ! kill -0 "$SOCAT" 2>/dev/null; then
+		echo "TEST_FAIL: socat exited before creating its pty pair" >&2
+		exit 1
+	fi
 	[ -e "$PTY_DIR/epA" ] && [ -e "$PTY_DIR/epB" ]
 }
 
@@ -88,8 +92,26 @@ wait_until "daemon to open both fds and become ready" 300 daemon_ready
 # wait_until's comment on why) rather than left at a couple of seconds;
 # the daemon is already confirmed ready above, so this is only timing
 # out on the actual relay, which is what should make it fail.
+# Captured into a variable, then matched separately, rather than piped
+# straight into `grep -q`: under `set -o pipefail`, grep -q exits (and
+# closes its stdin) the instant it sees a match, and the still-running
+# producer (dd | xxd here) can then be killed by SIGPIPE and report that
+# as its own exit status -- which pipefail then reports as the whole
+# pipeline's, even though the match was genuinely found. Capturing first
+# means there is no live downstream reader left to close early.
+# The trailing `|| true` on the capture is load-bearing, not decorative:
+# under `set -e` a bare `VAR=$(...)` assignment (not part of an if/&&/||)
+# still aborts the whole script on a non-zero pipeline status, and on the
+# genuinely-broken-relay case this exercises, `timeout 10 dd` really does
+# time out (exit 124) with nothing ever having arrived on epB -- that must
+# fall through to the explicit grep-and-TEST_FAIL below, not vanish as a
+# silent `set -e` exit with no diagnostic at all (confirmed against a
+# fault-injected build that disables the relay: without `|| true` here the
+# script died on the bare timeout exit code before ever printing
+# TEST_FAIL).
 ping -c1 -W1 172.16.52.2 >/dev/null 2>&1 || true
-timeout 10 dd if="$PTY_DIR/epB" bs=600 count=1 2>/dev/null | xxd | grep -qi '0806' \
+FRAME="$(timeout 10 dd if="$PTY_DIR/epB" bs=600 count=1 2>/dev/null | xxd)" || true
+grep -qi '0806' <<<"$FRAME" \
   || { echo "TEST_FAIL: no ARP frame relayed tap->endpoint"; exit 1; }
 
 # …and a frame written to epB must reach tap0 *intact* (checked via
@@ -130,8 +152,7 @@ timeout -k 2 5 tcpdump -Z root -c1 -i tap0 -w "$CAP" 'ether src 02:5c:52:00:00:0
 # fork+exec+dynamic-link+filter-compile startup took long enough (on the
 # order of a couple of real seconds, inferred from a ~2.6s gap between
 # tap0 becoming ready and tcpdump actually entering promiscuous mode,
-# plus tcpdump exiting well before the 2s SIGTERM deadline it was given
-# -- see task-9-report.md's CI-failure fix report for the full timeline)
+# plus tcpdump exiting well before the 2s SIGTERM deadline it was given)
 # that the frame was written to epB, and presumably relayed, before
 # tcpdump had attached at all -- the capture then correctly reported 0
 # packets, because there was nothing left to see by the time it started
@@ -152,6 +173,66 @@ wait $TD || {
 	cat "$TCPDUMP_LOG" >&2 2>/dev/null || true
 	exit 1
 }
-tcpdump -Z root -r "$CAP" -A -n 2>/dev/null | grep -q 'test' \
+# Same capture-then-match rationale as the ARP check above -- grep -q
+# closing this pipe early under pipefail must not turn a genuine pass into
+# a SIGPIPE-flavored TEST_FAIL, and `|| true` keeps a genuine tcpdump -r
+# failure falling through to the explicit TEST_FAIL below instead of
+# aborting the script silently under set -e.
+PAYLOAD="$(tcpdump -Z root -r "$CAP" -A -n 2>/dev/null)" || true
+grep -q 'test' <<<"$PAYLOAD" \
   || { echo "TEST_FAIL: frame relayed endpoint->tap but payload truncated"; exit 1; }
+
+# --- I7: exercise the discovery/rebind path (never triggered by anything
+# above; CI would otherwise ship having never run open_endpoint()'s retry
+# logic even once) ---------------------------------------------------------
+# Killing socat tears down BOTH ends of the pty pair it manages ($PTY_DIR's
+# epA and epB are just symlinks to the /dev/pts nodes socat allocated), so
+# the daemon's open fd on epA sees the same read-EOF/write-failure shape a
+# real CR52 reset produces. Confirm three things in order: the daemon
+# survives instead of exiting, it logs the loss (the "endpoint lost" lines
+# added in this review wave), and once a fresh pty pair reappears at the
+# SAME link paths (device mode's -d only ever retries the one path it was
+# given) it rebinds -- logged -- and the relay actually works again, not
+# just that a log line printed.
+OLD_SOCAT="$SOCAT"
+kill "$OLD_SOCAT"
+wait "$OLD_SOCAT" 2>/dev/null || true
+
+rebind_loss_logged() {
+	if ! kill -0 "$DAEMON" 2>/dev/null; then
+		echo "TEST_FAIL: daemon exited after losing its endpoint (should rebind, not die)" >&2
+		cat "$DAEMON_LOG" >&2 2>/dev/null || true
+		exit 1
+	fi
+	grep -q 'endpoint lost' "$DAEMON_LOG" 2>/dev/null
+}
+wait_until "daemon to notice and log the endpoint loss" 300 rebind_loss_logged
+
+# socat's PTY link= refuses to reuse an existing path, so the dead pair's
+# stale symlinks must go before the replacement can claim the same names.
+rm -f "$PTY_DIR/epA" "$PTY_DIR/epB"
+socat -d PTY,raw,echo=0,link="$PTY_DIR/epA" PTY,raw,echo=0,link="$PTY_DIR/epB" & SOCAT=$!
+wait_until "socat's replacement pty pair to appear" 300 pty_pair_ready
+
+rebind_logged() {
+	if ! kill -0 "$DAEMON" 2>/dev/null; then
+		echo "TEST_FAIL: daemon exited before rebinding to the replacement endpoint" >&2
+		cat "$DAEMON_LOG" >&2 2>/dev/null || true
+		exit 1
+	fi
+	[ "$(grep -c 'endpoint bound' "$DAEMON_LOG" 2>/dev/null || true)" -ge 2 ]
+}
+wait_until "daemon to rebind to the recreated endpoint" 300 rebind_logged
+
+# Second round trip, same shape as the first: an ARP probe out of tap0 must
+# reach the NEW epB. Flush the stale neighbor entry first -- 172.16.52.2
+# never actually answered the first probe, so without this the kernel may
+# just replay its existing (failed) ARP resolution state instead of sending
+# a fresh request the dd below can catch.
+ip neigh flush to 172.16.52.2 dev tap0 2>/dev/null || true
+ping -c1 -W1 172.16.52.2 >/dev/null 2>&1 || true
+FRAME2="$(timeout 10 dd if="$PTY_DIR/epB" bs=600 count=1 2>/dev/null | xxd)" || true
+grep -qi '0806' <<<"$FRAME2" \
+  || { echo "TEST_FAIL: no ARP frame relayed tap->endpoint after rebind"; exit 1; }
+
 kill $DAEMON $SOCAT; echo "TEST_PASS"

--- a/platforms/autosd/x5h/rpmsg-eth/test-rpmsg-eth.sh
+++ b/platforms/autosd/x5h/rpmsg-eth/test-rpmsg-eth.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Round-trips frames between a TAP device and a mock endpoint (socat pty).
+# Needs: unshared netns (no root on CI runners): run under 'unshare -rn'.
+set -euo pipefail
+cd "$(dirname "$0")"
+make
+PTY_DIR=$(mktemp -d)
+socat -d PTY,raw,echo=0,link="$PTY_DIR/epA" PTY,raw,echo=0,link="$PTY_DIR/epB" & SOCAT=$!
+sleep 0.3
+ip tuntap add dev tap0 mode tap && ip link set tap0 up && ip addr add 172.16.52.1/24 dev tap0
+./rpmsg-eth -t tap0 -d "$PTY_DIR/epA" & DAEMON=$!
+sleep 0.3
+# An ARP probe out of tap0 must appear on epB…
+ping -c1 -W1 172.16.52.2 >/dev/null 2>&1 || true
+timeout 2 dd if="$PTY_DIR/epB" bs=600 count=1 2>/dev/null | xxd | grep -qi '0806' \
+  || { echo "TEST_FAIL: no ARP frame relayed tap->endpoint"; exit 1; }
+# …and a frame written to epB must reach tap0 (checked via tcpdump on
+# tap0, filtered on the injected frame's own src MAC -- tap0 emits its own
+# ARP retries with its *own* auto-assigned MAC while unresolved, and an
+# unfiltered capture would count one of those as a false pass).
+timeout 2 tcpdump -c1 -i tap0 -w /dev/null 'ether src 02:5c:52:00:00:02' & TD=$!
+sleep 0.3
+printf '\xff\xff\xff\xff\xff\xff\x02\x5c\x52\x00\x00\x02\x08\x06test' > "$PTY_DIR/epB"
+wait $TD || { echo "TEST_FAIL: no frame relayed endpoint->tap"; exit 1; }
+kill $DAEMON $SOCAT; echo "TEST_PASS"

--- a/platforms/autosd/x5h/rpmsg-eth/test-rpmsg-eth.sh
+++ b/platforms/autosd/x5h/rpmsg-eth/test-rpmsg-eth.sh
@@ -235,4 +235,62 @@ FRAME2="$(timeout 10 dd if="$PTY_DIR/epB" bs=600 count=1 2>/dev/null | xxd)" || 
 grep -qi '0806' <<<"$FRAME2" \
   || { echo "TEST_FAIL: no ARP frame relayed tap->endpoint after rebind"; exit 1; }
 
-kill $DAEMON $SOCAT; echo "TEST_PASS"
+kill $DAEMON $SOCAT
+
+# --- OAK round 2 (final review finding 3, residual): wait_for_dev_or_tap()
+# must treat POLLERR/POLLHUP/POLLNVAL on the tap fd as fatal during the
+# endpoint wait, not just in the steady-state relay loop -- 627df09 fixed
+# only the relay loop (see rpmsg-eth.c's "POLLERR/POLLHUP handling below"
+# comment on the relay loop's own poll() check); wait_for_dev_or_tap()
+# itself still ignored them. That matters because BOTH the initial
+# endpoint wait (the daemon is normally started before the CR52 firmware
+# is up on the real board, so this is the ordinary startup state, not an
+# edge case) and the rebind wait after a CR52 reset go through this exact
+# function. Left unfixed: `ip link del` on the tap latches POLLERR, so
+# poll() returns immediately forever instead of waiting out its 1s
+# timeout, and open_endpoint()'s retry loop spins at full speed instead of
+# pacing at ~1Hz or exiting -- a pegged core and a flooded serial console
+# on a safety-adjacent ECU, not a clean, diagnosable failure.
+#
+# Exercise the endpoint-wait state specifically -- not the relay state
+# already covered above -- by pointing a fresh daemon at a device path
+# that can never appear, so it never leaves open_endpoint()'s retry loop,
+# then deleting its tap device out from under it. Correct behavior: the
+# daemon exits nonzero and logs the fatal condition, naming the interface
+# and which flags fired.
+WAIT_DAEMON_LOG="$PTY_DIR/wait-daemon.log"
+ip tuntap add dev tap1 mode tap && ip link set tap1 up
+
+wait_daemon_waiting() {
+	if ! kill -0 "$WAIT_DAEMON" 2>/dev/null; then
+		echo "TEST_FAIL: endpoint-wait daemon exited before ever entering its wait" >&2
+		cat "$WAIT_DAEMON_LOG" >&2 2>/dev/null || true
+		exit 1
+	fi
+	grep -q 'waiting for endpoint' "$WAIT_DAEMON_LOG" 2>/dev/null
+}
+
+./rpmsg-eth -t tap1 -d "$PTY_DIR/does-not-exist" >"$WAIT_DAEMON_LOG" 2>&1 & WAIT_DAEMON=$!
+wait_until "endpoint-wait daemon to enter open_endpoint()'s retry loop" 300 wait_daemon_waiting
+
+ip link del tap1
+
+# Bounded via wait_until, not a fixed sleep: on the unfixed code this
+# predicate never becomes true (see the header comment above -- the
+# daemon busy-spins instead of exiting) and wait_until's own timeout is
+# what turns that into a reported TEST_FAIL instead of this script hanging
+# forever -- exactly the failure-demonstration case this test exists for.
+wait_daemon_exited() {
+	! kill -0 "$WAIT_DAEMON" 2>/dev/null
+}
+wait_until "endpoint-wait daemon to exit after its tap fd hit a fatal poll condition" 300 wait_daemon_exited
+
+wait "$WAIT_DAEMON" && WAIT_DAEMON_STATUS=0 || WAIT_DAEMON_STATUS=$?
+[ "$WAIT_DAEMON_STATUS" -ne 0 ] \
+  || { echo "TEST_FAIL: endpoint-wait daemon exited 0 after a fatal tap condition, expected nonzero"; cat "$WAIT_DAEMON_LOG" >&2; exit 1; }
+grep -q 'fatal poll condition' "$WAIT_DAEMON_LOG" \
+  || { echo "TEST_FAIL: endpoint-wait daemon did not log the fatal tap condition"; cat "$WAIT_DAEMON_LOG" >&2; exit 1; }
+grep -q 'tap1' "$WAIT_DAEMON_LOG" \
+  || { echo "TEST_FAIL: fatal tap condition log did not name the interface"; cat "$WAIT_DAEMON_LOG" >&2; exit 1; }
+
+echo "TEST_PASS"

--- a/platforms/autosd/x5h/rpmsg-eth/test-rpmsg-eth.sh
+++ b/platforms/autosd/x5h/rpmsg-eth/test-rpmsg-eth.sh
@@ -293,4 +293,119 @@ grep -q 'fatal poll condition' "$WAIT_DAEMON_LOG" \
 grep -q 'tap1' "$WAIT_DAEMON_LOG" \
   || { echo "TEST_FAIL: fatal tap condition log did not name the interface"; cat "$WAIT_DAEMON_LOG" >&2; exit 1; }
 
+# --- Defect B: a wedged endpoint that accepts a bind but then services
+# neither reads nor writes must trip the -T progress deadline and exit
+# nonzero, not peg a core silently. This reproduces the board defect: the
+# CR52 wedged, and the daemon (no O_NONBLOCK anywhere) burned 100% of one
+# core in system time forever, never returning to userspace, while
+# systemd kept reporting "active (running)" because the process never
+# exited. The existing round-trip test above cannot catch this class of
+# bug at all -- its mock endpoint (epB) is continuously drained by a `dd`
+# read, so the daemon's write() there always has room and never blocks.
+#
+# Reuses the same two-pty-bridge mock as the round-trip test above (epA
+# exposed to the daemon via -d, epB the corresponding far end) but never
+# reads epB: held open (so it behaves like a connected far end, not a
+# dead one) via a bare `exec` onto an fd this script never reads from.
+# socat, which bridges epA and epB internally, backs off relaying once
+# its own write into epB's unread buffer can no longer proceed, which in
+# turn leaves epA's buffer with nowhere to drain -- so the daemon's own
+# write() to epA is what ultimately sees EAGAIN forever, the same shape
+# as a CR52 that has stopped returning TX buffers.
+STALL_PTY_DIR=$(mktemp -d)
+STALL_DAEMON_LOG="$STALL_PTY_DIR/stall-daemon.log"
+
+socat PTY,raw,echo=0,link="$STALL_PTY_DIR/epA" PTY,raw,echo=0,link="$STALL_PTY_DIR/epB" & STALL_SOCAT=$!
+stall_pty_pair_ready() {
+	if ! kill -0 "$STALL_SOCAT" 2>/dev/null; then
+		echo "TEST_FAIL: stall-test socat exited before creating its pty pair" >&2
+		exit 1
+	fi
+	[ -e "$STALL_PTY_DIR/epA" ] && [ -e "$STALL_PTY_DIR/epB" ]
+}
+wait_until "stall-test socat's pty pair to appear" 300 stall_pty_pair_ready
+
+# Opened but never read and never written -- exactly the mock shape the
+# defect needs: a far end that is live (so writes into it don't just
+# bounce off a closed pty with nobody home) but never services anything,
+# so its buffer fills and stays full. Closed explicitly in the cleanup
+# below, not left to script exit.
+exec {STALL_EPB_FD}<>"$STALL_PTY_DIR/epB"
+
+# A distinct subnet from tap0's 172.16.52.0/24 (tap0 is still up at this
+# point in the script -- only its daemon and socat were killed, not the
+# interface itself): with both on the same subnet the kernel prefers
+# tap0's route, which has nothing reading it any more, and the flood
+# below would silently vanish down the wrong interface instead of ever
+# reaching this test's daemon.
+ip tuntap add dev tap2 mode tap && ip link set tap2 up && ip addr add 172.16.99.1/24 dev tap2
+# A permanent, unresolved-free neighbor entry for the mock CR52 IP:
+# nothing on epB will ever answer an ARP request (the mock never reads,
+# let alone replies), and without this the kernel's neighbor subsystem
+# queues only a handful of packets per unresolved destination and drops
+# the rest -- starving the flood below of the volume it needs to fill
+# both pty buffers in the chain.
+ip neigh add 172.16.99.2 lladdr 02:5c:52:00:00:02 dev tap2 nud permanent
+
+# -T 2: a short deadline so this test runs quickly; RPMSG_ETH_EPT_PROGRESS_TIMEOUT_S's
+# real-world default of 10s is sized against the kernel's own 15s
+# "timeout waiting for a tx buffer" warning, not against test runtime.
+./rpmsg-eth -t tap2 -d "$STALL_PTY_DIR/epA" -T 2 >"$STALL_DAEMON_LOG" 2>&1 & STALL_DAEMON=$!
+stall_daemon_ready() {
+	if ! kill -0 "$STALL_DAEMON" 2>/dev/null; then
+		echo "TEST_FAIL: stall-test daemon exited before becoming ready" >&2
+		cat "$STALL_DAEMON_LOG" >&2 2>/dev/null || true
+		exit 1
+	fi
+	grep -q 'rpmsg-eth: ready' "$STALL_DAEMON_LOG" 2>/dev/null
+}
+wait_until "stall-test daemon to open both fds and become ready" 300 stall_daemon_ready
+
+# Flood tap2 toward the never-draining mock with one long-lived socat
+# rather than many short-lived ones -- both to avoid hundreds of
+# fork+exec calls under QEMU TCG (see wait_until's comment on how slow
+# that gets) and because a continuous stream, not a fixed packet count,
+# is what reliably overruns the buffer chain regardless of its exact
+# size on a given kernel. -b keeps each UDP datagram at 400 bytes,
+# comfortably under the 462 netif MTU so each one leaves as a single
+# unfragmented frame.
+socat -u -b 400 OPEN:/dev/zero UDP-SENDTO:172.16.99.2:9 >/dev/null 2>&1 & STALL_FLOOD=$!
+
+# Bounded via wait_until, not a fixed sleep, for the same reason as the
+# endpoint-wait case above: on daemon code with no O_NONBLOCK/deadline,
+# this predicate never becomes true (the daemon is genuinely blocked
+# inside a kernel write(), not merely slow) and wait_until's own ceiling
+# is what turns that into a reported TEST_FAIL instead of this script
+# hanging forever -- the failure-demonstration case this test exists for.
+STALL_WAIT_START=$(date +%s)
+stall_daemon_exited() {
+	! kill -0 "$STALL_DAEMON" 2>/dev/null
+}
+wait_until "the wedged-endpoint daemon to exit once its progress deadline expires" 300 stall_daemon_exited
+STALL_WAIT_ELAPSED=$(( $(date +%s) - STALL_WAIT_START ))
+echo "stall-test: daemon exited ${STALL_WAIT_ELAPSED}s after the wedge began (deadline was 2s)"
+# A real bound, not just wait_until's 30s ceiling: by this point the daemon
+# was already confirmed `ready` and the flood was already running, so this
+# wait is pure wedge-to-exit time, not QEMU-TCG startup latency -- the
+# generous-slack reasoning that justifies the 30s ceiling elsewhere does
+# not apply to it. 15s against a 2s deadline is still generous (7.5x), but
+# a deadline that silently stopped enforcing itself and instead relied on
+# some unrelated timeout (or no timeout at all) could still exit within
+# 30s and must not be able to pass this assertion.
+[ "$STALL_WAIT_ELAPSED" -le 15 ] \
+  || { echo "TEST_FAIL: wedged-endpoint daemon took ${STALL_WAIT_ELAPSED}s to exit, expected close to the 2s -T deadline"; cat "$STALL_DAEMON_LOG" >&2; exit 1; }
+
+kill "$STALL_FLOOD" 2>/dev/null || true
+wait "$STALL_FLOOD" 2>/dev/null || true
+exec {STALL_EPB_FD}<&-
+kill "$STALL_SOCAT" 2>/dev/null || true
+wait "$STALL_SOCAT" 2>/dev/null || true
+ip link del tap2 2>/dev/null || true
+
+wait "$STALL_DAEMON" && STALL_DAEMON_STATUS=0 || STALL_DAEMON_STATUS=$?
+[ "$STALL_DAEMON_STATUS" -ne 0 ] \
+  || { echo "TEST_FAIL: wedged-endpoint daemon exited 0, expected nonzero (the -T progress deadline should have made it exit fatal)"; cat "$STALL_DAEMON_LOG" >&2; exit 1; }
+grep -q 'did not finish writing a frame' "$STALL_DAEMON_LOG" \
+  || { echo "TEST_FAIL: wedged-endpoint daemon did not name the stall condition in its log"; cat "$STALL_DAEMON_LOG" >&2; exit 1; }
+
 echo "TEST_PASS"

--- a/platforms/autosd/x5h/rpmsg-eth/test-rpmsg-eth.sh
+++ b/platforms/autosd/x5h/rpmsg-eth/test-rpmsg-eth.sh
@@ -371,13 +371,95 @@ wait_until "stall-test daemon to open both fds and become ready" 300 stall_daemo
 # unfragmented frame.
 socat -u -b 400 OPEN:/dev/zero UDP-SENDTO:172.16.99.2:9 >/dev/null 2>&1 & STALL_FLOOD=$!
 
+# Captured immediately after the flood starts, not after the SIGUSR1 case
+# below -- this is what "stall-test: daemon exited Xs after the wedge
+# began" further down, and STALL_WAIT_ELAPSED's bound, measure against.
+# Capturing it any later would make both drift lenient by however long the
+# SIGUSR1 case takes to run.
+STALL_WAIT_START=$(date +%s)
+
+# --- OAK final review, item 4: a SIGUSR1 sent while the endpoint is
+# wedged must produce a counter dump promptly (well inside the -T
+# deadline), not be silently absorbed until the deadline expires. Reuses
+# this same stall fixture, not a fresh one -- the flood above is already
+# under way and the daemon's write() to epA is already retrying against
+# EAGAIN by the time this runs, the same wedge Defect B's own
+# deadline-expiry check below depends on and relies on forming quickly.
+# Before this fix, write_full()'s retry loop honoured g_stop but never
+# g_dump, so the daemon stays inside a single write_full() call for the
+# whole wedge and the relay loop's own top-of-loop g_dump handling never
+# runs again until the deadline fires -- and the deadline path exits
+# without ever returning to that check. No "counters" line is printed for
+# this SIGUSR1 at all in that case; only wait_until's timeout below fires.
+#
+# Sending SIGUSR1 right after starting the flood, rather than once the
+# daemon is confirmed genuinely wedged, races: land too early and it is
+# answered by the ordinary top-of-relay-loop g_dump handling instead --
+# that path has always existed, is untouched by this fix, and would make
+# this assertion pass against the unfixed code too (confirmed empirically
+# the first time this test was written, with a fixed sleep in place of
+# the wait_until below: it passed against reverted code). A fixed sleep
+# doesn't fix this properly either -- long enough here is not guaranteed
+# long enough on a much slower CI runner (see wait_until's own comment on
+# how much slower QEMU TCG can be), so a short sleep risks the same false
+# pass there instead of here. wait_until on write_full()'s "not ready,
+# retrying" log line (see rpmsg-eth.c's retry branch) avoids guessing at
+# timing altogether: that line only appears once the daemon's write() has
+# actually returned EAGAIN, i.e. once it is genuinely inside the retry
+# loop this task's fix targets, regardless of how fast or slow
+# buffer-fill happens to be on the machine running this.
+stall_write_retrying() {
+	if ! kill -0 "$STALL_DAEMON" 2>/dev/null; then
+		echo "TEST_FAIL: wedged-endpoint daemon exited before its write ever had to retry" >&2
+		cat "$STALL_DAEMON_LOG" >&2 2>/dev/null || true
+		exit 1
+	fi
+	grep -q 'not ready' "$STALL_DAEMON_LOG" 2>/dev/null
+}
+wait_until "the wedged-endpoint daemon's write to start retrying" 300 stall_write_retrying
+
+kill -USR1 "$STALL_DAEMON"
+STALL_DUMP_WAIT_START_MS=$(date +%s%3N)
+stall_dump_logged() {
+	if ! kill -0 "$STALL_DAEMON" 2>/dev/null; then
+		echo "TEST_FAIL: wedged-endpoint daemon exited before answering SIGUSR1" >&2
+		cat "$STALL_DAEMON_LOG" >&2 2>/dev/null || true
+		exit 1
+	fi
+	grep -q 'rpmsg-eth: counters ' "$STALL_DAEMON_LOG" 2>/dev/null
+}
+wait_until "the wedged-endpoint daemon to answer SIGUSR1 with a counter dump" 300 stall_dump_logged
+STALL_DUMP_WAIT_ELAPSED_MS=$(( $(date +%s%3N) - STALL_DUMP_WAIT_START_MS ))
+# A real bound, not just wait_until's 30s ceiling -- same rationale as
+# STALL_WAIT_ELAPSED further below: this is pure signal-response time (the
+# daemon was already confirmed genuinely wedged, via the wait_until
+# above, before the signal was sent), not QEMU-TCG process-startup
+# latency, so the generous 30s ceiling that covers the latter does not
+# excuse this one. write_full()'s retry loop rechecks g_dump at least
+# once per second even in the worst case (its poll() is bounded to
+# 1000ms once a deadline applies), and SIGUSR1's handler has no
+# SA_RESTART (see main()), so it interrupts that poll() immediately with
+# EINTR instead of the daemon waiting it out -- this should be
+# near-instant. Millisecond resolution (date +%s%3N), not whole seconds:
+# a genuinely sub-second latency measured with whole-second `date +%s`
+# could round up to a misleadingly large number purely from where the two
+# reads happen to straddle a second boundary, flaking this bound
+# independently of the daemon's real behaviour. 1500ms (75% of the -T 2
+# deadline below) leaves generous headroom for scheduling jitter on a
+# slower machine while still being unambiguously "well inside" the
+# deadline, not merely a dump that happens to land close to it.
+[ "$STALL_DUMP_WAIT_ELAPSED_MS" -le 1500 ] \
+  || { echo "TEST_FAIL: wedged-endpoint daemon took ${STALL_DUMP_WAIT_ELAPSED_MS}ms to answer SIGUSR1, expected well under the 2000ms -T deadline"; cat "$STALL_DAEMON_LOG" >&2; exit 1; }
+
 # Bounded via wait_until, not a fixed sleep, for the same reason as the
 # endpoint-wait case above: on daemon code with no O_NONBLOCK/deadline,
 # this predicate never becomes true (the daemon is genuinely blocked
 # inside a kernel write(), not merely slow) and wait_until's own ceiling
 # is what turns that into a reported TEST_FAIL instead of this script
 # hanging forever -- the failure-demonstration case this test exists for.
-STALL_WAIT_START=$(date +%s)
+# (STALL_WAIT_START was already captured right after the flood started,
+# above the SIGUSR1 case, so it still measures from when the wedge
+# actually began, not from whenever that case finishes.)
 stall_daemon_exited() {
 	! kill -0 "$STALL_DAEMON" 2>/dev/null
 }

--- a/platforms/autosd/x5h/scripts/cr52-rproc-up.sh
+++ b/platforms/autosd/x5h/scripts/cr52-rproc-up.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# cr52-rproc-up.sh -- bring the CR52 remoteproc vdev up at boot.
+#
+# Linux does NOT load the CR52 payload: rcar_gen5_rproc's .load and .stop are
+# no-ops, and the realtime core is already running whatever was flashed into its
+# UFS slot before Linux even started. What `start` does is parse the resource
+# table out of the ELF named in /sys/class/remoteproc/remoteprocN/firmware and
+# publish the vrings, then ring the MFIS doorbell. So the staged ELF must match
+# the flashed image or the vring layout will not agree -- a mismatch produces a
+# link that looks configured and passes no traffic.
+#
+# Without this unit the two modprobes and the `start` write have to be repeated
+# by hand after every boot, because neither survives a reboot. rpmsg-eth.service
+# tolerates their absence (its endpoint-wait loop retries and logs why), so the
+# failure mode was a link that never came up until someone remembered -- which
+# is exactly the kind of thing that gets forgotten during a board session.
+#
+# Markers on stdout, so `systemctl status` and the journal are self-explaining:
+#   CR52_RPROC_UP name=<n> firmware=<f>
+#   CR52_RPROC_SKIP reason=<no_device|no_firmware>
+#   CR52_RPROC_FAIL reason=<firmware_write|start_write|not_running> ...
+set -uo pipefail
+
+RPROC_DIR=${RPROC_DIR:-/sys/class/remoteproc/remoteproc0}
+# Empty means "leave whatever the driver already has", which is the stock
+# rproc-cr52_1-fw. Set CR52_FIRMWARE in /etc/default/cr52-remoteproc to point at
+# a specific staged ELF (the one flashed into the slot).
+CR52_FIRMWARE=${CR52_FIRMWARE:-}
+FIRMWARE_DIR=${FIRMWARE_DIR:-/lib/firmware}
+TIMEOUT=${TIMEOUT:-25}
+
+if [ ! -d "$RPROC_DIR" ]; then
+    echo "CR52_RPROC_SKIP reason=no_device dir=$RPROC_DIR"
+    exit 0
+fi
+
+name=$(cat "$RPROC_DIR/name" 2>/dev/null || echo unknown)
+state=$(cat "$RPROC_DIR/state" 2>/dev/null || echo unknown)
+
+# Idempotent: a re-run (or a manual start before this unit ran) is success, not
+# an error. `start` on a running rproc returns EBUSY, which would otherwise make
+# a restart of this unit look like a failure.
+if [ "$state" = running ]; then
+    echo "CR52_RPROC_UP name=$name firmware=$(cat "$RPROC_DIR/firmware" 2>/dev/null) (already running)"
+    exit 0
+fi
+
+# Select the firmware if one was configured.
+if [ -n "$CR52_FIRMWARE" ]; then
+    if [ ! -r "${FIRMWARE_DIR}/${CR52_FIRMWARE}" ]; then
+        # Deliberately exit 0, not 1. On a freshly imaged board the CR52 ELF has
+        # not been staged yet and that is the correct state -- failing here would
+        # mean every first boot shows a failed unit. The operator is not left
+        # guessing: this line names the missing file, and rpmsg-eth's own log
+        # says the link is down and why.
+        echo "CR52_RPROC_SKIP reason=no_firmware path=${FIRMWARE_DIR}/${CR52_FIRMWARE}"
+        exit 0
+    fi
+    if ! echo "$CR52_FIRMWARE" > "$RPROC_DIR/firmware"; then
+        echo "CR52_RPROC_FAIL reason=firmware_write firmware=$CR52_FIRMWARE"
+        exit 1
+    fi
+    got=$(cat "$RPROC_DIR/firmware" 2>/dev/null)
+    if [ "$got" != "$CR52_FIRMWARE" ]; then
+        echo "CR52_RPROC_FAIL reason=firmware_write firmware=$CR52_FIRMWARE readback=$got"
+        exit 1
+    fi
+fi
+
+selected=$(cat "$RPROC_DIR/firmware" 2>/dev/null)
+if [ ! -r "${FIRMWARE_DIR}/${selected}" ]; then
+    echo "CR52_RPROC_SKIP reason=no_firmware path=${FIRMWARE_DIR}/${selected}"
+    exit 0
+fi
+
+if ! echo start > "$RPROC_DIR/state"; then
+    echo "CR52_RPROC_FAIL reason=start_write firmware=$selected"
+    exit 1
+fi
+
+# Readiness polling rather than a fixed sleep: the vdev registration and the
+# rpmsg host coming online take a variable moment.
+i=0
+while [ "$i" -lt "$TIMEOUT" ]; do
+    [ "$(cat "$RPROC_DIR/state" 2>/dev/null)" = running ] && break
+    i=$((i + 1))
+    sleep 1
+done
+
+state=$(cat "$RPROC_DIR/state" 2>/dev/null || echo unknown)
+if [ "$state" != running ]; then
+    echo "CR52_RPROC_FAIL reason=not_running state=$state firmware=$selected waited=${i}s"
+    exit 1
+fi
+
+echo "CR52_RPROC_UP name=$name firmware=$selected waited=${i}s"

--- a/platforms/autosd/x5h/scripts/gate-guest.sh
+++ b/platforms/autosd/x5h/scripts/gate-guest.sh
@@ -190,7 +190,7 @@ else
     echo GATE7_SELINUX_BOOLS_OK
 fi
 
-# --- GATE8: rpmsg-eth daemon unit test (Task 9's test-rpmsg-eth.sh), run
+# --- GATE8: rpmsg-eth daemon unit test (test-rpmsg-eth.sh), run
 # inside a dedicated Fedora test container that carries the toolchain
 # (gcc/make) and tools (socat/tcpdump/xxd) the daemon's build+test need --
 # see make-test-images.sh for why those live in a throwaway container image

--- a/platforms/autosd/x5h/scripts/gate-guest.sh
+++ b/platforms/autosd/x5h/scripts/gate-guest.sh
@@ -190,4 +190,35 @@ else
     echo GATE7_SELINUX_BOOLS_OK
 fi
 
+# --- GATE8: rpmsg-eth daemon unit test (Task 9's test-rpmsg-eth.sh), run
+# inside a dedicated Fedora test container that carries the toolchain
+# (gcc/make) and tools (socat/tcpdump/xxd) the daemon's build+test need --
+# see make-test-images.sh for why those live in a throwaway container image
+# instead of the board's own aib manifest. --network=none: the daemon under
+# test only ever talks to a mock pty endpoint and a tap0 it creates inside
+# its OWN private netns (test-rpmsg-eth.sh's `unshare -rn` self-wrap), so it
+# needs no container network at all, and isolating it fully keeps it from
+# ever touching GATE6's podman networking above.
+#
+# GATE_RPMSG_ETH_UNIT_PASS is required to come from BOTH a zero podman-run
+# exit status AND a literal TEST_PASS in its output: exit-status-alone would
+# also read as success if the image failed to load and podman errored out
+# some other way, or if a future edit to the container's entrypoint changed
+# what "container exits 0" means without test-rpmsg-eth.sh actually having
+# run -- the marker must not be able to fire without the real test printing
+# its own, separately-meaningful PASS line.
+podman load -i "$T/rpmsg-eth-docker.tar" >/tmp/g8.log 2>&1
+RPMSGETH="$(podman images --format '{{.Repository}}:{{.Tag}}' | grep -m1 rpmsg-eth)"
+if [ -n "$RPMSGETH" ] && podman run --rm --cap-add=NET_ADMIN --cap-add=SYS_ADMIN \
+        --device /dev/net/tun --network=none "$RPMSGETH" \
+        sh -c 'cd /opt/rpmsg-eth && ./test-rpmsg-eth.sh' >/tmp/g8-run.log 2>&1 \
+        && grep -q TEST_PASS /tmp/g8-run.log; then
+    echo GATE_RPMSG_ETH_UNIT_PASS
+else
+    echo GATE_RPMSG_ETH_UNIT_FAIL
+    tail -5 /tmp/g8.log
+    tail -20 /tmp/g8-run.log
+fi
+podman rmi -af >/dev/null 2>&1
+
 echo GATE_DONE

--- a/platforms/autosd/x5h/scripts/inject-test-images.sh
+++ b/platforms/autosd/x5h/scripts/inject-test-images.sh
@@ -33,8 +33,8 @@ fi
 exit "$st"
 ' EXIT
 sudo mkdir -p "$MNT/var/lib/autosd-test"
-sudo cp "$IMAGES/busybox-oci.tar" "$IMAGES/captest-docker.tar" "$HERE/gate-guest.sh" \
-        "$MNT/var/lib/autosd-test/"
+sudo cp "$IMAGES/busybox-oci.tar" "$IMAGES/captest-docker.tar" "$IMAGES/rpmsg-eth-docker.tar" \
+        "$HERE/gate-guest.sh" "$MNT/var/lib/autosd-test/"
 sudo chmod +x "$MNT/var/lib/autosd-test/gate-guest.sh"
 
 # fstab was written for a disk image and carries a LABEL=ESP entry for

--- a/platforms/autosd/x5h/scripts/make-test-images.sh
+++ b/platforms/autosd/x5h/scripts/make-test-images.sh
@@ -46,7 +46,7 @@ with tarfile.open(sys.argv[1]) as outer:
 sys.exit(0 if found else "FATAL: no security.capability xattr in any layer")
 EOF
 
-# 4. rpmsg-eth: the Task 9 daemon's own unit test (test-rpmsg-eth.sh) needs a
+# 4. rpmsg-eth: the daemon's own unit test (test-rpmsg-eth.sh) needs a
 #    toolchain (gcc/make) plus socat/tcpdump/xxd/iproute/iputils that the aib
 #    guest rootfs manifest (aib/x5h-rootfs.aib.yml) deliberately does NOT
 #    carry -- that manifest's content.rpms list ships to the REAL board via

--- a/platforms/autosd/x5h/scripts/make-test-images.sh
+++ b/platforms/autosd/x5h/scripts/make-test-images.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Build the two pinned test images for the x5h gate and board smoke.
+# Build the three pinned test images for the x5h gate and board smoke.
 # Usage: make-test-images.sh <outdir>   (needs docker with arm64 support + skopeo)
 set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
 OUT="$(mkdir -p "$1" && cd "$1" && pwd)"
 
 # 1. busybox: tiny runtime + httpd for the networking assertion. ECR public
@@ -44,4 +45,30 @@ with tarfile.open(sys.argv[1]) as outer:
             continue
 sys.exit(0 if found else "FATAL: no security.capability xattr in any layer")
 EOF
+
+# 4. rpmsg-eth: the Task 9 daemon's own unit test (test-rpmsg-eth.sh) needs a
+#    toolchain (gcc/make) plus socat/tcpdump/xxd/iproute/iputils that the aib
+#    guest rootfs manifest (aib/x5h-rootfs.aib.yml) deliberately does NOT
+#    carry -- that manifest's content.rpms list ships to the REAL board via
+#    make-ufs-rootfs.sh/stage-nfs-rootfs.sh, and a compiler + test-tool
+#    footprint there would be a permanent board-image cost paid for a
+#    CI-only concern. Packaging them into a throwaway test container instead
+#    (same pattern as x5h-captest above) keeps the board image pristine
+#    while still genuinely exercising the booted guest kernel's TUN/TAP
+#    behaviour: the container is run with real /dev/net/tun access and its
+#    own private netns (test-rpmsg-eth.sh's `unshare -rn` self-wrap), so
+#    tap0 is a real interface on the kernel under test, not a mock.
+tmp="$(mktemp -d)"
+cp "$HERE/../rpmsg-eth/rpmsg-eth.c" "$HERE/../rpmsg-eth/Makefile" \
+   "$HERE/../rpmsg-eth/test-rpmsg-eth.sh" "$tmp/"
+cat > "$tmp/Containerfile" <<'EOF'
+FROM quay.io/fedora/fedora:42
+RUN dnf -y install gcc make glibc-static socat tcpdump xxd iproute iputils && \
+    dnf clean all
+COPY rpmsg-eth.c Makefile test-rpmsg-eth.sh /opt/rpmsg-eth/
+EOF
+docker build --platform linux/arm64 -f "$tmp/Containerfile" -t x5h-rpmsg-eth-test:latest "$tmp"
+docker save x5h-rpmsg-eth-test:latest -o "$OUT/rpmsg-eth-docker.tar"
+rm -rf "$tmp"
+
 echo "OK: $OUT"

--- a/platforms/autosd/x5h/scripts/qemu-gate.exp
+++ b/platforms/autosd/x5h/scripts/qemu-gate.exp
@@ -97,10 +97,22 @@ send "sh /var/lib/autosd-test/gate-guest.sh\r"
 # GATE8 (added after GATE7, also output-suppressed until its own verdict)
 # is a second silent stretch, but a much smaller one: a single podman load
 # of a small local tar, one container start, one static-link compile of a
-# ~450-line C file, and test-rpmsg-eth.sh's own internally-bounded waits
-# (two `timeout -k1 2 ...` calls at most). That's comfortably under GATE6's
-# 900s budget on its own, so it rides on the existing ceiling rather than
-# raising it.
+# ~450-line C file, and test-rpmsg-eth.sh's own internally-bounded waits --
+# two `timeout 10 dd` calls (the ARP-relay check, run once before the
+# rebind exercise and once after), a single `timeout -k 2 5 tcpdump`, and
+# six 30s-ceiling `wait_until` polls (socat's initial pty pair, the
+# daemon's readiness marker, tcpdump attaching, the daemon noticing and
+# logging the endpoint loss, socat's replacement pty pair, and the daemon
+# rebinding to it) -- roughly 207s worst case (6*30 + 2*10 + 7), not the
+# "two `timeout -k1 2` calls" this comment used to say (test-rpmsg-eth.sh
+# has grown real internal waits, most recently the rebind exercise added
+# in the final review wave, since that estimate was written; the numbers
+# above are re-derived from its current content, not carried over -- and
+# will go stale again the next time a wait is added or removed, the same
+# as this one did). That's comfortably under GATE6's 900s budget on its
+# own, so it rides on the existing ceiling rather than raising it -- the
+# 900s conclusion survives even though the arithmetic behind "comfortably
+# under" keeps moving.
 set inactivity_timeout 900
 set timeout $inactivity_timeout
 expect {

--- a/platforms/autosd/x5h/scripts/qemu-gate.exp
+++ b/platforms/autosd/x5h/scripts/qemu-gate.exp
@@ -93,11 +93,19 @@ send "sh /var/lib/autosd-test/gate-guest.sh\r"
 # polls longer (more iterations, a longer --max-time/attempt budget),
 # raise this number to match -- it is coupled to those bounds, not an
 # independent knob.
+#
+# GATE8 (added after GATE7, also output-suppressed until its own verdict)
+# is a second silent stretch, but a much smaller one: a single podman load
+# of a small local tar, one container start, one static-link compile of a
+# ~450-line C file, and test-rpmsg-eth.sh's own internally-bounded waits
+# (two `timeout -k1 2 ...` calls at most). That's comfortably under GATE6's
+# 900s budget on its own, so it rides on the existing ceiling rather than
+# raising it.
 set inactivity_timeout 900
 set timeout $inactivity_timeout
 expect {
     "GATE_DONE" {}
-    -re {GATE[0-9]_[^\r\n]*\r?\n} { exp_continue }
+    -re {GATE([0-9]_|_RPMSG)[^\r\n]*\r?\n} { exp_continue }
     eof { puts "FATAL: guest console closed before GATE_DONE"; exit 2 }
     timeout { puts "FATAL: gate produced no new marker output for ${inactivity_timeout}s (stalled)"; exit 2 }
 }
@@ -130,7 +138,7 @@ if {$guest_alive} {
 # Judge the markers from the captured log.
 set fh [open $logf r]; set log [read $fh]; close $fh
 set fail 0
-foreach must {GATE1_LOGIN_OK GATE1_KVER=6.1.102-autosd GATE1_CCVER_OK GATE2_STORE_FS=ext4 GATE2_EXT4_OK GATE3_TMPFS_OK GATE3_STORE_FS=tmpfs GATE4_BTRFS_OK GATE4_STORE_FS=btrfs GATE6_NFT_PORT_OK GATE6_SNAT_OK GATE7_SELINUX_PERMISSIVE_OK GATE7_SELINUX_BOOLS_OK GATE_DONE} {
+foreach must {GATE1_LOGIN_OK GATE1_KVER=6.1.102-autosd GATE1_CCVER_OK GATE2_STORE_FS=ext4 GATE2_EXT4_OK GATE3_TMPFS_OK GATE3_STORE_FS=tmpfs GATE4_BTRFS_OK GATE4_STORE_FS=btrfs GATE6_NFT_PORT_OK GATE6_SNAT_OK GATE7_SELINUX_PERMISSIVE_OK GATE7_SELINUX_BOOLS_OK GATE_RPMSG_ETH_UNIT_PASS GATE_DONE} {
     if {![string match "*$must*" $log]} { puts "MISSING: $must"; set fail 1 }
 }
 # Module staging failure poisons every verdict above; fail loudly on it even

--- a/platforms/autosd/x5h/scripts/rpmsg-eth-ifup.sh
+++ b/platforms/autosd/x5h/scripts/rpmsg-eth-ifup.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# ExecStartPre helper for rpmsg-eth.service (installed at
+# /usr/local/sbin/rpmsg-eth-ifup.sh -- see config/rpmsg-eth.service for the
+# full install path). Creates tap0 and brings it up with the frozen link
+# parameters for the CR52 bridge: address 172.16.52.1/24 and, critically,
+# MTU 462.
+#
+# MTU 462 is NOT a tuning knob: max Ethernet frame on this link is 476 bytes
+# (462 payload + 14-byte Ethernet header), sized to the RPMsg payload budget
+# on the CR52 side (496 bytes, leaving headroom for the RPMsg header itself).
+# Bringing tap0 up at the kernel's default MTU (1500) would let the kernel
+# hand the daemon frames it cannot forward whole; rpmsg-eth.c drops those
+# (counted as dropped_oversize) rather than fragmenting them, so a wrong MTU
+# here means silent, oversize-triggered packet loss on the link, not a
+# crash. rpmsg-eth-smoke.sh asserts this MTU on the running interface so a
+# regression here is caught before it reaches ping-loss territory.
+set -u
+
+ip tuntap add dev tap0 mode tap 2>/dev/null || true
+ip addr replace 172.16.52.1/24 dev tap0
+ip link set tap0 mtu 462 up

--- a/platforms/autosd/x5h/scripts/rpmsg-eth-ifup.sh
+++ b/platforms/autosd/x5h/scripts/rpmsg-eth-ifup.sh
@@ -2,8 +2,8 @@
 # ExecStartPre helper for rpmsg-eth.service (installed at
 # /usr/local/sbin/rpmsg-eth-ifup.sh -- see config/rpmsg-eth.service for the
 # full install path). Creates tap0 and brings it up with the frozen link
-# parameters for the CR52 bridge: address 172.16.52.1/24 and, critically,
-# MTU 462.
+# parameters for the CR52 bridge: address 172.16.52.1/24, MAC
+# 02:5c:52:00:00:01, and, critically, MTU 462.
 #
 # MTU 462 is NOT a tuning knob: max Ethernet frame on this link is 476 bytes
 # (462 payload + 14-byte Ethernet header), sized to the RPMsg payload budget
@@ -14,8 +14,36 @@
 # here means silent, oversize-triggered packet loss on the link, not a
 # crash. rpmsg-eth-smoke.sh asserts this MTU on the running interface so a
 # regression here is caught before it reaches ping-loss territory.
+#
+# The MAC is also a frozen constant, not cosmetic: without setting it, tap0
+# gets a kernel-random address that changes every time the persistent tap
+# is recreated, making board packet captures unreproducible across a
+# debugging session -- exactly the case where a stable MAC to filter on
+# matters most. The FreeRTOS side resolves peers with lwIP's ARP
+# (NETIF_FLAG_ETHARP) rather than a static peer table, so a wrong or
+# changing MAC here does not blackhole traffic today -- but the constraint
+# is still frozen and still checked (see rpmsg-eth-smoke.sh).
+#
+# set -u only, not -e: every command below is deliberately allowed to
+# report its own failure (the `add` is idempotent-by-design, see below; the
+# rest are asserted downstream by rpmsg-eth-smoke.sh) rather than aborting
+# this script silently mid-sequence.
 set -u
 
-ip tuntap add dev tap0 mode tap 2>/dev/null || true
-ip addr replace 172.16.52.1/24 dev tap0
-ip link set tap0 mtu 462 up
+# Interface name: takes $1 (rpmsg-eth.service's ExecStartPre passes the same
+# "tap0" its own ExecStart uses via -t) so the name lives in one place --
+# the unit file -- instead of being hardcoded here independently of it.
+# Defaults to tap0 so this script still works stand-alone/uninstalled.
+IFACE="${1:-tap0}"
+
+# 2>/dev/null || true makes this line idempotent (a persistent tap from a
+# previous run already exists and 'add' would otherwise fail every restart)
+# -- it is NOT meant to hide a genuine failure. A real one here (no
+# /dev/net/tun, no CONFIG_TUN) always resurfaces immediately at the next
+# line: 'ip addr replace' on a nonexistent interface fails loudly on its
+# own, so swallowing this specific command's stderr does not hide the
+# underlying problem, only this command's redundant complaint about it.
+ip tuntap add dev "$IFACE" mode tap 2>/dev/null || true
+ip addr replace 172.16.52.1/24 dev "$IFACE"
+ip link set "$IFACE" address 02:5c:52:00:00:01
+ip link set "$IFACE" mtu 462 up

--- a/platforms/autosd/x5h/scripts/rpmsg-eth-smoke.sh
+++ b/platforms/autosd/x5h/scripts/rpmsg-eth-smoke.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# Board smoke test for rpmsg-eth.service: assert the CR52's rpmsg-eth
+# channel is on the rpmsg bus, tap0 is configured correctly (address AND
+# the frozen MTU 462), then round-trip ping the CR52 side (172.16.52.2)
+# requiring 100% reply.
+#
+# Unlike rpmsg-smoke.sh this does not drive remoteproc itself: rpmsg-
+# eth.service is expected to already be running (systemctl start
+# rpmsg-eth.service, or automatically at boot via its [Install]
+# WantedBy=multi-user.target) -- this checks that an already-up link is
+# healthy, the same shape as any other "is this link alive" smoke test.
+#
+# Markers on stdout (grep-able, one per line):
+#   RPMSG_ETH_PING_PASS
+#   RPMSG_ETH_PING_FAIL reason=<no_channel|no_tap|ping_loss>
+#
+# -n skips the rpmsg-bus channel assertion, for bench runs with no board
+# attached (e.g. validating the tap0/ping plumbing against a manually
+# wired peer that answers 172.16.52.2 without a real CR52 on the other
+# end).
+set -u
+
+SERVICE=rpmsg-eth
+IFACE=tap0
+ADDR=172.16.52.1/24
+MTU=462
+PEER=172.16.52.2
+COUNT=20
+NOBOARD=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -n) NOBOARD=1; shift ;;
+        *)
+            echo "RPMSG_ETH_PING_FAIL reason=bad_args"
+            echo "usage: $0 [-n]"
+            exit 2
+            ;;
+    esac
+done
+
+fail() {
+    echo "RPMSG_ETH_PING_FAIL reason=$1"
+    exit 1
+}
+
+# --- assert the rpmsg-eth channel is on the bus (skippable with -n) --------
+# rpmsg-eth.c's find_service() discovers its endpoint the same way: scan
+# /sys/bus/rpmsg/devices/*/name for an exact match on the service name.
+if [ "$NOBOARD" -eq 0 ]; then
+    found=0
+    for dev in /sys/bus/rpmsg/devices/*; do
+        [ -e "$dev/name" ] || continue
+        if [ "$(cat "$dev/name")" = "$SERVICE" ]; then
+            found=1
+            break
+        fi
+    done
+    [ "$found" -eq 1 ] || fail no_channel
+fi
+
+# --- assert tap0 is up with the expected address and the frozen MTU --------
+# MTU 462 is a frozen wire constant (max Ethernet frame 476 = 462 + the
+# 14-byte Ethernet header, sized to the CR52 side's RPMsg payload budget --
+# see rpmsg-eth-ifup.sh). Checking it here, not just "is tap0 up", catches
+# an ifup regression that brings tap0 up at the kernel default (1500)
+# instead: the daemon would then silently drop oversize frames
+# (rpmsg-eth.c's dropped_oversize counter) rather than failing outright, so
+# nothing else in this smoke test would ever notice.
+LINE="$(ip -o link show "$IFACE" 2>/dev/null)"
+[ -n "$LINE" ] || fail no_tap
+FLAGS="$(echo "$LINE" | sed -n 's/.*<\([^>]*\)>.*/\1/p')"
+up=0
+IFS=,
+for f in $FLAGS; do
+    [ "$f" = "UP" ] && up=1
+done
+unset IFS
+[ "$up" -eq 1 ] || fail no_tap
+echo "$LINE" | grep -q " mtu $MTU " || fail no_tap
+ip -4 -o addr show "$IFACE" 2>/dev/null | grep -q " $ADDR " || fail no_tap
+
+# --- round-trip: 100% reply required ----------------------------------------
+# ping's own exit code is not enough to prove zero loss: iputils only
+# returns nonzero on ZERO packets received (or a local/usage error), so a
+# link dropping half its replies still exits 0. Parse the summary line's
+# transmitted/received counts instead and require them equal and nonzero --
+# an "N received" that never showed up at all (grep miss) or a mismatched
+# count both fail loudly via the same reason=ping_loss, rather than
+# trusting the exit status alone.
+OUT="$(ping -c "$COUNT" -i 0.2 "$PEER" 2>&1)" || true
+echo "$OUT" | grep -q ' packets transmitted' || fail ping_loss
+TX="$(echo "$OUT" | sed -n 's/^\([0-9][0-9]*\) packets transmitted.*/\1/p')"
+RX="$(echo "$OUT" | sed -n 's/.*, \([0-9][0-9]*\) received.*/\1/p')"
+[ -n "$TX" ] && [ -n "$RX" ] && [ "$TX" -gt 0 ] && [ "$TX" = "$RX" ] || fail ping_loss
+
+echo RPMSG_ETH_PING_PASS

--- a/platforms/autosd/x5h/scripts/rpmsg-eth-smoke.sh
+++ b/platforms/autosd/x5h/scripts/rpmsg-eth-smoke.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Board smoke test for rpmsg-eth.service: assert the CR52's rpmsg-eth
-# channel is on the rpmsg bus, tap0 is configured correctly (address AND
-# the frozen MTU 462), then round-trip ping the CR52 side (172.16.52.2)
-# requiring 100% reply.
+# channel is on the rpmsg bus, tap0 is configured correctly (address, the
+# frozen MAC 02:5c:52:00:00:01 AND the frozen MTU 462), then round-trip
+# ping the CR52 side (172.16.52.2) requiring 100% reply.
 #
 # Unlike rpmsg-smoke.sh this does not drive remoteproc itself: rpmsg-
 # eth.service is expected to already be running (systemctl start
@@ -12,7 +12,7 @@
 #
 # Markers on stdout (grep-able, one per line):
 #   RPMSG_ETH_PING_PASS
-#   RPMSG_ETH_PING_FAIL reason=<no_channel|no_tap|ping_loss>
+#   RPMSG_ETH_PING_FAIL reason=<bad_args|no_channel|service_inactive|no_tap|no_carrier|no_ping|ping_loss>
 #
 # -n skips the rpmsg-bus channel assertion, for bench runs with no board
 # attached (e.g. validating the tap0/ping plumbing against a manually
@@ -23,6 +23,7 @@ set -u
 SERVICE=rpmsg-eth
 IFACE=tap0
 ADDR=172.16.52.1/24
+MAC=02:5c:52:00:00:01
 MTU=462
 PEER=172.16.52.2
 COUNT=20
@@ -59,7 +60,22 @@ if [ "$NOBOARD" -eq 0 ]; then
     [ "$found" -eq 1 ] || fail no_channel
 fi
 
-# --- assert tap0 is up with the expected address and the frozen MTU --------
+# --- assert rpmsg-eth.service is actually running --------------------------
+# ifup creates tap0 persistent, addressed and UP as an ExecStartPre step
+# that runs independently of whether the daemon itself ever gets past its
+# endpoint wait (see rpmsg-eth.c's create_ept()/open_endpoint() retry loop)
+# or even started at all. Without this check, a configured-but-unattached
+# tap0 -- address, MAC, MTU and UP flag all correct -- passes every
+# assertion below and this script would only fail at the ping step,
+# pointing the operator at the CR52 for what is actually a stopped or
+# stuck local daemon. Checked before the interface assertions so that case
+# gets its own specific reason instead of a misleading ping_loss.
+if ! systemctl is-active --quiet "$SERVICE.service" 2>/dev/null; then
+    systemctl status "$SERVICE.service" --no-pager 2>&1 | head -10 >&2
+    fail service_inactive
+fi
+
+# --- assert tap0 is up with the expected address, MAC and the frozen MTU --
 # MTU 462 is a frozen wire constant (max Ethernet frame 476 = 462 + the
 # 14-byte Ethernet header, sized to the CR52 side's RPMsg payload budget --
 # see rpmsg-eth-ifup.sh). Checking it here, not just "is tap0 up", catches
@@ -67,18 +83,57 @@ fi
 # instead: the daemon would then silently drop oversize frames
 # (rpmsg-eth.c's dropped_oversize counter) rather than failing outright, so
 # nothing else in this smoke test would ever notice.
+#
+# The MAC (02:5c:52:00:00:01) is likewise frozen -- see rpmsg-eth-ifup.sh
+# for why a kernel-random MAC is wrong even though ARP means it doesn't
+# blackhole traffic today.
 LINE="$(ip -o link show "$IFACE" 2>/dev/null)"
-[ -n "$LINE" ] || fail no_tap
+if [ -z "$LINE" ]; then
+    echo "no such interface: $IFACE" >&2
+    fail no_tap
+fi
 FLAGS="$(echo "$LINE" | sed -n 's/.*<\([^>]*\)>.*/\1/p')"
 up=0
+no_carrier=0
 IFS=,
 for f in $FLAGS; do
     [ "$f" = "UP" ] && up=1
+    [ "$f" = "NO-CARRIER" ] && no_carrier=1
 done
 unset IFS
-[ "$up" -eq 1 ] || fail no_tap
-echo "$LINE" | grep -q " mtu $MTU " || fail no_tap
-ip -4 -o addr show "$IFACE" 2>/dev/null | grep -q " $ADDR " || fail no_tap
+if [ "$up" -ne 1 ]; then
+    echo "$LINE" >&2
+    fail no_tap
+fi
+# NO-CARRIER on a persistent tap the daemon holds open the way I2/I3 of the
+# final review wave require (a fatal tap-side poll condition exits the
+# daemon rather than spinning silently) is the interface-level echo of
+# "the daemon isn't actually attached to this tap" -- check it as its own
+# reason distinct from the systemctl check above, since a stale or
+# externally-recreated tap0 can show this even when the unit itself
+# reports active.
+if [ "$no_carrier" -eq 1 ]; then
+    echo "$LINE" >&2
+    fail no_carrier
+fi
+if ! echo "$LINE" | grep -q " mtu $MTU "; then
+    echo "$LINE" >&2
+    fail no_tap
+fi
+if ! echo "$LINE" | grep -qi " link/ether $MAC "; then
+    echo "$LINE" >&2
+    fail no_tap
+fi
+if ! ip -4 -o addr show "$IFACE" 2>/dev/null | grep -q " $ADDR "; then
+    ip -4 -o addr show "$IFACE" >&2 2>/dev/null
+    fail no_tap
+fi
+
+# --- confirm ping is actually available before blaming the link for it ----
+# Parsing ping's own summary line (below) silently reads a missing binary,
+# a permissions error and a routing error all as the same reason=ping_loss
+# unless this is checked first and given its own reason code.
+command -v ping >/dev/null 2>&1 || fail no_ping
 
 # --- round-trip: 100% reply required ----------------------------------------
 # ping's own exit code is not enough to prove zero loss: iputils only
@@ -89,9 +144,15 @@ ip -4 -o addr show "$IFACE" 2>/dev/null | grep -q " $ADDR " || fail no_tap
 # count both fail loudly via the same reason=ping_loss, rather than
 # trusting the exit status alone.
 OUT="$(ping -c "$COUNT" -i 0.2 "$PEER" 2>&1)" || true
-echo "$OUT" | grep -q ' packets transmitted' || fail ping_loss
+if ! echo "$OUT" | grep -q ' packets transmitted'; then
+    echo "$OUT" >&2
+    fail ping_loss
+fi
 TX="$(echo "$OUT" | sed -n 's/^\([0-9][0-9]*\) packets transmitted.*/\1/p')"
 RX="$(echo "$OUT" | sed -n 's/.*, \([0-9][0-9]*\) received.*/\1/p')"
-[ -n "$TX" ] && [ -n "$RX" ] && [ "$TX" -gt 0 ] && [ "$TX" = "$RX" ] || fail ping_loss
+if [ -z "$TX" ] || [ -z "$RX" ] || [ "$TX" -eq 0 ] || [ "$TX" != "$RX" ]; then
+    echo "$OUT" >&2
+    fail ping_loss
+fi
 
 echo RPMSG_ETH_PING_PASS


### PR DESCRIPTION
Gives the X5H's AutoSD side an IP link to the CR52 safety island over RPMsg, so ROS 2 / DDS traffic can reach the real-time core without a second physical Ethernet path. Fourth in the X5H single-ECU stack, on top of #129.

## What this adds

`rpmsg-eth` is a small userspace daemon that bridges a Linux TAP device to an RPMsg endpoint served by FreeRTOS firmware on the CR52. Frames go out of `tap0` to the endpoint and back, so from Linux's point of view the safety island is just another host on a point-to-point subnet — `172.16.52.1` on the Linux side, `172.16.52.2` on the CR52 side.

The wire contract is frozen and deliberately narrow: RPMsg service name `rpmsg-eth`, MTU 462 with a 476-byte maximum frame (462 payload plus the 14-byte Ethernet header), Linux MAC `02:5c:52:00:00:01` and CR52 MAC `02:5c:52:00:00:02`. The MTU is not a tuning knob — it is derived from the RPMsg payload budget, and bringing `tap0` up at the kernel's default 1500 would let the kernel hand the daemon frames it can only drop as oversize.

Also included: a systemd unit and an `ExecStartPre` bring-up script that configure the interface (including the MAC and MTU the contract requires), a smoke script that asserts the link end to end, and a host test that runs in CI.

## Design notes worth review attention

**The daemon is start-order independent.** It does not require the CR52 to be up first. It logs that it is waiting, names what it is waiting for, and retries at roughly 1 Hz — reporting the first occurrence of each distinct failure reason and then every ~30 attempts, so a wait stuck on one reason still produces console output. This matters because the board is diagnosed over a slow serial console where a silent retry loop and a hang look identical.

**It survives the CR52 going away and coming back.** A reset drops the endpoint; the daemon detects the loss, logs it, rebinds, and resumes relaying rather than exiting. The endpoint is re-announced once per reset, which the rebind path handles.

**Fatal conditions are fatal, and distinguishable from shutdown.** A `POLLERR` / `POLLHUP` / `POLLNVAL` on the tap fd — for example `ip link del tap0` under the running daemon — exits nonzero so `Restart=on-failure` fires, while a clean `SIGTERM` still exits 0 so `systemctl restart` does not look like a failure. Those two paths return through distinct sentinels precisely so a fatal tap can never be misread as a requested shutdown, and a signal arriving mid-`poll()` returns `EINTR` before any `revents` is examined, so it cannot be misclassified either.

**The smoke script fails with a specific reason rather than a generic one.** It distinguishes an inactive unit, a missing tap, a `NO-CARRIER` link, a missing `ping` binary, and genuine packet loss, and echoes the offending output to stderr. It parses ping's transmitted/received counts rather than trusting its exit status, because `iputils` returns nonzero only when *zero* packets come back — a link dropping half its replies exits 0.

## Verification

The daemon compiles clean under `-Wall -Wextra`, every touched shell script passes shellcheck, and `test-rpmsg-eth.sh` passes end to end in CI: it stands up a real TAP device in its own network namespace, relays frames both directions against a mock endpoint, then kills the peer to assert the daemon survives, logs the loss, rebinds, and round-trips again.

Each assertion was also checked for the ability to fail, by fault injection rather than by inspection: a build with the tap→endpoint relay disabled reports a failure instead of hanging; a build that exits instead of rebinding is caught by the rebind assertions; and reverting the fatal-tap detection makes the new endpoint-wait case report a bounded failure rather than spinning.

## Hardware results — what is and is not proven

This has now run against real CR52 firmware on the board. Full write-up with the evidence is on Confluence (internal): *X5H FreeRTOS Target + RPMsg netif — Board Results (2026-08-13 → 15)*. The companion firmware is autowarefoundation/autoware-safety-island#45.

**Proven on the board:** the daemon bridges IP over RPMsg in both directions and sustains it for hours; `ping` across the link returns 0% loss; oversize drops stayed at zero throughout; `tap0` comes up at MTU 462 as the wire contract requires; and the endpoint survives repeated `systemctl restart rpmsg-eth` with clean rebinds. The full DDS round trip over this link reached `DDS_ROUNDTRIP_PASS count=1979`.

**Update — the safety-island defect referenced below is fixed, and the round trip now passes on the shipping firmware build.** An earlier revision of this description said the round trip passed at most once per boot and not at all on the shipping build, and attributed that to the CR52's controller thread ceasing to exist partway through the first run. The attribution was right that the fault was not in this daemon or in the transport, and it is now explained: the vendor BSP indexed the GIC redistributor by MPIDR Aff0 on a base that is already per-CPU, so on this core the timer interrupt kept the GIC reset priority and was therefore never masked by the firmware's priority-masked critical sections. A tick landing inside the scheduler's priority-inheritance cleanup left a ready-list insert half-complete and the controller task on no counted list. It was unlinked, not deleted, which is why it looked like it had vanished.

The fix, along with a per-task emulated-TLS runtime, a trajectory-buffer growth fix, and an input-staleness gate, is in autowarefoundation/autoware-safety-island#45. Nothing in this daemon changed as a result. The round trip has since been exercised on the target in the shipping configuration, including consecutive runs within a single boot, which is the case that previously failed; detailed results are recorded on the internal results page rather than here.

Two traps from bring-up are worth keeping for anyone reproducing this: the board image needs `iputils` for the smoke test to prove a round trip, and `tcpdump` is not present on the board.

Two things worth carrying into the next board session, both of which cost time here:

- **`iputils` was missing from the image manifest**, so the smoke test could only ever have reported `reason=no_ping` on a real board — it would have proven `tap0` was configured and never that IP round-trips. Fixed in this PR, but it fixes the *next* image build.
- **The board image has no `tcpdump`** — nor `tshark`, `socat`, `nc`, `python3` or `busybox` — so any diagnostic step that assumes a packet capture is available needs a binary staged first.

