### PR TITLE
fix(ci): restore build-all-images to green

### DIFF
--- a/.github/workflows/build-all-images.yaml
+++ b/.github/workflows/build-all-images.yaml
@@ -32,6 +32,12 @@ on:
         required: false
         type: boolean
         default: false
+      upstream_tag:
+        description: >-
+          Override the upstream Autoware base image tag (e.g. 1.9.0). Leave
+          empty to derive it from the Autoware ref being built.
+        required: false
+        default: ''
 
 concurrency:
   group: build-all-images-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
@@ -53,6 +59,7 @@ jobs:
       autoware_ref_type: ${{ steps.prepare.outputs.autoware_ref_type }}
       autoware_ref: ${{ steps.prepare.outputs.autoware_ref }}
       autoware_base_version: ${{ steps.prepare.outputs.autoware_base_version }}
+      upstream_tag: ${{ steps.prepare.outputs.upstream_tag }}
       autoware_lock_sha256: ${{ steps.lock.outputs.autoware_lock_sha256 }}
       build_tag: ${{ steps.prepare.outputs.build_tag }}
       scan_requested: ${{ steps.prepare.outputs.scan_requested }}
@@ -68,6 +75,7 @@ jobs:
         env:
           AUTOWARE_REF_INPUT: ${{ inputs.autoware_ref || 'main' }}
           RUN_SCAN_INPUT: ${{ inputs.run_scan || false }}
+          UPSTREAM_TAG_INPUT: ${{ inputs.upstream_tag || '' }}
         run: |
           set -euo pipefail
 
@@ -105,11 +113,20 @@ jobs:
           )
           [ -n "${autoware_base_version}" ] || (echo "Could not infer Autoware base version from ${autoware_input_ref}" && exit 1)
 
+          # The upstream base images are tagged by Autoware release, and the
+          # sources compiled on top of them come from that same ref. Derive the
+          # tag from the ref so the two cannot drift: a hand-maintained pin goes
+          # stale on every release and then fails as an unrelated-looking
+          # compile error deep inside colcon.
+          upstream_tag="${UPSTREAM_TAG_INPUT:-}"
+          [ -n "${upstream_tag}" ] || upstream_tag="${autoware_base_version}"
+
           {
             echo "autoware_input_ref=${autoware_input_ref}"
             echo "autoware_ref_type=${autoware_ref_type}"
             echo "autoware_ref=${autoware_ref}"
             echo "autoware_base_version=${autoware_base_version}"
+            echo "upstream_tag=${upstream_tag}"
             echo "build_tag=${build_tag}"
             echo "scan_requested=${scan_requested}"
           } >> "$GITHUB_OUTPUT"
@@ -301,7 +318,7 @@ jobs:
       - name: Ensure upstream Autoware base images exist
         env:
           ROS_DISTRO: ${{ matrix.ros-distro }}
-          UPSTREAM_TAG: ${{ vars.UPSTREAM_TAG }}
+          UPSTREAM_TAG: ${{ needs.prepare.outputs.upstream_tag }}
         run: |
           set -euo pipefail
           # universe-common surfaces core/core-devel; sensing-perception-cuda
@@ -365,7 +382,7 @@ jobs:
         uses: docker/bake-action@v5
         env:
           ROS_DISTRO: ${{ matrix.ros-distro }}
-          UPSTREAM_TAG: ${{ vars.UPSTREAM_TAG }}
+          UPSTREAM_TAG: ${{ needs.prepare.outputs.upstream_tag }}
         with:
           files: |
             ${{ env.BAKE_FILE }}
@@ -521,7 +538,7 @@ jobs:
         uses: docker/bake-action@v5
         env:
           ROS_DISTRO: ${{ matrix.ros-distro }}
-          UPSTREAM_TAG: ${{ vars.UPSTREAM_TAG }}
+          UPSTREAM_TAG: ${{ needs.prepare.outputs.upstream_tag }}
         with:
           files: |
             ${{ env.BAKE_FILE }}

--- a/components/carla-interface/Dockerfile
+++ b/components/carla-interface/Dockerfile
@@ -8,6 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
+    python3-pip \
     ros-${ROS_DISTRO}-compressed-image-transport \
     ros-${ROS_DISTRO}-topic-tools \
   && python3 -m pip install --no-cache-dir \

--- a/components/docker-bake.hcl
+++ b/components/docker-bake.hcl
@@ -14,9 +14,10 @@ variable "ROS_DISTRO" {
 }
 
 // Pin for upstream Autoware images. A concrete release tag (e.g. "1.2.3") is
-// the production default, set via a repo Variable in CI. Empty string yields
-// the upstream "plain" <name>-<distro> multi-arch manifest — handy for local
-// experiments, but NOT what CI should run with.
+// the production default; CI derives it from the Autoware ref being built so
+// the base images always match the sources compiled on top of them. Empty
+// string yields the upstream "plain" <name>-<distro> multi-arch manifest —
+// handy for local experiments, but NOT what CI should run with.
 variable "UPSTREAM_TAG" {
   default = ""
 }

--- a/components/visualizer/Dockerfile
+++ b/components/visualizer/Dockerfile
@@ -51,6 +51,7 @@ RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=
 FROM ${UNIVERSE_COMMON_IMAGE} AS visualizer
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
+ARG TARGETARCH
 
 USER root
 COPY --from=visualizer-devel /opt/autoware /opt/autoware
@@ -87,7 +88,7 @@ RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=
       pipx && \
     PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install yamale && \
     PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install xmlschema && \
-    curl -fsSL -o /tmp/virtualgl.deb https://github.com/VirtualGL/virtualgl/releases/download/3.1.2/virtualgl_3.1.2_amd64.deb && \
+    curl -fsSL -o /tmp/virtualgl.deb "https://github.com/VirtualGL/virtualgl/releases/download/3.1.2/virtualgl_3.1.2_${TARGETARCH}.deb" && \
     apt-get install -y --no-install-recommends /tmp/virtualgl.deb && \
     rm -f /tmp/virtualgl.deb
 


### PR DESCRIPTION
## Summary

`build-all-images` has failed on every run since 2026-06-13. This restores it to a fully green run. There were **two independent causes** that overlapped in time, which is why it looked like one continuous failure.

## Root cause

**Cause A — two version knobs with nothing tying them together (all four `build-common` jobs).** The workflow compiles Autoware sources from `autowarefoundation/autoware` at the requested ref (`main` by default), but selected the upstream base images from `vars.UPSTREAM_TAG`, a hand-maintained repository Variable. Nothing kept the two in agreement, and they drifted: the variable still read `1.8.0` while `main`'s `repositories/autoware.repos` had moved on to `autoware_core` 1.9.0 and `autoware_universe` 0.52.1.

`autoware_universe` 0.52.1 calls the three-argument overload `VehicleInfo::createFootprint(lat_margin, lon_margin, base_pose)` at `autoware_deprecated_boundary_departure_checker/src/utils.cpp:355`. That optional `base_pose` parameter was added in `autoware_core` 1.9.0; the 1.8.0 base image ships only the one-, two- and six-argument forms — exactly the three candidates the compiler listed. The package failed to compile, which sank every `build-common` job and cascaded into every `create-manifests` job as `missing architecture(s)`.

**Cause B — two latent Dockerfile bugs (three `build-components` jobs).** `visualizer` is declared for both `linux/amd64` and `linux/arm64` but always fetched `virtualgl_3.1.2_amd64.deb`, so on arm64 apt tried to satisfy an amd64 dependency chain that is not installable there (`virtualgl:amd64 : Depends: libxtst6:amd64 but it is not installable`). Separately, `carla-interface` called `python3 -m pip install` on the runtime simulator base, which ships no Python packaging tools (`/usr/bin/python3: No module named pip`).

**How they overlapped.** Cause B broke the workflow first, on 2026-06-13. From then until 2026-07-12 every run failed with exactly three red jobs — `visualizer` (arm64 × 2) and `carla-interface` — while `build-common` passed. Autoware 1.9.0 was released on 2026-07-16; from the 07-19 run onward Cause A took over, `build-components` became `skipped`, and Cause B was hidden from view. Both must be fixed for the workflow to go green.

## Changes

- **`fix(ci): derive the upstream base image tag from the Autoware ref`** — the `prepare` job already computes `autoware_base_version` (the release the requested ref belongs to) but used it only as an OCI label. It now also drives the base image tag, so the base images and the sources compiled on top of them cannot drift apart. An optional `upstream_tag` `workflow_dispatch` input keeps a deliberate pin available for experiments. `vars.UPSTREAM_TAG` is no longer read.
- **`fix(visualizer): install the VirtualGL build matching the target arch`** — select the package with BuildKit's `TARGETARCH`, whose values (`amd64`, `arm64`) already match both the Debian architecture names and the VirtualGL release asset naming. Upstream publishes `virtualgl_3.1.2_arm64.deb` alongside the amd64 build.
- **`fix(carla-interface): install pip before using it`** — add `python3-pip` to the apt install that already immediately precedes the `pip install`, matching how the sibling `visualizer` image installs the Python tooling it needs rather than assuming the base provides it.

## Verification

Verified end to end on a fork run, since this workflow cannot be exercised from a PR branch here: https://github.com/youtalk/openadkit/actions/runs/32311729626 — **60/60 jobs green, 0 failures** (the single skipped job is `notify-failure`, correctly skipped because nothing failed).

An earlier run with only the first commit applied confirmed Cause A in isolation: base images resolved to `core-humble-1.9.0` / `core-devel-humble-1.9.0` / `base-cuda-{devel,runtime}-humble-1.9.0`, `autoware_deprecated_boundary_departure_checker` went from `Failed <<< [57.8s, exited with code 2]` to `Finished <<< [2min 41s]`, and the colcon summary went from `11 packages finished / 1 failed / 3 aborted` to `60 packages finished` with no failures. That run's only remaining failures were exactly the three Cause B jobs — the same set that had been failing before 2026-07-16, which is what confirmed the two causes were distinct.

## Note

Deriving the tag from `autoware_base_version` pins the base to the most recent release the requested ref descends from. If `main` ever bumps `autoware.repos` to a core newer than the latest tag, a smaller version of this skew could recur — but it would then fail immediately and legibly as `Missing upstream image: ...` in the existing guard step, rather than as a compile error deep inside colcon. I left an explicit consistency check out to keep this change reviewable; happy to add one if you would prefer it.
