### PR TITLE
feat(release): add unified dual-distro release pipeline

### DIFF
--- a/.github/scripts/manage_github_release.sh
+++ b/.github/scripts/manage_github_release.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# Safely prepare and publish workflow-owned GitHub releases.
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.github/scripts/release_tag.sh
+source "${script_dir}/release_tag.sh"
+
+readonly RELEASE_WORKFLOW_MARKER='<!-- openadkit-release-workflow:v1 -->'
+
+project_release() {
+  jq -c '{
+    id,
+    assets,
+    body: (.body // ""),
+    isDraft: .draft,
+    isPrerelease: .prerelease,
+    name,
+    tagName: .tag_name,
+    targetCommitish: .target_commitish
+  }'
+}
+
+expected_prerelease() {
+  if [ "${STABLE_RELEASE}" = true ]; then
+    printf '%s\n' false
+  else
+    printf '%s\n' true
+  fi
+}
+
+verify_release_tag_target() {
+  local tag_sha lookup_status=0
+  tag_sha=$(release_tag_sha) || lookup_status=$?
+  if [ "${lookup_status}" -ne 0 ]; then
+    echo "Release tag ${VERSION} could not be resolved" >&2
+    return 1
+  fi
+  if [ "${tag_sha}" != "${RELEASE_SHA}" ]; then
+    echo "Release tag ${VERSION} resolves to ${tag_sha}, expected ${RELEASE_SHA}" >&2
+    return 1
+  fi
+}
+
+verify_owned_draft() {
+  local state="$1"
+  jq -e \
+    --arg marker "${RELEASE_WORKFLOW_MARKER}" \
+    --arg version "${VERSION}" \
+    --arg release_sha "${RELEASE_SHA}" '
+      (.id | type == "number") and
+      .isDraft == true and
+      .tagName == $version and
+      .name == $version and
+      .targetCommitish == $release_sha and
+      (.body | startswith($marker))
+    ' <<<"${state}" >/dev/null
+}
+
+write_expected_asset_manifest() {
+  {
+    for asset in \
+      release-metadata.json \
+      release-input/build/autoware-lock.repos \
+      release-input/build/upstream-images.json \
+      dist/*.tar.gz; do
+      [ -f "${asset}" ] || {
+        echo "Expected release asset is missing: ${asset}" >&2
+        return 1
+      }
+      printf '%s  %s\n' "$(sha256sum "${asset}" | cut -d ' ' -f1)" "$(basename "${asset}")"
+    done
+  } | sort -k2,2 > release-assets.sha256
+}
+
+verify_draft_assets() {
+  local state="$1"
+  local manifest="${RELEASE_ASSET_MANIFEST:-release-assets.sha256}"
+  local expected_assets existing_assets download_dir manifest_path
+
+  [ -f "${manifest}" ] || {
+    echo "Expected release asset manifest is missing: ${manifest}" >&2
+    return 1
+  }
+  if ! awk '
+    NF != 2 || $1 !~ /^[0-9a-f]{64}$/ || $2 !~ /^[A-Za-z0-9._-]+$/ { invalid=1 }
+    { count++ }
+    END { exit(!invalid && count > 0 ? 0 : 1) }
+  ' "${manifest}"; then
+    echo "Release asset manifest is invalid" >&2
+    return 1
+  fi
+
+  expected_assets=$(awk '{ print $2 }' "${manifest}" | sort)
+  existing_assets=$(jq -r '.assets[].name' <<<"${state}" | sort)
+  if ! diff -u <(printf '%s\n' "${expected_assets}") <(printf '%s\n' "${existing_assets}"); then
+    echo "Draft release asset names changed before publication" >&2
+    return 1
+  fi
+
+  download_dir=$(mktemp -d)
+  manifest_path=$(realpath "${manifest}")
+  if ! (
+    cd "${download_dir}"
+    while IFS=$'\t' read -r asset_id asset_name; do
+      [[ "${asset_id}" =~ ^[0-9]+$ && "${asset_name}" =~ ^[A-Za-z0-9._-]+$ ]] || exit 1
+      gh api \
+        -H 'Accept: application/octet-stream' \
+        "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" > "${asset_name}"
+    done < <(jq -r '.assets[] | [.id, .name] | @tsv' <<<"${state}")
+    sha256sum --check "${manifest_path}"
+  ); then
+    rm -rf "${download_dir}"
+    echo "Draft release asset contents changed before publication" >&2
+    return 1
+  fi
+  rm -rf "${download_dir}"
+}
+
+fetch_release_by_id() {
+  local release_id="$1" response
+  response=$(gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}") || return
+  project_release <<<"${response}"
+}
+
+fetch_release_by_tag() {
+  local response
+  response=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100") || return
+  jq -c --arg version "${VERSION}" '
+    [.[][] | select(.tag_name == $version)] |
+    if length > 1 then error("duplicate releases for tag")
+    elif length == 1 then
+      .[0] | {
+        id,
+        assets,
+        body: (.body // ""),
+        isDraft: .draft,
+        isPrerelease: .prerelease,
+        name,
+        tagName: .tag_name,
+        targetCommitish: .target_commitish
+      }
+    else empty end
+  ' <<<"${response}"
+}
+
+verify_published_release() {
+  local state="$1"
+  local prerelease expected_assets existing_assets existing_dir release_id refreshed
+  prerelease=$(expected_prerelease)
+  release_id=$(jq -r '.id' <<<"${state}")
+  jq -e \
+    --arg version "${VERSION}" \
+    --arg release_sha "${RELEASE_SHA}" \
+    --argjson prerelease "${prerelease}" \
+    --rawfile expected_body release-notes.md '
+      (.id | type == "number") and
+      .tagName == $version and
+      .targetCommitish == $release_sha and
+      .name == $version and
+      .isDraft == false and
+      .isPrerelease == $prerelease and
+      .body == $expected_body
+    ' <<<"${state}" >/dev/null
+
+  refreshed=$(fetch_release_by_id "${release_id}")
+  cmp <(jq -S . <<<"${state}") <(jq -S . <<<"${refreshed}")
+
+  expected_assets=$(
+    {
+      printf '%s\n' release-metadata.json autoware-lock.repos upstream-images.json
+      for asset in dist/*.tar.gz; do
+        basename "${asset}"
+      done
+    } | sort
+  )
+  existing_assets=$(jq -r '.assets[].name' <<<"${state}" | sort)
+  diff -u <(printf '%s\n' "${expected_assets}") <(printf '%s\n' "${existing_assets}")
+
+  existing_dir=$(mktemp -d)
+  gh release download "${VERSION}" \
+    --dir "${existing_dir}" \
+    --pattern release-metadata.json \
+    --pattern autoware-lock.repos \
+    --pattern upstream-images.json \
+    --pattern '*.tar.gz'
+  cmp <(jq -S . "${existing_dir}/release-metadata.json") <(jq -S . release-metadata.json)
+  for asset in release-input/build/autoware-lock.repos release-input/build/upstream-images.json dist/*.tar.gz; do
+    cmp "${asset}" "${existing_dir}/$(basename "${asset}")"
+  done
+  rm -rf "${existing_dir}"
+}
+
+create_draft() {
+  local state
+  gh release create "${VERSION}" \
+    --target "${RELEASE_SHA}" \
+    --title "${VERSION}" \
+    --notes-file release-notes.md \
+    --draft \
+    release-metadata.json \
+    release-input/build/autoware-lock.repos \
+    release-input/build/upstream-images.json \
+    dist/*.tar.gz >/dev/null
+  state=$(fetch_release_by_tag) || return
+  if [ -z "${state}" ] || ! verify_owned_draft "${state}"; then
+    echo "Created draft release ${VERSION} could not be verified" >&2
+    return 1
+  fi
+  jq -er '.id' <<<"${state}"
+}
+
+prepare_release() {
+  local release_state existing_is_draft release_id refreshed body_sha256 create_release=false
+
+  : "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+  write_expected_asset_manifest
+  verify_release_tag_target
+  release_state=$(fetch_release_by_tag) || return
+
+  if [ -n "${release_state}" ]; then
+    existing_is_draft=$(jq -r '.isDraft' <<<"${release_state}")
+    release_id=$(jq -r '.id' <<<"${release_state}")
+    if [ "${existing_is_draft}" = true ]; then
+      verify_owned_draft "${release_state}" || return
+      refreshed=$(fetch_release_by_id "${release_id}") || return
+      verify_owned_draft "${refreshed}" || return
+      cmp <(jq -S . <<<"${release_state}") <(jq -S . <<<"${refreshed}")
+      echo "Removing workflow-owned incomplete draft release ${VERSION}."
+      gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/${release_id}" >/dev/null
+      create_release=true
+    else
+      verify_published_release "${release_state}"
+      echo "Existing release ${VERSION} matches validated metadata, notes, and assets."
+    fi
+  else
+    create_release=true
+  fi
+
+  if [ "${create_release}" = true ]; then
+    release_id=$(create_draft) || return
+  fi
+  body_sha256=$(sha256sum release-notes.md | cut -d ' ' -f1)
+  {
+    echo "created=${create_release}"
+    echo "release_id=${release_id}"
+    echo "release_body_sha256=${body_sha256}"
+  } >>"${GITHUB_OUTPUT}"
+}
+
+publish_release() {
+  local state prerelease make_latest actual_body_sha256
+  : "${RELEASE_ID:?RELEASE_ID is required}"
+  : "${RELEASE_BODY_SHA256:?RELEASE_BODY_SHA256 is required}"
+  verify_release_tag_target
+  state=$(fetch_release_by_id "${RELEASE_ID}")
+  verify_owned_draft "${state}"
+  actual_body_sha256=$(jq -jr '.body' <<<"${state}" | sha256sum | cut -d ' ' -f1)
+  if [ "${actual_body_sha256}" != "${RELEASE_BODY_SHA256}" ]; then
+    echo "Draft release body changed before publication" >&2
+    return 1
+  fi
+  verify_draft_assets "${state}"
+  prerelease=$(expected_prerelease)
+  make_latest=false
+  if [ "${STABLE_RELEASE}" = true ] && [ "${PUBLISH_LATEST_ALIASES}" = true ]; then
+    make_latest=true
+  fi
+  gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
+    -F draft=false \
+    -F prerelease="${prerelease}" \
+    -f make_latest="${make_latest}" >/dev/null
+}
+
+: "${VERSION:?VERSION is required}"
+: "${RELEASE_SHA:?RELEASE_SHA is required}"
+: "${STABLE_RELEASE:?STABLE_RELEASE is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+case "${1:-}" in
+  prepare) prepare_release ;;
+  publish)
+    : "${PUBLISH_LATEST_ALIASES:?PUBLISH_LATEST_ALIASES is required}"
+    publish_release
+    ;;
+  *)
+    echo "Usage: $0 prepare|publish" >&2
+    exit 2
+    ;;
+esac

--- a/.github/scripts/manage_github_release.sh
+++ b/.github/scripts/manage_github_release.sh
@@ -7,6 +7,26 @@ script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 source "${script_dir}/release_tag.sh"
 
 readonly RELEASE_WORKFLOW_MARKER='<!-- openadkit-release-workflow:v1 -->'
+plan_file=${RELEASE_PLAN_FILE:-release-plan.json}
+jq -e '
+  .schemaVersion == 1 and
+  (.release.version | type == "string") and
+  (.release.releaseSha | test("^[0-9a-f]{40}$")) and
+  (.release.stable | type == "boolean") and
+  (.release.publishLatestAliases | type == "boolean") and
+  (.githubAssets | type == "array" and length > 0) and
+  ([.githubAssets[].name] | length == (unique | length)) and
+  all(.githubAssets[];
+    (.name | test("^[A-Za-z0-9._-]+$")) and
+    (.path | type == "string" and length > 0) and
+    (.path | startswith("/") | not) and
+    (.path | split("/") | all(. != ".." and . != ""))
+  )
+' "${plan_file}" >/dev/null
+VERSION=$(jq -r '.release.version' "${plan_file}")
+RELEASE_SHA=$(jq -r '.release.releaseSha' "${plan_file}")
+STABLE_RELEASE=$(jq -r '.release.stable' "${plan_file}")
+PUBLISH_LATEST_ALIASES=$(jq -r '.release.publishLatestAliases' "${plan_file}")
 
 project_release() {
   jq -c '{
@@ -59,17 +79,13 @@ verify_owned_draft() {
 
 write_expected_asset_manifest() {
   {
-    for asset in \
-      release-metadata.json \
-      release-input/build/autoware-lock.repos \
-      release-input/build/upstream-images.json \
-      dist/*.tar.gz; do
-      [ -f "${asset}" ] || {
-        echo "Expected release asset is missing: ${asset}" >&2
+    while IFS=$'\t' read -r path name; do
+      [ -f "${path}" ] || {
+        echo "Expected release asset is missing: ${path}" >&2
         return 1
       }
-      printf '%s  %s\n' "$(sha256sum "${asset}" | cut -d ' ' -f1)" "$(basename "${asset}")"
-    done
+      printf '%s  %s\n' "$(sha256sum "${path}" | cut -d ' ' -f1)" "${name}"
+    done < <(jq -r '.githubAssets[] | [.path, .name] | @tsv' "${plan_file}")
   } | sort -k2,2 > release-assets.sha256
 }
 
@@ -147,6 +163,7 @@ fetch_release_by_tag() {
 verify_published_release() {
   local state="$1"
   local prerelease expected_assets existing_assets existing_dir release_id refreshed
+  local -a download_args
   prerelease=$(expected_prerelease)
   release_id=$(jq -r '.id' <<<"${state}")
   jq -e \
@@ -166,42 +183,33 @@ verify_published_release() {
   refreshed=$(fetch_release_by_id "${release_id}")
   cmp <(jq -S . <<<"${state}") <(jq -S . <<<"${refreshed}")
 
-  expected_assets=$(
-    {
-      printf '%s\n' release-metadata.json autoware-lock.repos upstream-images.json
-      for asset in dist/*.tar.gz; do
-        basename "${asset}"
-      done
-    } | sort
-  )
+  expected_assets=$(jq -r '.githubAssets[].name' "${plan_file}" | sort)
   existing_assets=$(jq -r '.assets[].name' <<<"${state}" | sort)
   diff -u <(printf '%s\n' "${expected_assets}") <(printf '%s\n' "${existing_assets}")
 
   existing_dir=$(mktemp -d)
-  gh release download "${VERSION}" \
-    --dir "${existing_dir}" \
-    --pattern release-metadata.json \
-    --pattern autoware-lock.repos \
-    --pattern upstream-images.json \
-    --pattern '*.tar.gz'
+  download_args=(release download "${VERSION}" --dir "${existing_dir}")
+  while IFS= read -r name; do
+    download_args+=(--pattern "${name}")
+  done < <(jq -r '.githubAssets[].name' "${plan_file}")
+  gh "${download_args[@]}"
   cmp <(jq -S . "${existing_dir}/release-metadata.json") <(jq -S . release-metadata.json)
-  for asset in release-input/build/autoware-lock.repos release-input/build/upstream-images.json dist/*.tar.gz; do
-    cmp "${asset}" "${existing_dir}/$(basename "${asset}")"
-  done
+  while IFS=$'\t' read -r path name; do
+    cmp "${path}" "${existing_dir}/${name}"
+  done < <(jq -r '.githubAssets[] | [.path, .name] | @tsv' "${plan_file}")
   rm -rf "${existing_dir}"
 }
 
 create_draft() {
   local state
+  local -a assets
+  mapfile -t assets < <(jq -r '.githubAssets[].path' "${plan_file}")
   gh release create "${VERSION}" \
     --target "${RELEASE_SHA}" \
     --title "${VERSION}" \
     --notes-file release-notes.md \
     --draft \
-    release-metadata.json \
-    release-input/build/autoware-lock.repos \
-    release-input/build/upstream-images.json \
-    dist/*.tar.gz >/dev/null
+    "${assets[@]}" >/dev/null
   state=$(fetch_release_by_tag) || return
   if [ -z "${state}" ] || ! verify_owned_draft "${state}"; then
     echo "Created draft release ${VERSION} could not be verified" >&2
@@ -272,15 +280,11 @@ publish_release() {
     -f make_latest="${make_latest}" >/dev/null
 }
 
-: "${VERSION:?VERSION is required}"
-: "${RELEASE_SHA:?RELEASE_SHA is required}"
-: "${STABLE_RELEASE:?STABLE_RELEASE is required}"
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 
 case "${1:-}" in
   prepare) prepare_release ;;
   publish)
-    : "${PUBLISH_LATEST_ALIASES:?PUBLISH_LATEST_ALIASES is required}"
     publish_release
     ;;
   *)

--- a/.github/scripts/package_release_bundles.sh
+++ b/.github/scripts/package_release_bundles.sh
@@ -1,163 +1,85 @@
 #!/usr/bin/env bash
-# Assemble and validate self-contained deployment bundles for a release.
+# Assemble and validate the unified Open AD Kit release bundle.
 set -euo pipefail
+export PYTHONDONTWRITEBYTECODE=1
 
-source_dir="${SOURCE_DIR:-src}"
-install="${source_dir}/install.sh"
-base_dir="${source_dir}/deployments/base"
-image_prefix_component="${IMAGE_PREFIX_COMPONENT:-ghcr.io/autowarefoundation/openadkit}"
-build_metadata_file="${BUILD_METADATA_FILE:-release-input/build/build-metadata.json}"
+: "${VERSION:?VERSION is required}"
+: "${RELEASE_SHA:?RELEASE_SHA is required}"
+: "${PACKAGER_SHA:?PACKAGER_SHA is required}"
+: "${DEFAULT_ROS_DISTRO:?DEFAULT_ROS_DISTRO is required}"
+: "${STABLE_RELEASE:?STABLE_RELEASE is required}"
+: "${PUBLISH_LATEST_ALIASES:?PUBLISH_LATEST_ALIASES is required}"
 
-mkdir -p dist staging
-for entry in \
-  "planning-simulation:${source_dir}/deployments/planning-simulation" \
-  "scenario-simulation:${source_dir}/deployments/scenario-simulation" \
-  "logging-simulation:${source_dir}/deployments/logging-simulation" \
-  "carla-simulation:${source_dir}/deployments/carla-simulation" \
-  "zenoh-bridge:${source_dir}/deployments/zenoh-bridge"; do
-  name="${entry%%:*}"
-  dir="${entry#*:}"
-  rm -rf "staging/${name}"
-  cp -a "${dir}" "staging/${name}"
+source_dir=${SOURCE_DIR:-src}
+build_metadata=${BUILD_METADATA_FILE:-release-input/build/build-metadata.json}
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+planner=${RELEASE_PLAN_SCRIPT:-${script_dir}/release_plan.py}
+root_name="openadkit-${VERSION}"
+bundle_root="staging/${root_name}"
+asset="dist/${root_name}.tar.gz"
 
-  # carla-simulation downloads its own assets via start-carla-e2e-demo.sh.
-  if [ "${name}" != "carla-simulation" ]; then
-    cp "${install}" "staging/${name}/install.sh"
-    chmod +x "staging/${name}/install.sh"
-  fi
-
-  # Base-backed deployments ship the complete base beside their config.env.
-  compose="staging/${name}/docker-compose.yaml"
-  if [ -f "${compose}" ] && grep -q '\.\./base/docker-compose\.yaml' "${compose}"; then
-    mkdir -p "staging/${name}/base"
-    cp -a "${base_dir}/." "staging/${name}/base/"
-    sed -i 's#\.\./base/#./base/#' "${compose}"
-  fi
-
-  # Keep the readable release tag, but bind it to the exact validated digest so
-  # a downloaded bundle cannot change if a registry credential later moves it.
-  if [ -n "${VERSION:-}" ] && [ -n "${DEFAULT_ROS_DISTRO:-}" ]; then
-    [ -f "${build_metadata_file}" ] || {
-      echo "Validated build metadata not found: ${build_metadata_file}" >&2
-      exit 1
-    }
-    bundle_ros_distro="${DEFAULT_ROS_DISTRO}"
-    if [ "${name}" = "carla-simulation" ]; then
-      bundle_ros_distro=humble
-    fi
-    bundle_files=(
-      "staging/${name}/docker-compose.yaml" \
-      "staging/${name}/docker-compose."*.yaml \
-      "staging/${name}/base/docker-compose.yaml" \
-      "staging/${name}/config.env"
-    )
-    echo "Pinning Open AD Kit image refs to ${bundle_ros_distro}-${VERSION} and validated digests"
-    while IFS= read -r target; do
-      [ -n "${target}" ] || continue
-      source_pattern="ghcr\\.io/autowarefoundation/openadkit:${target}(-(amd64|arm64))?(-(humble|jazzy))?([^a-z0-9-]|$)"
-      present=false
-      for f in "${bundle_files[@]}"; do
-        [ -f "${f}" ] || continue
-        if grep -Eq "${source_pattern}" "${f}"; then
-          present=true
-          break
-        fi
-      done
-      [ "${present}" = true ] || continue
-      matches=$(jq -c \
-        --arg repo "${image_prefix_component}" \
-        --arg target "${target}" \
-        --arg distro "${bundle_ros_distro}" \
-        '[.images[] | select(.repo == $repo and .target == $target and .ros_distro == $distro)]' \
-        "${build_metadata_file}")
-      [ "$(jq 'length' <<<"${matches}")" -eq 1 ] || {
-        echo "Expected one validated digest for ${image_prefix_component}:${target}-${bundle_ros_distro}, found $(jq 'length' <<<"${matches}")" >&2
-        exit 1
-      }
-      digest=$(jq -r '.[0].digest | select(test("^sha256:[0-9a-f]{64}$"))' <<<"${matches}")
-      [ -n "${digest}" ] || {
-        echo "Invalid validated digest for ${target}-${bundle_ros_distro}" >&2
-        exit 1
-      }
-      for f in "${bundle_files[@]}"; do
-        [ -f "${f}" ] || continue
-        sed -i -E "s#${source_pattern}#${image_prefix_component}:${target}-${bundle_ros_distro}-${VERSION}@${digest}\\5#g" "${f}"
-        if grep -Eq "${source_pattern}" "${f}"; then
-          echo "Unpinned Open AD Kit image reference remains in ${f}" >&2
-          exit 1
-        fi
-      done
-    done < <(
-      jq -r \
-        --arg repo "${image_prefix_component}" \
-        --arg distro "${bundle_ros_distro}" \
-        '.images[] | select(.repo == $repo and .ros_distro == $distro) | .target' \
-        "${build_metadata_file}" | sort -r
-    )
-  else
-    echo "VERSION/DEFAULT_ROS_DISTRO not set; skipping image pinning"
-  fi
-
-  # Source deployments must pin every third-party image. Resolving mutable tags
-  # during packaging would make a rerun of the same release non-reproducible.
-  for ref in \
-    ghcr.io/autowarefoundation/autoware:universe \
-    eclipse/zenoh-bridge-ros2dds:latest \
-    ghcr.io/evshary/autoware_manual_control:latest \
-    ghcr.io/tier4/scenario_simulator_v2:humble-25.0.20-runtime \
-    carlasim/carla:0.9.16 \
-    busybox:1.36.1; do
-    matching_files=()
-    while IFS= read -r -d '' candidate; do
-      # Skip files where this ref is already digest-pinned (e.g. source compose
-      # defaults that ship "<tag>@sha256:..."), so pinning stays idempotent and
-      # never produces a malformed "<tag>@sha256:...@sha256:..." reference.
-      if grep -Fq "${ref}@sha256:" "${candidate}"; then
-        continue
-      fi
-      if grep -Fq "${ref}" "${candidate}"; then
-        matching_files+=("${candidate}")
-      fi
-    done < <(find "staging/${name}" -type f \( -name '*.yaml' -o -name '*.env' \) -print0)
-    [ "${#matching_files[@]}" -gt 0 ] || continue
-    echo "Unpinned third-party image reference ${ref} in ${matching_files[*]}" >&2
-    exit 1
-  done
-
-  env_file="staging/${name}/config.env"
-  if [ -f "${env_file}" ]; then
-    echo "::group::validate ${name}"
-    if (cd "staging/${name}" && docker compose --env-file config.env config -q); then
-      echo "ok: ${name}"
-    else
-      echo "::error::invalid docker compose config in staging/${name}"
-      exit 1
-    fi
-    for variant_path in "staging/${name}/docker-compose."*.yaml; do
-      [ -f "${variant_path}" ] || continue
-      variant_compose="$(basename "${variant_path}")"
-      variant="${variant_compose#docker-compose.}"
-      variant="${variant%.yaml}"
-      if (cd "staging/${name}" && docker compose --env-file config.env -f docker-compose.yaml -f "${variant_compose}" config -q); then
-        echo "ok: ${name} ${variant}"
-      else
-        echo "::error::invalid docker compose config for ${variant} variant in staging/${name}"
-        exit 1
-      fi
-    done
-    echo "::endgroup::"
-  fi
-
-  # Normalize archive metadata so an idempotent release rerun produces the
-  # exact same bytes instead of silently replacing historical assets.
-  tar \
-    --sort=name \
-    --mtime='@0' \
-    --owner=0 \
-    --group=0 \
-    --numeric-owner \
-    -C staging \
-    -czf "dist/${name}.tar.gz" \
-    "${name}"
-  echo "packaged dist/${name}.tar.gz"
+rm -rf dist staging
+mkdir -p dist "${bundle_root}/deployments"
+cp -a "${source_dir}/openadkit" "${bundle_root}/openadkit"
+cp -a "${source_dir}/openadkit.d" "${bundle_root}/openadkit.d"
+for name in base logging-simulation planning-simulation scenario-simulation; do
+  cp -a "${source_dir}/deployments/${name}" "${bundle_root}/deployments/${name}"
 done
+
+find "${bundle_root}" -type f \( -name config.local.env -o -name '*.pyc' \) -delete
+find "${bundle_root}" -type d -name __pycache__ -prune -exec rm -rf {} +
+if symlink=$(find "${bundle_root}" -type l -print -quit) && [ -n "${symlink}" ]; then
+  echo "Release bundle must not contain symlinks: ${symlink}" >&2
+  exit 1
+fi
+
+python3 "${planner}" \
+  --source-root "${bundle_root}" \
+  --build-metadata "${build_metadata}" \
+  --version "${VERSION}" \
+  --release-sha "${RELEASE_SHA}" \
+  --packager-sha "${PACKAGER_SHA}" \
+  --default-ros-distro "${DEFAULT_ROS_DISTRO}" \
+  --stable-release "${STABLE_RELEASE}" \
+  --publish-latest-aliases "${PUBLISH_LATEST_ALIASES}" \
+  --output release-plan.json \
+  --context-output "${bundle_root}/openadkit.d/context.json"
+
+list_output=$(cd "${bundle_root}" && ./openadkit list)
+printf '%s\n' "${list_output}"
+for deployment in logging-simulation planning-simulation scenario-simulation; do
+  if ! awk -F '\t' -v name="${deployment}" \
+    '$1 == name && $2 == "verified" { found=1 } END { exit !found }' \
+    <<<"${list_output}"; then
+    echo "Packaged deployment is not verified: ${deployment}" >&2
+    exit 1
+  fi
+done
+
+for ros_distro in humble jazzy; do
+  for deployment in planning-simulation scenario-simulation logging-simulation; do
+    (cd "${bundle_root}" && ./openadkit validate "${deployment}" --ros-distro "${ros_distro}")
+  done
+  (cd "${bundle_root}" && ./openadkit validate logging-simulation \
+    --ros-distro "${ros_distro}" --gpu)
+done
+
+if cache=$(find "${bundle_root}" \( -type d -name __pycache__ -o -type f -name '*.pyc' \) -print -quit) \
+  && [ -n "${cache}" ]; then
+  echo "Release bundle contains generated Python cache: ${cache}" >&2
+  exit 1
+fi
+
+LC_ALL=C tar \
+  --format=gnu \
+  --sort=name \
+  --mtime='@0' \
+  --owner=0 \
+  --group=0 \
+  --numeric-owner \
+  --mode='u+rwX,go+rX,go-w' \
+  -C staging \
+  -cf - \
+  "${root_name}" \
+  | gzip -n >"${asset}"
+echo "packaged ${asset}"

--- a/.github/scripts/package_release_bundles.sh
+++ b/.github/scripts/package_release_bundles.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Assemble and validate self-contained deployment bundles for a release.
+set -euo pipefail
+
+source_dir="${SOURCE_DIR:-src}"
+install="${source_dir}/install.sh"
+base_dir="${source_dir}/deployments/base"
+image_prefix_component="${IMAGE_PREFIX_COMPONENT:-ghcr.io/autowarefoundation/openadkit}"
+build_metadata_file="${BUILD_METADATA_FILE:-release-input/build/build-metadata.json}"
+
+mkdir -p dist staging
+for entry in \
+  "planning-simulation:${source_dir}/deployments/planning-simulation" \
+  "scenario-simulation:${source_dir}/deployments/scenario-simulation" \
+  "logging-simulation:${source_dir}/deployments/logging-simulation" \
+  "carla-simulation:${source_dir}/deployments/carla-simulation" \
+  "zenoh-bridge:${source_dir}/deployments/zenoh-bridge"; do
+  name="${entry%%:*}"
+  dir="${entry#*:}"
+  rm -rf "staging/${name}"
+  cp -a "${dir}" "staging/${name}"
+
+  # carla-simulation downloads its own assets via start-carla-e2e-demo.sh.
+  if [ "${name}" != "carla-simulation" ]; then
+    cp "${install}" "staging/${name}/install.sh"
+    chmod +x "staging/${name}/install.sh"
+  fi
+
+  # Base-backed deployments ship the complete base beside their config.env.
+  compose="staging/${name}/docker-compose.yaml"
+  if [ -f "${compose}" ] && grep -q '\.\./base/docker-compose\.yaml' "${compose}"; then
+    mkdir -p "staging/${name}/base"
+    cp -a "${base_dir}/." "staging/${name}/base/"
+    sed -i 's#\.\./base/#./base/#' "${compose}"
+  fi
+
+  # Keep the readable release tag, but bind it to the exact validated digest so
+  # a downloaded bundle cannot change if a registry credential later moves it.
+  if [ -n "${VERSION:-}" ] && [ -n "${DEFAULT_ROS_DISTRO:-}" ]; then
+    [ -f "${build_metadata_file}" ] || {
+      echo "Validated build metadata not found: ${build_metadata_file}" >&2
+      exit 1
+    }
+    bundle_ros_distro="${DEFAULT_ROS_DISTRO}"
+    if [ "${name}" = "carla-simulation" ]; then
+      bundle_ros_distro=humble
+    fi
+    bundle_files=(
+      "staging/${name}/docker-compose.yaml" \
+      "staging/${name}/docker-compose."*.yaml \
+      "staging/${name}/base/docker-compose.yaml" \
+      "staging/${name}/config.env"
+    )
+    echo "Pinning Open AD Kit image refs to ${bundle_ros_distro}-${VERSION} and validated digests"
+    while IFS= read -r target; do
+      [ -n "${target}" ] || continue
+      source_pattern="ghcr\\.io/autowarefoundation/openadkit:${target}(-(amd64|arm64))?(-(humble|jazzy))?([^a-z0-9-]|$)"
+      present=false
+      for f in "${bundle_files[@]}"; do
+        [ -f "${f}" ] || continue
+        if grep -Eq "${source_pattern}" "${f}"; then
+          present=true
+          break
+        fi
+      done
+      [ "${present}" = true ] || continue
+      matches=$(jq -c \
+        --arg repo "${image_prefix_component}" \
+        --arg target "${target}" \
+        --arg distro "${bundle_ros_distro}" \
+        '[.images[] | select(.repo == $repo and .target == $target and .ros_distro == $distro)]' \
+        "${build_metadata_file}")
+      [ "$(jq 'length' <<<"${matches}")" -eq 1 ] || {
+        echo "Expected one validated digest for ${image_prefix_component}:${target}-${bundle_ros_distro}, found $(jq 'length' <<<"${matches}")" >&2
+        exit 1
+      }
+      digest=$(jq -r '.[0].digest | select(test("^sha256:[0-9a-f]{64}$"))' <<<"${matches}")
+      [ -n "${digest}" ] || {
+        echo "Invalid validated digest for ${target}-${bundle_ros_distro}" >&2
+        exit 1
+      }
+      for f in "${bundle_files[@]}"; do
+        [ -f "${f}" ] || continue
+        sed -i -E "s#${source_pattern}#${image_prefix_component}:${target}-${bundle_ros_distro}-${VERSION}@${digest}\\5#g" "${f}"
+        if grep -Eq "${source_pattern}" "${f}"; then
+          echo "Unpinned Open AD Kit image reference remains in ${f}" >&2
+          exit 1
+        fi
+      done
+    done < <(
+      jq -r \
+        --arg repo "${image_prefix_component}" \
+        --arg distro "${bundle_ros_distro}" \
+        '.images[] | select(.repo == $repo and .ros_distro == $distro) | .target' \
+        "${build_metadata_file}" | sort -r
+    )
+  else
+    echo "VERSION/DEFAULT_ROS_DISTRO not set; skipping image pinning"
+  fi
+
+  # Source deployments must pin every third-party image. Resolving mutable tags
+  # during packaging would make a rerun of the same release non-reproducible.
+  for ref in \
+    ghcr.io/autowarefoundation/autoware:universe \
+    eclipse/zenoh-bridge-ros2dds:latest \
+    ghcr.io/evshary/autoware_manual_control:latest \
+    ghcr.io/tier4/scenario_simulator_v2:humble-25.0.20-runtime \
+    carlasim/carla:0.9.16 \
+    busybox:1.36.1; do
+    matching_files=()
+    while IFS= read -r -d '' candidate; do
+      # Skip files where this ref is already digest-pinned (e.g. source compose
+      # defaults that ship "<tag>@sha256:..."), so pinning stays idempotent and
+      # never produces a malformed "<tag>@sha256:...@sha256:..." reference.
+      if grep -Fq "${ref}@sha256:" "${candidate}"; then
+        continue
+      fi
+      if grep -Fq "${ref}" "${candidate}"; then
+        matching_files+=("${candidate}")
+      fi
+    done < <(find "staging/${name}" -type f \( -name '*.yaml' -o -name '*.env' \) -print0)
+    [ "${#matching_files[@]}" -gt 0 ] || continue
+    echo "Unpinned third-party image reference ${ref} in ${matching_files[*]}" >&2
+    exit 1
+  done
+
+  env_file="staging/${name}/config.env"
+  if [ -f "${env_file}" ]; then
+    echo "::group::validate ${name}"
+    if (cd "staging/${name}" && docker compose --env-file config.env config -q); then
+      echo "ok: ${name}"
+    else
+      echo "::error::invalid docker compose config in staging/${name}"
+      exit 1
+    fi
+    for variant_path in "staging/${name}/docker-compose."*.yaml; do
+      [ -f "${variant_path}" ] || continue
+      variant_compose="$(basename "${variant_path}")"
+      variant="${variant_compose#docker-compose.}"
+      variant="${variant%.yaml}"
+      if (cd "staging/${name}" && docker compose --env-file config.env -f docker-compose.yaml -f "${variant_compose}" config -q); then
+        echo "ok: ${name} ${variant}"
+      else
+        echo "::error::invalid docker compose config for ${variant} variant in staging/${name}"
+        exit 1
+      fi
+    done
+    echo "::endgroup::"
+  fi
+
+  # Normalize archive metadata so an idempotent release rerun produces the
+  # exact same bytes instead of silently replacing historical assets.
+  tar \
+    --sort=name \
+    --mtime='@0' \
+    --owner=0 \
+    --group=0 \
+    --numeric-owner \
+    -C staging \
+    -czf "dist/${name}.tar.gz" \
+    "${name}"
+  echo "packaged dist/${name}.tar.gz"
+done

--- a/.github/scripts/promote_release_images.sh
+++ b/.github/scripts/promote_release_images.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Promote validated build image digests to release tags and stable aliases.
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.github/scripts/registry_lookup.sh
+source "${script_dir}/registry_lookup.sh"
+# shellcheck source=.github/scripts/stable_alias_policy.sh
+source "${script_dir}/stable_alias_policy.sh"
+
+: "${VERSION:?VERSION is required}"
+: "${DEFAULT_ROS_DISTRO:?DEFAULT_ROS_DISTRO is required}"
+: "${PUBLISH_LATEST_ALIASES:?PUBLISH_LATEST_ALIASES is required}"
+: "${STABLE_RELEASE:?STABLE_RELEASE is required}"
+
+stable_release="${STABLE_RELEASE}"
+
+# Record converged refs for the summary. Any failed promotion aborts immediately
+# so a later alias phase cannot expose a partially tagged release.
+PROMOTED_REFS=()
+
+available_distros=$(jq -r '.images | unique_by(.ros_distro) | map(.ros_distro) | join(" ")' release-input/build/build-metadata.json)
+echo "Available ROS distros in build: ${available_distros}"
+
+if ! echo "${available_distros}" | grep -qw "${DEFAULT_ROS_DISTRO}"; then
+  echo "ERROR: default_ros_distro '${DEFAULT_ROS_DISTRO}' is not in the build metadata." >&2
+  echo "Available distros: ${available_distros}" >&2
+  echo "Update the 'default_ros_distro' input or trigger a new build for '${DEFAULT_ROS_DISTRO}'." >&2
+  exit 1
+fi
+
+promote_tag() {
+  local ref="$1"
+  local repo="$2"
+  local digest="$3"
+  local mode="$4"
+  local existing_digest lookup_status=0
+
+  existing_digest=$(registry_manifest_digest "${ref}") || lookup_status=$?
+  if [ "${lookup_status}" -eq 0 ]; then
+    if [ "${existing_digest}" = "${digest}" ]; then
+      echo "${ref} already points to ${digest}; skipping"
+      PROMOTED_REFS+=("${ref}")
+      return
+    fi
+    if [ "${mode}" = "immutable" ]; then
+      echo "Release tag conflict: ${ref} points to ${existing_digest}, expected ${digest}" >&2
+      exit 1
+    fi
+    echo "Updating ${ref}: ${existing_digest} -> ${digest}"
+  elif [ "${lookup_status}" -eq 1 ]; then
+    echo "Promoting ${repo}@${digest} -> ${ref}"
+  else
+    return "${lookup_status}"
+  fi
+
+  # Retry the mutating create, then confirm the alias actually resolves to the
+  # intended digest before treating it as promoted. A timeout, rate limit, or
+  # transient network failure on a single alias no longer leaves the release
+  # split across old and new digests unnoticed.
+  local attempt result_digest result_status
+  for attempt in 1 2 3; do
+    if docker buildx imagetools create -t "${ref}" "${repo}@${digest}"; then
+      result_status=0
+      result_digest=$(registry_manifest_digest "${ref}") || result_status=$?
+      if [ "${result_status}" -eq 0 ] && [ "${result_digest}" = "${digest}" ]; then
+        PROMOTED_REFS+=("${ref}")
+        return 0
+      fi
+      echo "Post-promote verification for ${ref} did not match on attempt ${attempt}: got '${result_digest:-<none>}', want '${digest}'" >&2
+    else
+      echo "imagetools create for ${ref} failed on attempt ${attempt}" >&2
+    fi
+    if [ "${attempt}" -lt 3 ]; then
+      sleep "$(( attempt * 5 ))"
+    fi
+  done
+
+  echo "ERROR: ${ref} did not converge to ${digest} after retries" >&2
+  return 1
+}
+
+while IFS=$'\t' read -r repo target distro digest; do
+  release_ref="${repo}:${target}-${distro}-${VERSION}"
+  promote_tag "${release_ref}" "${repo}" "${digest}" immutable
+done < <(jq -r '.images[] | [.repo, .target, .ros_distro, .digest] | @tsv' release-input/build/build-metadata.json)
+
+if [ "${stable_release}" = true ]; then
+  current_policy=$(current_latest_alias_policy)
+  if [ "${current_policy}" != "${PUBLISH_LATEST_ALIASES}" ]; then
+    echo "Latest alias policy changed during release: expected ${PUBLISH_LATEST_ALIASES}, now ${current_policy}; rerun the release workflow" >&2
+    exit 1
+  fi
+fi
+
+if [ "${stable_release}" = true ] && [ "${PUBLISH_LATEST_ALIASES}" = true ]; then
+  while IFS=$'\t' read -r repo target distro digest; do
+    promote_tag "${repo}:${target}-${distro}" "${repo}" "${digest}" alias
+    promote_tag "${repo}:${target}-${distro}-latest" "${repo}" "${digest}" alias
+
+    if [ "${distro}" = "${DEFAULT_ROS_DISTRO}" ]; then
+      promote_tag "${repo}:${target}" "${repo}" "${digest}" alias
+      promote_tag "${repo}:${target}-latest" "${repo}" "${digest}" alias
+    fi
+  done < <(jq -r '.images[] | [.repo, .target, .ros_distro, .digest] | @tsv' release-input/build/build-metadata.json)
+fi
+
+echo "Alias promotion summary: ${#PROMOTED_REFS[@]} converged."

--- a/.github/scripts/promote_release_images.sh
+++ b/.github/scripts/promote_release_images.sh
@@ -8,10 +8,19 @@ source "${script_dir}/registry_lookup.sh"
 # shellcheck source=.github/scripts/stable_alias_policy.sh
 source "${script_dir}/stable_alias_policy.sh"
 
-: "${VERSION:?VERSION is required}"
-: "${DEFAULT_ROS_DISTRO:?DEFAULT_ROS_DISTRO is required}"
-: "${PUBLISH_LATEST_ALIASES:?PUBLISH_LATEST_ALIASES is required}"
-: "${STABLE_RELEASE:?STABLE_RELEASE is required}"
+plan_file=${RELEASE_PLAN_FILE:-release-plan.json}
+jq -e '
+  .schemaVersion == 1 and
+  (.release.version | type == "string") and
+  (.release.defaultRosDistro | IN("humble", "jazzy")) and
+  (.release.stable | type == "boolean") and
+  (.release.publishLatestAliases | type == "boolean") and
+  (.images | type == "array" and length > 0)
+' "${plan_file}" >/dev/null
+VERSION=$(jq -r '.release.version' "${plan_file}")
+DEFAULT_ROS_DISTRO=$(jq -r '.release.defaultRosDistro' "${plan_file}")
+PUBLISH_LATEST_ALIASES=$(jq -r '.release.publishLatestAliases' "${plan_file}")
+STABLE_RELEASE=$(jq -r '.release.stable' "${plan_file}")
 
 stable_release="${STABLE_RELEASE}"
 
@@ -19,7 +28,7 @@ stable_release="${STABLE_RELEASE}"
 # so a later alias phase cannot expose a partially tagged release.
 PROMOTED_REFS=()
 
-available_distros=$(jq -r '.images | unique_by(.ros_distro) | map(.ros_distro) | join(" ")' release-input/build/build-metadata.json)
+available_distros=$(jq -r '.images | unique_by(.rosDistro) | map(.rosDistro) | join(" ")' "${plan_file}")
 echo "Available ROS distros in build: ${available_distros}"
 
 if ! echo "${available_distros}" | grep -qw "${DEFAULT_ROS_DISTRO}"; then
@@ -80,29 +89,69 @@ promote_tag() {
   return 1
 }
 
-while IFS=$'\t' read -r repo target distro digest; do
-  release_ref="${repo}:${target}-${distro}-${VERSION}"
-  promote_tag "${release_ref}" "${repo}" "${digest}" immutable
-done < <(jq -r '.images[] | [.repo, .target, .ros_distro, .digest] | @tsv' release-input/build/build-metadata.json)
+preflight_images() {
+  local conflicts=0 source_ref release_ref digest source_digest existing_digest lookup_status
+  while IFS=$'\t' read -r source_ref release_ref digest; do
+    lookup_status=0
+    source_digest=$(registry_manifest_digest "${source_ref}") || lookup_status=$?
+    if [ "${lookup_status}" -eq 1 ]; then
+      echo "Source image not found: ${source_ref}" >&2
+      conflicts=1
+    elif [ "${lookup_status}" -ne 0 ]; then
+      return "${lookup_status}"
+    elif [ "${source_digest}" != "${digest}" ]; then
+      echo "Source digest mismatch for ${source_ref}: ${source_digest} != ${digest}" >&2
+      conflicts=1
+    fi
 
-if [ "${stable_release}" = true ]; then
+    lookup_status=0
+    existing_digest=$(registry_manifest_digest "${release_ref}") || lookup_status=$?
+    if [ "${lookup_status}" -eq 0 ] && [ "${existing_digest}" != "${digest}" ]; then
+      echo "Release tag conflict: ${release_ref} points to ${existing_digest}, expected ${digest}" >&2
+      conflicts=1
+    elif [ "${lookup_status}" -ne 0 ] && [ "${lookup_status}" -ne 1 ]; then
+      return "${lookup_status}"
+    fi
+  done < <(jq -r '.images[] | [.sourceRef, .releaseRef, .digest] | @tsv' "${plan_file}")
+  [ "${conflicts}" -eq 0 ]
+}
+
+check_alias_policy() {
+  local current_policy
+  [ "${stable_release}" = true ] || return 0
   current_policy=$(current_latest_alias_policy)
   if [ "${current_policy}" != "${PUBLISH_LATEST_ALIASES}" ]; then
     echo "Latest alias policy changed during release: expected ${PUBLISH_LATEST_ALIASES}, now ${current_policy}; rerun the release workflow" >&2
-    exit 1
+    return 1
   fi
-fi
+}
+
+preflight_aliases() {
+  local alias lookup_status existing_digest
+  while IFS= read -r alias; do
+    [ -n "${alias}" ] || continue
+    lookup_status=0
+    existing_digest=$(registry_manifest_digest "${alias}") || lookup_status=$?
+    if [ "${lookup_status}" -ne 0 ] && [ "${lookup_status}" -ne 1 ]; then
+      return "${lookup_status}"
+    fi
+  done < <(jq -r '.images[].aliases[]?' "${plan_file}")
+}
+
+check_alias_policy
+preflight_images
+preflight_aliases
+
+while IFS=$'\t' read -r release_ref repo digest; do
+  promote_tag "${release_ref}" "${repo}" "${digest}" immutable
+done < <(jq -r '.images[] | [.releaseRef, .repo, .digest] | @tsv' "${plan_file}")
+
+check_alias_policy
 
 if [ "${stable_release}" = true ] && [ "${PUBLISH_LATEST_ALIASES}" = true ]; then
-  while IFS=$'\t' read -r repo target distro digest; do
-    promote_tag "${repo}:${target}-${distro}" "${repo}" "${digest}" alias
-    promote_tag "${repo}:${target}-${distro}-latest" "${repo}" "${digest}" alias
-
-    if [ "${distro}" = "${DEFAULT_ROS_DISTRO}" ]; then
-      promote_tag "${repo}:${target}" "${repo}" "${digest}" alias
-      promote_tag "${repo}:${target}-latest" "${repo}" "${digest}" alias
-    fi
-  done < <(jq -r '.images[] | [.repo, .target, .ros_distro, .digest] | @tsv' release-input/build/build-metadata.json)
+  while IFS=$'\t' read -r alias repo digest; do
+    promote_tag "${alias}" "${repo}" "${digest}" alias
+  done < <(jq -r '.images[] | .repo as $repo | .digest as $digest | .aliases[] | [., $repo, $digest] | @tsv' "${plan_file}")
 fi
 
 echo "Alias promotion summary: ${#PROMOTED_REFS[@]} converged."

--- a/.github/scripts/release_plan.py
+++ b/.github/scripts/release_plan.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Build the immutable release plan and runtime context."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import re
+import sys
+from types import ModuleType
+from typing import Any
+
+
+CURATED_DEPLOYMENTS = (
+    "logging-simulation",
+    "planning-simulation",
+    "scenario-simulation",
+)
+ROS_DISTROS = ("humble", "jazzy")
+SEMVER_RE = re.compile(
+    r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"could not read JSON from {path}: {error}")
+    if not isinstance(value, dict):
+        fail(f"JSON root must be an object: {path}")
+    return value
+
+
+def load_runtime(source_root: Path) -> ModuleType:
+    module_path = source_root / "openadkit.d/manifest.py"
+    spec = importlib.util.spec_from_file_location("openadkit_release_manifest", module_path)
+    if spec is None or spec.loader is None:
+        fail(f"could not load runtime manifest module: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def require_string(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value:
+        fail(f"{name} must be a nonempty string")
+    return value
+
+
+def build_plan(args: argparse.Namespace) -> dict[str, Any]:
+    source_root = args.source_root.resolve()
+    metadata = load_json(args.build_metadata)
+    runtime = load_runtime(source_root)
+
+    if not SEMVER_RE.fullmatch(args.version):
+        fail(f"invalid release version: {args.version}")
+    if not SHA_RE.fullmatch(args.release_sha):
+        fail("release SHA must be 40 lowercase hexadecimal characters")
+    if not SHA_RE.fullmatch(args.packager_sha):
+        fail("packager SHA must be 40 lowercase hexadecimal characters")
+    if args.default_ros_distro not in ROS_DISTROS:
+        fail(f"unsupported default ROS distro: {args.default_ros_distro}")
+    if args.publish_latest_aliases and not args.stable_release:
+        fail("prereleases cannot publish stable aliases")
+    if metadata.get("openadkit_sha") != args.release_sha:
+        fail("build metadata Open AD Kit SHA does not match the release SHA")
+
+    build_tag = require_string(metadata.get("build_tag"), "build_tag")
+    raw_images = metadata.get("images")
+    if not isinstance(raw_images, list) or not raw_images:
+        fail("build metadata images must be a nonempty array")
+
+    image_rows: list[dict[str, Any]] = []
+    indexed: dict[tuple[str, str], dict[str, Any]] = {}
+    seen: set[tuple[str, str, str]] = set()
+    for index, raw in enumerate(raw_images):
+        if not isinstance(raw, dict):
+            fail(f"images[{index}] must be an object")
+        repo = require_string(raw.get("repo"), f"images[{index}].repo")
+        target = require_string(raw.get("target"), f"images[{index}].target")
+        distro = require_string(raw.get("ros_distro"), f"images[{index}].ros_distro")
+        source_ref = require_string(raw.get("ref"), f"images[{index}].ref")
+        digest = require_string(raw.get("digest"), f"images[{index}].digest")
+        platforms = raw.get("platforms")
+        key = (repo, target, distro)
+        if key in seen:
+            fail(f"duplicate build image: {repo}:{target}-{distro}")
+        seen.add(key)
+        if not DIGEST_RE.fullmatch(digest):
+            fail(f"invalid image digest for {target}-{distro}")
+        if source_ref != f"{repo}:{target}-{distro}-{build_tag}":
+            fail(f"invalid source image reference for {target}-{distro}")
+        if not isinstance(platforms, list) or not platforms or any(
+            platform not in ("linux/amd64", "linux/arm64") for platform in platforms
+        ):
+            fail(f"invalid platforms for {target}-{distro}")
+
+        release_ref = f"{repo}:{target}-{distro}-{args.version}"
+        aliases: list[str] = []
+        if args.stable_release and args.publish_latest_aliases:
+            aliases.extend((f"{repo}:{target}-{distro}", f"{repo}:{target}-{distro}-latest"))
+            if distro == args.default_ros_distro:
+                aliases.extend((f"{repo}:{target}", f"{repo}:{target}-latest"))
+        row = {
+            "aliases": aliases,
+            "digest": digest,
+            "platforms": sorted(platforms),
+            "releaseExactRef": f"{release_ref}@{digest}",
+            "releaseRef": release_ref,
+            "repo": repo,
+            "rosDistro": distro,
+            "sourceRef": source_ref,
+            "target": target,
+        }
+        image_rows.append(row)
+        runtime_key = (target, distro)
+        if runtime_key in indexed:
+            fail(f"duplicate target/distro image across repositories: {target}-{distro}")
+        indexed[runtime_key] = row
+
+    runtime_targets = sorted(set(runtime.COMPONENT_IMAGE_TARGETS.values()))
+    context_images: dict[str, dict[str, str]] = {}
+    for distro in ROS_DISTROS:
+        distro_images: dict[str, str] = {}
+        for target in runtime_targets:
+            row = indexed.get((target, distro))
+            if row is None:
+                fail(f"missing runtime image: {target}-{distro}")
+            distro_images[target] = row["releaseExactRef"]
+        context_images[distro] = distro_images
+
+    discovered = runtime.discover(source_root)
+    if set(discovered) != set(CURATED_DEPLOYMENTS):
+        fail(
+            "release source must contain exactly the curated deployments: "
+            + ", ".join(CURATED_DEPLOYMENTS)
+        )
+    deployments: dict[str, str] = {}
+    shared_names: set[str] = set()
+    for name in CURATED_DEPLOYMENTS:
+        deployment = runtime.validate_manifest(source_root, discovered[name])
+        deployments[name] = runtime.deployment_checksum(deployment.directory)
+        shared_names.update(deployment.shared)
+    if shared_names != {"base"}:
+        fail("curated deployments must use exactly the shared base assets")
+    shared = {
+        name: runtime.deployment_checksum(source_root / "deployments" / name)
+        for name in sorted(shared_names)
+    }
+
+    root_name = f"openadkit-{args.version}"
+    asset_name = f"{root_name}.tar.gz"
+    release_context = {
+        "defaultRosDistro": args.default_ros_distro,
+        "deployments": deployments,
+        "images": context_images,
+        "kind": "release",
+        "schemaVersion": 1,
+        "shared": shared,
+        "version": args.version,
+    }
+    return {
+        "bundle": {
+            "asset": asset_name,
+            "deployments": list(CURATED_DEPLOYMENTS),
+            "root": root_name,
+            "runtime": ["openadkit", "openadkit.d"],
+            "shared": sorted(shared_names),
+        },
+        "githubAssets": [
+            {"name": "release-plan.json", "path": "release-plan.json"},
+            {"name": "release-metadata.json", "path": "release-metadata.json"},
+            {
+                "name": "autoware-lock.repos",
+                "path": "release-input/build/autoware-lock.repos",
+            },
+            {
+                "name": "upstream-images.json",
+                "path": "release-input/build/upstream-images.json",
+            },
+            {"name": asset_name, "path": f"dist/{asset_name}"},
+        ],
+        "images": sorted(
+            image_rows,
+            key=lambda row: (row["repo"], row["target"], row["rosDistro"]),
+        ),
+        "release": {
+            "buildTag": build_tag,
+            "defaultRosDistro": args.default_ros_distro,
+            "packagerSha": args.packager_sha,
+            "publishLatestAliases": args.publish_latest_aliases,
+            "releaseSha": args.release_sha,
+            "stable": args.stable_release,
+            "version": args.version,
+        },
+        "releaseContext": release_context,
+        "schemaVersion": 1,
+    }
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True, separators=(",", ": ")) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_bool(value: str) -> bool:
+    if value not in ("true", "false"):
+        raise argparse.ArgumentTypeError("expected true or false")
+    return value == "true"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-root", type=Path, required=True)
+    parser.add_argument("--build-metadata", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--release-sha", required=True)
+    parser.add_argument("--packager-sha", required=True)
+    parser.add_argument("--default-ros-distro", required=True)
+    parser.add_argument("--stable-release", type=parse_bool, required=True)
+    parser.add_argument("--publish-latest-aliases", type=parse_bool, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--context-output", type=Path)
+    args = parser.parse_args()
+    try:
+        plan = build_plan(args)
+        write_json(args.output, plan)
+        if args.context_output:
+            write_json(args.context_output, plan["releaseContext"])
+    except ValueError as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/release_tag.sh
+++ b/.github/scripts/release_tag.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Query and create release tags without treating arbitrary API failures as 404s.
+
+release_tag_sha() {
+  local object response sha status type
+  local depth=0
+
+  : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+  : "${VERSION:?VERSION is required}"
+
+  if response=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${VERSION}" 2>/dev/null); then
+    if ! object=$(jq -ec '.object' <<< "${response}"); then
+      echo "Invalid tag response for ${VERSION}" >&2
+      return 2
+    fi
+    while [ "${depth}" -lt 5 ]; do
+      depth=$((depth + 1))
+      if ! type=$(jq -er '.type | strings' <<< "${object}") || \
+        ! sha=$(jq -er '.sha | strings | select(test("^[0-9a-fA-F]{40}$"))' <<< "${object}"); then
+        echo "Invalid tag object for ${VERSION}" >&2
+        return 2
+      fi
+      case "${type}" in
+        commit)
+          printf '%s\n' "${sha}"
+          return 0
+          ;;
+        tag)
+          if ! response=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${sha}" 2>/dev/null) || \
+            ! object=$(jq -ec '.object' <<< "${response}"); then
+            echo "Failed to resolve annotated tag ${VERSION}" >&2
+            return 2
+          fi
+          ;;
+        *)
+          echo "Unsupported tag object type '${type}' for ${VERSION}" >&2
+          return 2
+          ;;
+      esac
+    done
+    echo "Annotated tag ${VERSION} exceeds the supported nesting depth" >&2
+    return 2
+  fi
+
+  status=$(jq -r '(.status // empty) | tostring' <<< "${response}" 2>/dev/null || true)
+  if [ "${status}" = "404" ]; then
+    return 1
+  fi
+
+  if [ -n "${status}" ]; then
+    echo "Failed to query tag ${VERSION}: GitHub API returned HTTP ${status}" >&2
+  else
+    echo "Failed to query tag ${VERSION}: GitHub API request failed" >&2
+  fi
+  return 2
+}
+
+ensure_release_tag() {
+  local lookup_status tag_sha
+
+  : "${RELEASE_SHA:?RELEASE_SHA is required}"
+
+  if tag_sha=$(release_tag_sha); then
+    if [ "${tag_sha}" != "${RELEASE_SHA}" ]; then
+      echo "Tag ${VERSION} exists at ${tag_sha}, expected ${RELEASE_SHA}" >&2
+      return 1
+    fi
+    echo "Tag ${VERSION} already exists at ${RELEASE_SHA}; continuing"
+    return 0
+  else
+    lookup_status=$?
+  fi
+
+  [ "${lookup_status}" -eq 1 ] || return "${lookup_status}"
+  gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+    -f ref="refs/tags/${VERSION}" \
+    -f sha="${RELEASE_SHA}" >/dev/null
+  echo "Created tag ${VERSION} at ${RELEASE_SHA}"
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  set -euo pipefail
+  ensure_release_tag
+fi

--- a/.github/scripts/stable_alias_policy.sh
+++ b/.github/scripts/stable_alias_policy.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Resolve whether VERSION is currently the highest stable Open AD Kit tag.
+
+current_latest_alias_policy() {
+  local stable_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+  local existing_tag_refs existing_stable_tags highest_stable
+
+  : "${VERSION:?VERSION is required}"
+  : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+  existing_tag_refs=$(
+    gh api --paginate "repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/v" \
+      --jq '.[].ref | sub("^refs/tags/"; "")'
+  ) || return 2
+  existing_stable_tags=$(printf '%s\n' "${existing_tag_refs}" | grep -E "${stable_re}" || true)
+  highest_stable=$(
+    {
+      printf '%s\n' "${VERSION}"
+      printf '%s\n' "${existing_stable_tags}"
+    } | grep -E "${stable_re}" | sort -V | tail -n 1
+  )
+
+  if [ "${highest_stable}" = "${VERSION}" ]; then
+    printf '%s\n' true
+  else
+    printf '%s\n' false
+  fi
+}

--- a/.github/scripts/tests/test_release_pipeline.py
+++ b/.github/scripts/tests/test_release_pipeline.py
@@ -2,8 +2,8 @@ import hashlib
 import json
 import os
 from pathlib import Path
-import re
 import subprocess
+import tarfile
 
 import pytest
 
@@ -11,18 +11,95 @@ import pytest
 ROOT = Path(__file__).resolve().parents[3]
 MANAGER = ROOT / ".github/scripts/manage_github_release.sh"
 PACKAGER = ROOT / ".github/scripts/package_release_bundles.sh"
+PLANNER = ROOT / ".github/scripts/release_plan.py"
 PROMOTER = ROOT / ".github/scripts/promote_release_images.sh"
 REGISTRY_LOOKUP = ROOT / ".github/scripts/registry_lookup.sh"
 VALIDATOR = ROOT / ".github/scripts/validate_release.sh"
+WRITE_NOTES = ROOT / ".github/scripts/write_release_notes.sh"
 DIGEST = "sha256:" + "a" * 64
 RELEASE_SHA = "b" * 40
 VERSION = "v9.8.7"
 MARKER = "<!-- openadkit-release-workflow:v1 -->"
+BUILD_TAG = "123-1"
+RUNTIME_TARGETS = {
+    "api",
+    "localization-mapping",
+    "planning-control",
+    "sensing-perception",
+    "sensing-perception-cuda",
+    "simulator",
+    "vehicle-system",
+    "visualizer",
+}
 
 
 def executable(path, content):
     path.write_text(content)
     path.chmod(0o755)
+
+
+def build_images():
+    inventory = json.loads((ROOT / ".github/image-inventory.json").read_text())
+    rows = []
+    for image in inventory["images"]:
+        repo = (
+            "ghcr.io/example/openadkit-common"
+            if image["repo"] == "common"
+            else "ghcr.io/example/openadkit"
+        )
+        for distro in image.get("ros_distros", inventory["ros_distros"]):
+            rows.append(
+                {
+                    "repo": repo,
+                    "target": image["target"],
+                    "ros_distro": distro,
+                    "ref": f"{repo}:{image['target']}-{distro}-{BUILD_TAG}",
+                    "digest": DIGEST,
+                    "platforms": image["platforms"],
+                }
+            )
+    return rows
+
+
+def write_plan(tmp_path, *, images=None):
+    metadata = tmp_path / "build-metadata.json"
+    metadata.write_text(
+        json.dumps(
+            {
+                "build_tag": BUILD_TAG,
+                "openadkit_sha": RELEASE_SHA,
+                "images": images if images is not None else build_images(),
+            }
+        )
+    )
+    output = tmp_path / "release-plan.json"
+    result = subprocess.run(
+        [
+            "python3",
+            str(PLANNER),
+            "--source-root",
+            str(ROOT),
+            "--build-metadata",
+            str(metadata),
+            "--version",
+            VERSION,
+            "--release-sha",
+            RELEASE_SHA,
+            "--packager-sha",
+            "c" * 40,
+            "--default-ros-distro",
+            "humble",
+            "--stable-release",
+            "true",
+            "--publish-latest-aliases",
+            "true",
+            "--output",
+            str(output),
+        ],
+        text=True,
+        capture_output=True,
+    )
+    return result, output
 
 
 def run_release_rules(tmp_path, *, version, ref_type, input_ref, base_version="1.8.0"):
@@ -150,27 +227,59 @@ def release_record(
 
 def release_assets():
     return [
-        {"id": 101, "name": "release-metadata.json"},
-        {"id": 102, "name": "autoware-lock.repos"},
-        {"id": 103, "name": "upstream-images.json"},
-        {"id": 104, "name": "example.tar.gz"},
+        {"id": 101, "name": "release-plan.json"},
+        {"id": 102, "name": "release-metadata.json"},
+        {"id": 103, "name": "autoware-lock.repos"},
+        {"id": 104, "name": "upstream-images.json"},
+        {"id": 105, "name": f"openadkit-{VERSION}.tar.gz"},
     ]
 
 
 def release_workspace(tmp_path):
     (tmp_path / "dist").mkdir()
-    (tmp_path / "dist/example.tar.gz").write_bytes(b"bundle")
+    bundle = tmp_path / f"dist/openadkit-{VERSION}.tar.gz"
+    bundle.write_bytes(b"bundle")
     build = tmp_path / "release-input/build"
     build.mkdir(parents=True)
     (build / "autoware-lock.repos").write_text("repositories: {}\n")
     (build / "upstream-images.json").write_text("[]\n")
     (tmp_path / "release-metadata.json").write_text("{}\n")
     (tmp_path / "release-notes.md").write_text(MARKER + "\n")
+    (tmp_path / "release-plan.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "release": {
+                    "version": VERSION,
+                    "releaseSha": RELEASE_SHA,
+                    "stable": True,
+                    "publishLatestAliases": True,
+                },
+                "githubAssets": [
+                    {"name": "release-plan.json", "path": "release-plan.json"},
+                    {"name": "release-metadata.json", "path": "release-metadata.json"},
+                    {
+                        "name": "autoware-lock.repos",
+                        "path": "release-input/build/autoware-lock.repos",
+                    },
+                    {
+                        "name": "upstream-images.json",
+                        "path": "release-input/build/upstream-images.json",
+                    },
+                    {
+                        "name": bundle.name,
+                        "path": f"dist/{bundle.name}",
+                    },
+                ],
+            }
+        )
+    )
     files = [
+        tmp_path / "release-plan.json",
         tmp_path / "release-metadata.json",
         build / "autoware-lock.repos",
         build / "upstream-images.json",
-        tmp_path / "dist/example.tar.gz",
+        bundle,
     ]
     manifest = "".join(
         f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}\n"
@@ -190,10 +299,11 @@ def fake_gh_environment(tmp_path, listed, refreshed=None):
     (responses / "created").write_text(json.dumps(created))
     state = refreshed or listed or {}
     asset_sources = {
+        "release-plan.json": tmp_path / "release-plan.json",
         "release-metadata.json": tmp_path / "release-metadata.json",
         "autoware-lock.repos": tmp_path / "release-input/build/autoware-lock.repos",
         "upstream-images.json": tmp_path / "release-input/build/upstream-images.json",
-        "example.tar.gz": tmp_path / "dist/example.tar.gz",
+        f"openadkit-{VERSION}.tar.gz": tmp_path / f"dist/openadkit-{VERSION}.tar.gz",
     }
     for asset in state.get("assets", []):
         source = asset_sources.get(asset["name"])
@@ -305,7 +415,7 @@ def test_publish_rejects_changed_draft_asset(tmp_path):
     release_workspace(tmp_path)
     owned = release_record(assets=release_assets())
     env, _ = fake_gh_environment(tmp_path, owned)
-    (tmp_path / "responses/asset-104").write_bytes(b"replaced bundle")
+    (tmp_path / "responses/asset-105").write_bytes(b"replaced bundle")
     env |= {
         "RELEASE_ID": "42",
         "RELEASE_BODY_SHA256": hashlib.sha256((MARKER + "\n").encode()).hexdigest(),
@@ -324,20 +434,32 @@ def test_registry_auth_failure_never_mutates_image_tags(tmp_path):
         bin_dir / "docker",
         "#!/usr/bin/env bash\n"
         f'printf "%s\\n" "$*" >> {json.dumps(str(calls))}\n'
-        'echo "401 Unauthorized" >&2\nexit 1\n',
+        'if [ "$1 $2 $3" = "buildx imagetools inspect" ]; then\n'
+        f'  if [[ "$4" == *"-{BUILD_TAG}" ]]; then printf \'%s\\n\' \'{json.dumps({"manifest": {"digest": DIGEST}})}\'; exit; fi\n'
+        f'  if [[ "$4" == *"-{VERSION}" ]]; then echo "ERROR: $4: not found" >&2; exit 1; fi\n'
+        '  echo "401 Unauthorized" >&2; exit 1\n'
+        'fi\n'
+        "exit 1\n",
     )
     executable(bin_dir / "gh", "#!/usr/bin/env bash\nprintf '%s\\n' v9.8.7\n")
-    build = tmp_path / "release-input/build"
-    build.mkdir(parents=True)
-    (build / "build-metadata.json").write_text(
+    (tmp_path / "release-plan.json").write_text(
         json.dumps(
             {
+                "schemaVersion": 1,
+                "release": {
+                    "version": VERSION,
+                    "defaultRosDistro": "humble",
+                    "stable": True,
+                    "publishLatestAliases": True,
+                },
                 "images": [
                     {
                         "repo": "ghcr.io/example/openadkit",
-                        "target": "api",
-                        "ros_distro": "humble",
+                        "rosDistro": "humble",
                         "digest": DIGEST,
+                        "sourceRef": f"ghcr.io/example/openadkit:api-humble-{BUILD_TAG}",
+                        "releaseRef": f"ghcr.io/example/openadkit:api-humble-{VERSION}",
+                        "aliases": ["ghcr.io/example/openadkit:api-humble"],
                     }
                 ]
             }
@@ -345,12 +467,8 @@ def test_registry_auth_failure_never_mutates_image_tags(tmp_path):
     )
     env = os.environ | {
         "PATH": f"{bin_dir}:{os.environ['PATH']}",
-        "DEFAULT_ROS_DISTRO": "humble",
         "GITHUB_REPOSITORY": "example/repo",
-        "PUBLISH_LATEST_ALIASES": "true",
         "REGISTRY_LOOKUP_RETRY_DELAY_SECONDS": "0",
-        "STABLE_RELEASE": "true",
-        "VERSION": VERSION,
     }
     result = subprocess.run(["bash", str(PROMOTER)], cwd=tmp_path, env=env)
     assert result.returncode != 0
@@ -364,23 +482,33 @@ def test_failed_version_tag_never_updates_stable_aliases(tmp_path):
     executable(
         bin_dir / "docker",
         "#!/usr/bin/env bash\n"
-        'if [ "$1 $2 $3" = "buildx imagetools inspect" ]; then '
-        'echo "ERROR: $4: not found" >&2; exit 1; fi\n'
+        'if [ "$1 $2 $3" = "buildx imagetools inspect" ]; then\n'
+        f'  if [[ "$4" == *"-{BUILD_TAG}" ]]; then printf \'%s\\n\' \'{json.dumps({"manifest": {"digest": DIGEST}})}\'; exit; fi\n'
+        '  echo "ERROR: $4: not found" >&2; exit 1\n'
+        'fi\n'
         f'printf "%s\\n" "$*" >> {json.dumps(str(calls))}\n'
         "exit 1\n",
     )
     executable(bin_dir / "sleep", "#!/usr/bin/env bash\nexit 0\n")
-    build = tmp_path / "release-input/build"
-    build.mkdir(parents=True)
-    (build / "build-metadata.json").write_text(
+    executable(bin_dir / "gh", f"#!/usr/bin/env bash\nprintf '%s\\n' {VERSION}\n")
+    (tmp_path / "release-plan.json").write_text(
         json.dumps(
             {
+                "schemaVersion": 1,
+                "release": {
+                    "version": VERSION,
+                    "defaultRosDistro": "humble",
+                    "stable": True,
+                    "publishLatestAliases": True,
+                },
                 "images": [
                     {
                         "repo": "ghcr.io/example/openadkit",
-                        "target": "api",
-                        "ros_distro": "humble",
+                        "rosDistro": "humble",
                         "digest": DIGEST,
+                        "sourceRef": f"ghcr.io/example/openadkit:api-humble-{BUILD_TAG}",
+                        "releaseRef": f"ghcr.io/example/openadkit:api-humble-{VERSION}",
+                        "aliases": ["ghcr.io/example/openadkit:api-humble"],
                     }
                 ]
             }
@@ -388,107 +516,234 @@ def test_failed_version_tag_never_updates_stable_aliases(tmp_path):
     )
     env = os.environ | {
         "PATH": f"{bin_dir}:{os.environ['PATH']}",
-        "DEFAULT_ROS_DISTRO": "humble",
-        "PUBLISH_LATEST_ALIASES": "true",
+        "GITHUB_REPOSITORY": "example/repo",
         "REGISTRY_LOOKUP_MAX_ATTEMPTS": "1",
-        "STABLE_RELEASE": "true",
-        "VERSION": VERSION,
     }
     result = subprocess.run(["bash", str(PROMOTER)], cwd=tmp_path, env=env)
     assert result.returncode != 0
     assert all(f"-{VERSION}" in call for call in calls.read_text().splitlines())
 
 
-def test_release_bundles_pin_images_and_are_reproducible(tmp_path):
+def test_stable_promotion_consumes_planned_version_and_aliases(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
+    promoted = tmp_path / "promoted"
+    executable(
+        bin_dir / "docker",
+        "#!/usr/bin/env bash\nset -euo pipefail\n"
+        'if [ "$1 $2 $3" = "buildx imagetools inspect" ]; then\n'
+        '  ref="$4"\n'
+        f'  if [[ "$ref" == *"-{BUILD_TAG}" ]] || grep -Fxq "$ref" "$PROMOTED" 2>/dev/null; then\n'
+        f'    printf \'%s\\n\' \'{json.dumps({"manifest": {"digest": DIGEST}})}\'; exit\n'
+        '  fi\n'
+        '  echo "ERROR: $ref: not found" >&2; exit 1\n'
+        'fi\n'
+        'if [ "$1 $2 $3" = "buildx imagetools create" ]; then printf \'%s\\n\' "$5" >> "$PROMOTED"; exit; fi\n'
+        'exit 2\n',
+    )
+    executable(bin_dir / "gh", f"#!/usr/bin/env bash\nprintf '%s\\n' {VERSION}\n")
+    (tmp_path / "release-plan.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "release": {
+                    "version": VERSION,
+                    "defaultRosDistro": "humble",
+                    "stable": True,
+                    "publishLatestAliases": True,
+                },
+                "images": [
+                    {
+                        "repo": "ghcr.io/example/openadkit",
+                        "rosDistro": "humble",
+                        "digest": DIGEST,
+                        "sourceRef": f"ghcr.io/example/openadkit:api-humble-{BUILD_TAG}",
+                        "releaseRef": f"ghcr.io/example/openadkit:api-humble-{VERSION}",
+                        "aliases": ["ghcr.io/example/openadkit:api-humble"],
+                    }
+                ],
+            }
+        )
+    )
+    result = subprocess.run(
+        ["bash", str(PROMOTER)],
+        cwd=tmp_path,
+        env=os.environ
+        | {
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "GITHUB_REPOSITORY": "example/repo",
+            "PROMOTED": str(promoted),
+            "REGISTRY_LOOKUP_MAX_ATTEMPTS": "1",
+        },
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert promoted.read_text().splitlines() == [
+        f"ghcr.io/example/openadkit:api-humble-{VERSION}",
+        "ghcr.io/example/openadkit:api-humble",
+    ]
+
+
+def test_release_plan_builds_complete_dual_distro_context(tmp_path):
+    result, output = write_plan(tmp_path)
+    assert result.returncode == 0, result.stderr
+    plan = json.loads(output.read_text())
+    assert plan["bundle"] == {
+        "asset": f"openadkit-{VERSION}.tar.gz",
+        "deployments": [
+            "logging-simulation",
+            "planning-simulation",
+            "scenario-simulation",
+        ],
+        "root": f"openadkit-{VERSION}",
+        "runtime": ["openadkit", "openadkit.d"],
+        "shared": ["base"],
+    }
+    context = plan["releaseContext"]
+    assert context["defaultRosDistro"] == "humble"
+    assert set(context["deployments"]) == set(plan["bundle"]["deployments"])
+    assert set(context["shared"]) == {"base"}
+    for distro in ("humble", "jazzy"):
+        assert set(context["images"][distro]) == RUNTIME_TARGETS
+        assert all(
+            reference.endswith(f"@{DIGEST}")
+            and f"-{distro}-{VERSION}@" in reference
+            for reference in context["images"][distro].values()
+        )
+    assert "carla-interface" not in context["images"]["humble"]
+    assert "universe-common" not in context["images"]["humble"]
+
+
+@pytest.mark.parametrize("case", ("missing", "duplicate"))
+def test_release_plan_rejects_incomplete_or_duplicate_runtime_images(tmp_path, case):
+    images = build_images()
+    if case == "missing":
+        images = [
+            image
+            for image in images
+            if (image["target"], image["ros_distro"]) != ("api", "jazzy")
+        ]
+    else:
+        images.append(dict(images[0]))
+    result, _ = write_plan(tmp_path, images=images)
+    assert result.returncode != 0
+    assert case in result.stderr
+
+
+def test_release_bundle_is_unified_verified_and_reproducible(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls = tmp_path / "docker-calls"
     executable(
         bin_dir / "docker",
         "#!/usr/bin/env bash\n"
-        'if [[ "$*" == *"config --environment"* ]]; then cat config.env; fi\n'
+        f'printf "%s|%s\\n" "${{ROS_DISTRO:-}}" "$*" >> {json.dumps(str(calls))}\n'
+        'if [[ "$*" == *"config --services"* ]]; then\n'
+        "  printf '%s\\n' map map-check planning vehicle system control simulator api visualizer sensing perception localization rosbag scenario_simulator\n"
+        "fi\n"
         "exit 0\n",
     )
     build = tmp_path / "release-input/build"
     build.mkdir(parents=True)
-    images = []
-    for image in json.loads((ROOT / ".github/image-inventory.json").read_text())["images"]:
-        if image["repo"] != "component":
-            continue
-        for distro in image.get("ros_distros", ["humble", "jazzy"]):
-            images.append(
-                {
-                    "repo": "ghcr.io/example/openadkit",
-                    "target": image["target"],
-                    "ros_distro": distro,
-                    "digest": DIGEST,
-                }
-            )
-    (build / "build-metadata.json").write_text(json.dumps({"images": images}))
+    (build / "build-metadata.json").write_text(
+        json.dumps(
+            {
+                "build_tag": BUILD_TAG,
+                "openadkit_sha": RELEASE_SHA,
+                "autoware_input_ref": "1.8.0",
+                "autoware_ref_type": "tag",
+                "autoware_ref": "d" * 40,
+                "autoware_base_version": "1.8.0",
+                "autoware_lock_sha256": "e" * 64,
+                "upstream_images_sha256": "f" * 64,
+                "images": build_images(),
+            }
+        )
+    )
     env = os.environ | {
         "PATH": f"{bin_dir}:{os.environ['PATH']}",
         "SOURCE_DIR": str(ROOT),
         "VERSION": VERSION,
+        "RELEASE_SHA": RELEASE_SHA,
+        "PACKAGER_SHA": "c" * 40,
         "DEFAULT_ROS_DISTRO": "jazzy",
-        "IMAGE_PREFIX_COMPONENT": "ghcr.io/example/openadkit",
+        "PUBLISH_LATEST_ALIASES": "true",
+        "STABLE_RELEASE": "true",
     }
-    subprocess.run(["bash", str(PACKAGER)], cwd=tmp_path, env=env, check=True)
-    first = {
-        path.name: hashlib.sha256(path.read_bytes()).hexdigest()
-        for path in (tmp_path / "dist").glob("*.tar.gz")
+    command = [
+        "bash",
+        "-c",
+        'umask "$1"; exec bash "$2"',
+        "bash",
+        "022",
+        str(PACKAGER),
+    ]
+    subprocess.run(command, cwd=tmp_path, env=env, check=True)
+    asset = tmp_path / f"dist/openadkit-{VERSION}.tar.gz"
+    assert [path.name for path in (tmp_path / "dist").iterdir()] == [asset.name]
+    first_asset = hashlib.sha256(asset.read_bytes()).hexdigest()
+    first_plan = hashlib.sha256((tmp_path / "release-plan.json").read_bytes()).hexdigest()
+
+    with tarfile.open(asset) as archive:
+        members = archive.getmembers()
+        assert members
+        assert all(member.mtime == 0 and member.uid == 0 and member.gid == 0 for member in members)
+        assert all(not member.issym() and not member.islnk() for member in members)
+        assert all("__pycache__" not in member.name and not member.name.endswith(".pyc") for member in members)
+        extract = tmp_path / "extracted"
+        archive.extractall(extract, filter="data")
+
+    root = extract / f"openadkit-{VERSION}"
+    assert os.access(root / "openadkit", os.X_OK)
+    assert (root / "openadkit.d/context.json").is_file()
+    bundled_deployments = {
+        path.name for path in (root / "deployments").iterdir() if path.is_dir()
     }
-    assert len(first) == 5
-    for name in (
+    assert bundled_deployments == {
+        "base",
+        "logging-simulation",
         "planning-simulation",
         "scenario-simulation",
-        "logging-simulation",
-        "carla-simulation",
-        "zenoh-bridge",
-    ):
-        text = "\n".join(
-            path.read_text()
-            for path in (tmp_path / "staging" / name).rglob("*")
-            if path.is_file() and path.suffix in {".yaml", ".env"}
-        )
-        assert "ghcr.io/autowarefoundation/openadkit:" not in text
-        refs = re.findall(r"ghcr.io/example/openadkit:[a-z-]+-(?:humble|jazzy)-v9\.8\.7[^\s\"}]*", text)
-        assert refs
-        assert all(ref.endswith(f"@{DIGEST}") for ref in refs)
-    for name in (
-        "planning-simulation",
-        "scenario-simulation",
-        "logging-simulation",
-        "carla-simulation",
-        "zenoh-bridge",
-    ):
-        bundle = tmp_path / "staging" / name
-        assert (bundle / "config.env").is_file()
-        assert not (bundle / ".env").exists()
-        assert not (bundle / ".env.example").exists()
-    for name in (
-        "planning-simulation",
-        "scenario-simulation",
-        "logging-simulation",
-        "carla-simulation",
-    ):
-        bundle = tmp_path / "staging" / name
-        assert (bundle / "base/runtime.env").is_file()
-        assert (bundle / "base/config/vehicle_cmd_gate.param.yaml").is_file()
-        assert f"{name}.env" not in {path.name for path in bundle.iterdir()}
-    for name, command in (
-        ("planning-simulation", ["bash", "check-planning-simulation.sh", "--dry-run"]),
-        ("carla-simulation", ["bash", "start-carla-e2e-demo.sh", "--dry-run"]),
-    ):
-        result = subprocess.run(
-            command,
-            cwd=tmp_path / "staging" / name,
-            env=env,
-            text=True,
-            capture_output=True,
-        )
-        assert result.returncode == 0, result.stderr
-    subprocess.run(["bash", str(PACKAGER)], cwd=tmp_path, env=env, check=True)
-    second = {
-        path.name: hashlib.sha256(path.read_bytes()).hexdigest()
-        for path in (tmp_path / "dist").glob("*.tar.gz")
     }
-    assert second == first
+    assert not (root / "install.sh").exists()
+    listed = subprocess.run(
+        [str(root / "openadkit"), "list"],
+        cwd=root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout
+    assert listed.count("\tverified\t") == 3
+    assert "custom/unverified" not in listed
+
+    docker_calls = calls.read_text()
+    assert "humble|" in docker_calls
+    assert "jazzy|" in docker_calls
+    assert "docker-compose.gpu.yaml" in docker_calls
+
+    (tmp_path / "dist/stale.tar.gz").write_bytes(b"stale")
+    command[-2] = "077"
+    subprocess.run(command, cwd=tmp_path, env=env, check=True)
+    assert hashlib.sha256(asset.read_bytes()).hexdigest() == first_asset
+    assert hashlib.sha256((tmp_path / "release-plan.json").read_bytes()).hexdigest() == first_plan
+    assert [path.name for path in (tmp_path / "dist").iterdir()] == [asset.name]
+
+    scan = tmp_path / "release-input/scan"
+    scan.mkdir()
+    (scan / "scan-metadata.json").write_text(json.dumps({"scan_status": "passed"}))
+    subprocess.run(
+        ["bash", str(WRITE_NOTES)],
+        cwd=tmp_path,
+        env=env | {"RELEASE_PLAN_FILE": "release-plan.json"},
+        check=True,
+    )
+    release_metadata = json.loads((tmp_path / "release-metadata.json").read_text())
+    assert release_metadata["bundles"] == [
+        {"name": asset.name, "sha256": first_asset}
+    ]
+    assert release_metadata["release_plan_sha256"] == first_plan
+    notes = (tmp_path / "release-notes.md").read_text()
+    assert "## Open AD Kit Bundle" in notes
+    assert notes.count(asset.name) == 1

--- a/.github/scripts/tests/test_release_pipeline.py
+++ b/.github/scripts/tests/test_release_pipeline.py
@@ -1,0 +1,494 @@
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+MANAGER = ROOT / ".github/scripts/manage_github_release.sh"
+PACKAGER = ROOT / ".github/scripts/package_release_bundles.sh"
+PROMOTER = ROOT / ".github/scripts/promote_release_images.sh"
+REGISTRY_LOOKUP = ROOT / ".github/scripts/registry_lookup.sh"
+VALIDATOR = ROOT / ".github/scripts/validate_release.sh"
+DIGEST = "sha256:" + "a" * 64
+RELEASE_SHA = "b" * 40
+VERSION = "v9.8.7"
+MARKER = "<!-- openadkit-release-workflow:v1 -->"
+
+
+def executable(path, content):
+    path.write_text(content)
+    path.chmod(0o755)
+
+
+def run_release_rules(tmp_path, *, version, ref_type, input_ref, base_version="1.8.0"):
+    build = tmp_path / "release-input/build"
+    build.mkdir(parents=True)
+    (build / "build-metadata.json").write_text(
+        json.dumps(
+            {
+                "openadkit_sha": RELEASE_SHA,
+                "autoware_input_ref": input_ref,
+                "autoware_ref_type": ref_type,
+                "autoware_base_version": base_version,
+            }
+        )
+    )
+    env = os.environ | {
+        "BUILD_TAG": "123-1",
+        "GH_TOKEN": "test",
+        "GITHUB_OUTPUT": str(tmp_path / "output"),
+        "GITHUB_REF": "refs/heads/main",
+        "GITHUB_REPOSITORY": "example/repo",
+        "IMAGE_PREFIX_COMMON": "ghcr.io/example/openadkit-common",
+        "IMAGE_PREFIX_COMPONENT": "ghcr.io/example/openadkit",
+        "VERSION": version,
+    }
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; release_sha="$2"; validate_release_rules',
+            "bash",
+            str(VALIDATOR),
+            RELEASE_SHA,
+        ],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("version", "ref_type", "input_ref"),
+    [
+        ("v2.0.0", "tag", "1.8.0"),
+        ("v2.0.0-rc.1", "tag", "1.8.0"),
+        ("v2.0.0-rc.1", "sha", "a" * 40),
+    ],
+)
+def test_release_rules_accept_supported_autoware_refs(
+    tmp_path, version, ref_type, input_ref
+):
+    result = run_release_rules(
+        tmp_path, version=version, ref_type=ref_type, input_ref=input_ref
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    ("version", "ref_type", "input_ref"),
+    [
+        ("v2.0.0", "sha", "a" * 40),
+        ("v2.0.0-rc.1", "branch", "main"),
+        ("v2.0.0-rc.1", "sha", "abc123"),
+    ],
+)
+def test_release_rules_reject_unsupported_autoware_refs(
+    tmp_path, version, ref_type, input_ref
+):
+    result = run_release_rules(
+        tmp_path, version=version, ref_type=ref_type, input_ref=input_ref
+    )
+    assert result.returncode != 0
+
+
+def test_registry_lookup_retries_and_classifies_failures(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    count = tmp_path / "count"
+    docker = bin_dir / "docker"
+    env = os.environ | {
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "REGISTRY_LOOKUP_RETRY_DELAY_SECONDS": "0",
+    }
+
+    executable(
+        docker,
+        "#!/usr/bin/env bash\n"
+        f"count_file={json.dumps(str(count))}\n"
+        'count=$(cat "$count_file" 2>/dev/null || printf 0)\n'
+        'count=$((count + 1)); printf "%s\\n" "$count" > "$count_file"\n'
+        'if [ "$count" -lt 3 ]; then echo "503 Service Unavailable" >&2; exit 1; fi\n'
+        f"printf '%s\\n' '{json.dumps({'manifest': {'digest': DIGEST}})}'\n",
+    )
+    command = [
+        "bash",
+        "-c",
+        'source "$1"; registry_manifest_digest ghcr.io/example/image:tag',
+        "bash",
+        str(REGISTRY_LOOKUP),
+    ]
+    result = subprocess.run(command, env=env, text=True, capture_output=True)
+    assert result.returncode == 0
+    assert result.stdout.strip() == DIGEST
+    assert count.read_text().strip() == "3"
+
+    executable(docker, '#!/usr/bin/env bash\necho "401 Unauthorized" >&2\nexit 1\n')
+    assert subprocess.run(command, env=env).returncode == 2
+
+
+def release_record(
+    *, release_id=42, body=MARKER + "\n", target=RELEASE_SHA, assets=None
+):
+    return {
+        "id": release_id,
+        "tag_name": VERSION,
+        "target_commitish": target,
+        "name": VERSION,
+        "draft": True,
+        "prerelease": False,
+        "body": body,
+        "assets": assets or [],
+    }
+
+
+def release_assets():
+    return [
+        {"id": 101, "name": "release-metadata.json"},
+        {"id": 102, "name": "autoware-lock.repos"},
+        {"id": 103, "name": "upstream-images.json"},
+        {"id": 104, "name": "example.tar.gz"},
+    ]
+
+
+def release_workspace(tmp_path):
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist/example.tar.gz").write_bytes(b"bundle")
+    build = tmp_path / "release-input/build"
+    build.mkdir(parents=True)
+    (build / "autoware-lock.repos").write_text("repositories: {}\n")
+    (build / "upstream-images.json").write_text("[]\n")
+    (tmp_path / "release-metadata.json").write_text("{}\n")
+    (tmp_path / "release-notes.md").write_text(MARKER + "\n")
+    files = [
+        tmp_path / "release-metadata.json",
+        build / "autoware-lock.repos",
+        build / "upstream-images.json",
+        tmp_path / "dist/example.tar.gz",
+    ]
+    manifest = "".join(
+        f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}\n"
+        for path in sorted(files, key=lambda path: path.name)
+    )
+    (tmp_path / "release-assets.sha256").write_text(manifest)
+
+
+def fake_gh_environment(tmp_path, listed, refreshed=None):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    responses = tmp_path / "responses"
+    responses.mkdir()
+    created = release_record(release_id=43)
+    (responses / "listed").write_text(json.dumps([listed] if listed else []))
+    (responses / "refreshed").write_text(json.dumps(refreshed or listed or {}))
+    (responses / "created").write_text(json.dumps(created))
+    state = refreshed or listed or {}
+    asset_sources = {
+        "release-metadata.json": tmp_path / "release-metadata.json",
+        "autoware-lock.repos": tmp_path / "release-input/build/autoware-lock.repos",
+        "upstream-images.json": tmp_path / "release-input/build/upstream-images.json",
+        "example.tar.gz": tmp_path / "dist/example.tar.gz",
+    }
+    for asset in state.get("assets", []):
+        source = asset_sources.get(asset["name"])
+        if source is not None:
+            (responses / f"asset-{asset['id']}").write_bytes(source.read_bytes())
+    log = tmp_path / "gh-calls"
+    executable(
+        bin_dir / "gh",
+        "#!/usr/bin/env bash\nset -euo pipefail\n"
+        'printf "%s\\n" "$*" >> "$GH_LOG"\n'
+        'if [[ "$*" == *"/git/refs/tags/"* ]]; then '
+        f"printf '%s\\n' '{json.dumps({'object': {'type': 'commit', 'sha': RELEASE_SHA}})}'; exit; fi\n"
+        'if [[ "$*" == *"--paginate --slurp"* ]]; then '
+        'if [ -f "$GH_CREATED" ]; then printf "[["; cat "$GH_RESPONSES/created"; printf "]]\\n"; '
+        'else printf "["; cat "$GH_RESPONSES/listed"; printf "]\\n"; fi; exit; fi\n'
+        'if [[ "$*" == *"--method DELETE"* ]]; then touch "$GH_DELETED"; exit; fi\n'
+        'if [[ "$*" == *"--method PATCH"* ]]; then touch "$GH_PATCHED"; exit; fi\n'
+        'if [[ "$*" == *"/releases/assets/"* ]]; then uri="${!#}"; cat "$GH_RESPONSES/asset-${uri##*/}"; exit; fi\n'
+        'if [[ "$1" == api && "$*" == *"/releases/"* ]]; then cat "$GH_RESPONSES/refreshed"; exit; fi\n'
+        'if [[ "$1 $2" == "release create" ]]; then touch "$GH_CREATED"; exit; fi\n'
+        'echo "unhandled gh call: $*" >&2; exit 2\n',
+    )
+    env = os.environ | {
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "GH_LOG": str(log),
+        "GH_RESPONSES": str(responses),
+        "GH_CREATED": str(tmp_path / "created"),
+        "GH_DELETED": str(tmp_path / "deleted"),
+        "GH_PATCHED": str(tmp_path / "patched"),
+        "GITHUB_OUTPUT": str(tmp_path / "output"),
+        "GITHUB_REPOSITORY": "example/repo",
+        "RELEASE_SHA": RELEASE_SHA,
+        "STABLE_RELEASE": "true",
+        "VERSION": VERSION,
+    }
+    return env, log
+
+
+def run_manager(tmp_path, env, operation="prepare"):
+    return subprocess.run(
+        ["bash", str(MANAGER), operation],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_prepare_replaces_only_unchanged_owned_draft(tmp_path):
+    release_workspace(tmp_path)
+    owned = release_record()
+    env, log = fake_gh_environment(tmp_path, owned)
+    result = run_manager(tmp_path, env)
+    assert result.returncode == 0, result.stderr
+    calls = log.read_text().splitlines()
+    assert next(i for i, call in enumerate(calls) if "DELETE" in call) < next(
+        i for i, call in enumerate(calls) if "release create" in call
+    )
+    assert (tmp_path / "output").read_text().startswith("created=true\nrelease_id=43\n")
+
+
+@pytest.mark.parametrize(
+    ("listed", "refreshed"),
+    [
+        (release_record(body="manual draft\n"), None),
+        (release_record(), release_record(target="f" * 40)),
+    ],
+)
+def test_prepare_refuses_unowned_or_changed_draft(tmp_path, listed, refreshed):
+    release_workspace(tmp_path)
+    env, _ = fake_gh_environment(tmp_path, listed, refreshed)
+    result = run_manager(tmp_path, env)
+    assert result.returncode != 0
+    assert not (tmp_path / "deleted").exists()
+    assert not (tmp_path / "created").exists()
+
+
+def test_publish_revalidates_body_before_mutation(tmp_path):
+    release_workspace(tmp_path)
+    changed = release_record(body=MARKER + "\nchanged\n")
+    env, _ = fake_gh_environment(tmp_path, changed)
+    env |= {
+        "RELEASE_ID": "42",
+        "RELEASE_BODY_SHA256": hashlib.sha256((MARKER + "\n").encode()).hexdigest(),
+        "PUBLISH_LATEST_ALIASES": "true",
+    }
+    result = run_manager(tmp_path, env, "publish")
+    assert result.returncode != 0
+    assert not (tmp_path / "patched").exists()
+
+
+def test_publish_patches_the_revalidated_release_id(tmp_path):
+    release_workspace(tmp_path)
+    owned = release_record(assets=release_assets())
+    env, log = fake_gh_environment(tmp_path, owned)
+    env |= {
+        "RELEASE_ID": "42",
+        "RELEASE_BODY_SHA256": hashlib.sha256((MARKER + "\n").encode()).hexdigest(),
+        "PUBLISH_LATEST_ALIASES": "true",
+    }
+    result = run_manager(tmp_path, env, "publish")
+    assert result.returncode == 0, result.stderr
+    patch = next(call for call in log.read_text().splitlines() if "PATCH" in call)
+    assert "releases/42" in patch
+    assert "draft=false" in patch
+
+
+def test_publish_rejects_changed_draft_asset(tmp_path):
+    release_workspace(tmp_path)
+    owned = release_record(assets=release_assets())
+    env, _ = fake_gh_environment(tmp_path, owned)
+    (tmp_path / "responses/asset-104").write_bytes(b"replaced bundle")
+    env |= {
+        "RELEASE_ID": "42",
+        "RELEASE_BODY_SHA256": hashlib.sha256((MARKER + "\n").encode()).hexdigest(),
+        "PUBLISH_LATEST_ALIASES": "true",
+    }
+    result = run_manager(tmp_path, env, "publish")
+    assert result.returncode != 0
+    assert not (tmp_path / "patched").exists()
+
+
+def test_registry_auth_failure_never_mutates_image_tags(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls = tmp_path / "docker-calls"
+    executable(
+        bin_dir / "docker",
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$*" >> {json.dumps(str(calls))}\n'
+        'echo "401 Unauthorized" >&2\nexit 1\n',
+    )
+    executable(bin_dir / "gh", "#!/usr/bin/env bash\nprintf '%s\\n' v9.8.7\n")
+    build = tmp_path / "release-input/build"
+    build.mkdir(parents=True)
+    (build / "build-metadata.json").write_text(
+        json.dumps(
+            {
+                "images": [
+                    {
+                        "repo": "ghcr.io/example/openadkit",
+                        "target": "api",
+                        "ros_distro": "humble",
+                        "digest": DIGEST,
+                    }
+                ]
+            }
+        )
+    )
+    env = os.environ | {
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "DEFAULT_ROS_DISTRO": "humble",
+        "GITHUB_REPOSITORY": "example/repo",
+        "PUBLISH_LATEST_ALIASES": "true",
+        "REGISTRY_LOOKUP_RETRY_DELAY_SECONDS": "0",
+        "STABLE_RELEASE": "true",
+        "VERSION": VERSION,
+    }
+    result = subprocess.run(["bash", str(PROMOTER)], cwd=tmp_path, env=env)
+    assert result.returncode != 0
+    assert all("imagetools create" not in call for call in calls.read_text().splitlines())
+
+
+def test_failed_version_tag_never_updates_stable_aliases(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls = tmp_path / "docker-calls"
+    executable(
+        bin_dir / "docker",
+        "#!/usr/bin/env bash\n"
+        'if [ "$1 $2 $3" = "buildx imagetools inspect" ]; then '
+        'echo "ERROR: $4: not found" >&2; exit 1; fi\n'
+        f'printf "%s\\n" "$*" >> {json.dumps(str(calls))}\n'
+        "exit 1\n",
+    )
+    executable(bin_dir / "sleep", "#!/usr/bin/env bash\nexit 0\n")
+    build = tmp_path / "release-input/build"
+    build.mkdir(parents=True)
+    (build / "build-metadata.json").write_text(
+        json.dumps(
+            {
+                "images": [
+                    {
+                        "repo": "ghcr.io/example/openadkit",
+                        "target": "api",
+                        "ros_distro": "humble",
+                        "digest": DIGEST,
+                    }
+                ]
+            }
+        )
+    )
+    env = os.environ | {
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "DEFAULT_ROS_DISTRO": "humble",
+        "PUBLISH_LATEST_ALIASES": "true",
+        "REGISTRY_LOOKUP_MAX_ATTEMPTS": "1",
+        "STABLE_RELEASE": "true",
+        "VERSION": VERSION,
+    }
+    result = subprocess.run(["bash", str(PROMOTER)], cwd=tmp_path, env=env)
+    assert result.returncode != 0
+    assert all(f"-{VERSION}" in call for call in calls.read_text().splitlines())
+
+
+def test_release_bundles_pin_images_and_are_reproducible(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    executable(
+        bin_dir / "docker",
+        "#!/usr/bin/env bash\n"
+        'if [[ "$*" == *"config --environment"* ]]; then cat config.env; fi\n'
+        "exit 0\n",
+    )
+    build = tmp_path / "release-input/build"
+    build.mkdir(parents=True)
+    images = []
+    for image in json.loads((ROOT / ".github/image-inventory.json").read_text())["images"]:
+        if image["repo"] != "component":
+            continue
+        for distro in image.get("ros_distros", ["humble", "jazzy"]):
+            images.append(
+                {
+                    "repo": "ghcr.io/example/openadkit",
+                    "target": image["target"],
+                    "ros_distro": distro,
+                    "digest": DIGEST,
+                }
+            )
+    (build / "build-metadata.json").write_text(json.dumps({"images": images}))
+    env = os.environ | {
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "SOURCE_DIR": str(ROOT),
+        "VERSION": VERSION,
+        "DEFAULT_ROS_DISTRO": "jazzy",
+        "IMAGE_PREFIX_COMPONENT": "ghcr.io/example/openadkit",
+    }
+    subprocess.run(["bash", str(PACKAGER)], cwd=tmp_path, env=env, check=True)
+    first = {
+        path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in (tmp_path / "dist").glob("*.tar.gz")
+    }
+    assert len(first) == 5
+    for name in (
+        "planning-simulation",
+        "scenario-simulation",
+        "logging-simulation",
+        "carla-simulation",
+        "zenoh-bridge",
+    ):
+        text = "\n".join(
+            path.read_text()
+            for path in (tmp_path / "staging" / name).rglob("*")
+            if path.is_file() and path.suffix in {".yaml", ".env"}
+        )
+        assert "ghcr.io/autowarefoundation/openadkit:" not in text
+        refs = re.findall(r"ghcr.io/example/openadkit:[a-z-]+-(?:humble|jazzy)-v9\.8\.7[^\s\"}]*", text)
+        assert refs
+        assert all(ref.endswith(f"@{DIGEST}") for ref in refs)
+    for name in (
+        "planning-simulation",
+        "scenario-simulation",
+        "logging-simulation",
+        "carla-simulation",
+        "zenoh-bridge",
+    ):
+        bundle = tmp_path / "staging" / name
+        assert (bundle / "config.env").is_file()
+        assert not (bundle / ".env").exists()
+        assert not (bundle / ".env.example").exists()
+    for name in (
+        "planning-simulation",
+        "scenario-simulation",
+        "logging-simulation",
+        "carla-simulation",
+    ):
+        bundle = tmp_path / "staging" / name
+        assert (bundle / "base/runtime.env").is_file()
+        assert (bundle / "base/config/vehicle_cmd_gate.param.yaml").is_file()
+        assert f"{name}.env" not in {path.name for path in bundle.iterdir()}
+    for name, command in (
+        ("planning-simulation", ["bash", "check-planning-simulation.sh", "--dry-run"]),
+        ("carla-simulation", ["bash", "start-carla-e2e-demo.sh", "--dry-run"]),
+    ):
+        result = subprocess.run(
+            command,
+            cwd=tmp_path / "staging" / name,
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode == 0, result.stderr
+    subprocess.run(["bash", str(PACKAGER)], cwd=tmp_path, env=env, check=True)
+    second = {
+        path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in (tmp_path / "dist").glob("*.tar.gz")
+    }
+    assert second == first

--- a/.github/scripts/validate_release.sh
+++ b/.github/scripts/validate_release.sh
@@ -1,0 +1,467 @@
+#!/usr/bin/env bash
+# Validate that a build-all-images run can be promoted to an OpenADKit release.
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.github/scripts/release_tag.sh
+source "${script_dir}/release_tag.sh"
+# shellcheck source=.github/scripts/registry_lookup.sh
+source "${script_dir}/registry_lookup.sh"
+# shellcheck source=.github/scripts/stable_alias_policy.sh
+source "${script_dir}/stable_alias_policy.sh"
+
+: "${BUILD_TAG:?BUILD_TAG is required}"
+: "${VERSION:?VERSION is required}"
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${GITHUB_REF:?GITHUB_REF is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+: "${IMAGE_PREFIX_COMMON:?IMAGE_PREFIX_COMMON is required}"
+: "${IMAGE_PREFIX_COMPONENT:?IMAGE_PREFIX_COMPONENT is required}"
+
+openadkit_semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z]*))*)?$'
+openadkit_stable_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+autoware_stable_re='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+
+publish_latest_aliases=false
+is_stable_release=false
+release_sha=""
+run_id=""
+run_attempt=""
+readonly BUILD_AGE_MAX_DAYS=90
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+validate_inputs() {
+  printf '%s\n' "${VERSION}" | grep -Eq "${openadkit_semver_re}" \
+    || fail "Invalid version format '${VERSION}': must be strict SemVer vX.Y.Z or vX.Y.Z-prerelease"
+  printf '%s\n' "${BUILD_TAG}" | grep -Eq '^[0-9]+-[0-9]+$' \
+    || fail "Invalid build_tag format '${BUILD_TAG}': must be RUN_ID-RUN_ATTEMPT"
+  [ "${GITHUB_REF}" = "refs/heads/main" ] \
+    || fail "Release must be triggered from main branch (got ${GITHUB_REF})"
+  case "${DEFAULT_ROS_DISTRO:-humble}" in
+    humble|jazzy) ;;
+    *) fail "Invalid default_ros_distro '${DEFAULT_ROS_DISTRO}': must be one of humble, jazzy" ;;
+  esac
+}
+
+resolve_latest_alias_policy() {
+  local current_policy
+
+  if printf '%s\n' "${VERSION}" | grep -Eq "${openadkit_stable_re}"; then
+    is_stable_release=true
+    current_policy=$(current_latest_alias_policy)
+    if [ "${current_policy}" = true ]; then
+      publish_latest_aliases=true
+    else
+      echo "Stable aliases will not be updated because a newer stable release exists"
+    fi
+  fi
+}
+
+validate_build_run() {
+  local run_json workflow_name workflow_path head_branch status conclusion created_at
+  local created_epoch now_epoch max_age_seconds
+
+  run_id="${BUILD_TAG%%-*}"
+  run_attempt="${BUILD_TAG##*-}"
+  run_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/attempts/${run_attempt}")
+
+  workflow_name=$(printf '%s' "${run_json}" | jq -r '.name')
+  workflow_path=$(printf '%s' "${run_json}" | jq -r '.path')
+  head_branch=$(printf '%s' "${run_json}" | jq -r '.head_branch')
+  status=$(printf '%s' "${run_json}" | jq -r '.status')
+  conclusion=$(printf '%s' "${run_json}" | jq -r '.conclusion')
+  release_sha=$(printf '%s' "${run_json}" | jq -r '.head_sha')
+  created_at=$(printf '%s' "${run_json}" | jq -r '.created_at')
+
+  [ "${workflow_name}" = "build-all-images" ] || fail "Expected build-all-images run, got '${workflow_name}'"
+  [ "${workflow_path}" = ".github/workflows/build-all-images.yaml" ] || fail "Unexpected workflow path '${workflow_path}'"
+  [ "${head_branch}" = "main" ] || fail "Source build must come from main branch (got '${head_branch}')"
+  [ "${status}" = "completed" ] || fail "Source build must be completed (got '${status}')"
+  [ "${conclusion}" = "success" ] || fail "Source build must succeed (got '${conclusion}')"
+
+  created_epoch=$(date -u -d "${created_at}" +%s)
+  now_epoch=$(date -u +%s)
+  max_age_seconds=$((BUILD_AGE_MAX_DAYS * 24 * 60 * 60))
+  if [ $((now_epoch - created_epoch)) -gt "${max_age_seconds}" ]; then
+    fail "Build ${BUILD_TAG} is older than ${BUILD_AGE_MAX_DAYS} days and is no longer promotable"
+  fi
+}
+
+download_build_metadata() {
+  mkdir -p release-input/build release-input/scan
+  gh run download "${run_id}" \
+    --repo "${GITHUB_REPOSITORY}" \
+    --name "build-metadata-${BUILD_TAG}" \
+    --dir release-input/build
+}
+
+select_scan_metadata() {
+  local scan_artifact_ids scan_artifact_id artifact_json artifact_run_id scan_run_id scan_run_attempt
+  local scan_run_json scan_workflow_name scan_workflow_path scan_head_branch scan_status scan_conclusion
+  local selected_scan_artifact_id selected_scan_run_id selected_scan_run_attempt selected_scan_status selected_scan_conclusion
+
+  scan_artifact_ids=$(
+    gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=scan-metadata-${BUILD_TAG}" \
+      --jq '.artifacts[] | select(.expired == false) | [.id, .created_at] | @tsv' \
+      | sort -k2,2r \
+      | cut -f1
+  )
+  [ -n "${scan_artifact_ids}" ] || fail "No non-expired full scan metadata found for ${BUILD_TAG}"
+
+  selected_scan_artifact_id=""
+  selected_scan_run_id=""
+  selected_scan_run_attempt=""
+  selected_scan_status=""
+  selected_scan_conclusion=""
+  while IFS= read -r scan_artifact_id; do
+    [ -n "${scan_artifact_id}" ] || continue
+
+    rm -rf release-input/scan
+    mkdir -p release-input/scan
+    rm -f scan-metadata.zip
+
+    artifact_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${scan_artifact_id}")
+    artifact_run_id=$(printf '%s' "${artifact_json}" | jq -r '.workflow_run.id // empty')
+    gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${scan_artifact_id}/zip" > scan-metadata.zip
+    unzip -q scan-metadata.zip -d release-input/scan
+
+    if ! jq -e --arg build_tag "${BUILD_TAG}" '
+      .build_tag == $build_tag and
+      (.policy_sha | test("^[0-9a-f]{40}$")) and
+      .scan_scope == "all" and
+      (.scan_status == "passed" or .scan_status == "failed") and
+      (.run_id | test("^[0-9]+$")) and
+      (.run_attempt | test("^[0-9]+$")) and
+      (.scanned_images | type == "array" and length > 0) and
+      all(.scanned_images[];
+        (.repo | type == "string" and length > 0) and
+        (.target | type == "string" and length > 0) and
+        (.ros_distro | type == "string" and length > 0) and
+        (.digest | test("^sha256:[0-9a-f]{64}$")) and
+        (.platform | test("^linux/(amd64|arm64)$")) and
+        (.image_ref == (.repo + "@" + .digest))
+      )
+    ' release-input/scan/scan-metadata.json >/dev/null 2>&1; then
+      echo "Ignoring scan artifact ${scan_artifact_id}: metadata is not full scan metadata for ${BUILD_TAG}" >&2
+      continue
+    fi
+
+    scan_run_id=$(jq -r '.run_id' release-input/scan/scan-metadata.json)
+    scan_run_attempt=$(jq -r '.run_attempt' release-input/scan/scan-metadata.json)
+    if [ "${artifact_run_id}" != "${scan_run_id}" ]; then
+      echo "Ignoring scan artifact ${scan_artifact_id}: artifact run ${artifact_run_id} does not match metadata run ${scan_run_id}" >&2
+      continue
+    fi
+
+    if ! scan_run_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${scan_run_id}/attempts/${scan_run_attempt}" 2>/dev/null); then
+      echo "Ignoring scan artifact ${scan_artifact_id}: could not read scan run ${scan_run_id}-${scan_run_attempt}" >&2
+      continue
+    fi
+
+    scan_workflow_name=$(printf '%s' "${scan_run_json}" | jq -r '.name')
+    scan_workflow_path=$(printf '%s' "${scan_run_json}" | jq -r '.path')
+    scan_head_branch=$(printf '%s' "${scan_run_json}" | jq -r '.head_branch')
+    scan_status=$(printf '%s' "${scan_run_json}" | jq -r '.status')
+    scan_conclusion=$(printf '%s' "${scan_run_json}" | jq -r '.conclusion')
+
+    if [ "${scan_workflow_name}" != "scan-images" ] || \
+      [ "${scan_workflow_path}" != ".github/workflows/scan.yaml" ] || \
+      [ "${scan_head_branch}" != "main" ] || \
+      [ "${scan_status}" != "completed" ]; then
+      echo "Ignoring scan artifact ${scan_artifact_id}: scan run ${scan_run_id}-${scan_run_attempt} is not a completed scan-images run on main" >&2
+      continue
+    fi
+
+    selected_scan_artifact_id="${scan_artifact_id}"
+    selected_scan_run_id="${scan_run_id}"
+    selected_scan_run_attempt="${scan_run_attempt}"
+    selected_scan_status=$(jq -r '.scan_status' release-input/scan/scan-metadata.json)
+    selected_scan_conclusion="${scan_conclusion}"
+    break
+  done <<< "${scan_artifact_ids}"
+
+  [ -n "${selected_scan_artifact_id}" ] || fail "No validated full scan metadata found for ${BUILD_TAG}"
+  if [ "${selected_scan_status}" != "passed" ] || [ "${selected_scan_conclusion}" != "success" ]; then
+    fail "Latest full scan for ${BUILD_TAG} did not pass: scan run ${selected_scan_run_id}-${selected_scan_run_attempt} has metadata status '${selected_scan_status}' and conclusion '${selected_scan_conclusion}'"
+  fi
+}
+
+validate_build_metadata_schema() {
+  if ! jq -e \
+    --arg build_tag "${BUILD_TAG}" \
+    --arg run_id "${run_id}" \
+    --arg run_attempt "${run_attempt}" '
+    .build_tag == $build_tag and
+    .run_id == $run_id and
+    .run_attempt == $run_attempt and
+    (.openadkit_sha | test("^[0-9a-f]{40}$")) and
+    (.autoware_input_ref | type == "string" and length > 0) and
+    (.autoware_ref_type as $type | ["branch", "tag", "sha", "ref"] | index($type) != null) and
+    (.autoware_ref | test("^[0-9a-f]{40}$")) and
+    (.autoware_base_version | test("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$")) and
+    (.autoware_lock_sha256 | test("^[0-9a-f]{64}$")) and
+    (.image_inventory_sha256 | test("^[0-9a-f]{64}$")) and
+    (.upstream_images_sha256 | test("^[0-9a-f]{64}$")) and
+    (.scan_requested | type == "boolean") and
+    (.images | type == "array" and length > 0) and
+    all(.images[];
+      (.repo | type == "string" and length > 0) and
+      (.target | type == "string" and length > 0) and
+      (.ros_distro | type == "string" and length > 0) and
+      (.digest | test("^sha256:[0-9a-f]{64}$")) and
+      (.ref == (.repo + ":" + .target + "-" + .ros_distro + "-" + $build_tag)) and
+      (.platforms | type == "array" and length > 0) and
+      all(.platforms[]; test("^linux/(amd64|arm64)$"))
+    ) and
+    (.upstream_images | type == "array" and length > 0) and
+    all(.upstream_images[];
+      (.name | IN("core-devel", "base", "base-cuda-runtime", "base-cuda-devel")) and
+      (.ros_distro | type == "string" and length > 0) and
+      (.ref | type == "string" and length > 0) and
+      (.digest | test("^sha256:[0-9a-f]{64}$")) and
+      .uri == ("docker-image://" + .ref + "@" + .digest)
+    )
+  ' release-input/build/build-metadata.json >/dev/null; then
+    fail "Build metadata failed schema validation"
+  fi
+}
+
+validate_metadata_files() {
+  local metadata_lock_sha actual_lock_sha metadata_inventory_sha actual_inventory_sha
+  local metadata_upstream_sha actual_upstream_sha
+
+  [ -f release-input/build/autoware-lock.repos ] || fail "Build metadata is missing autoware-lock.repos"
+  metadata_lock_sha=$(jq -r '.autoware_lock_sha256' release-input/build/build-metadata.json)
+  actual_lock_sha=$(sha256sum release-input/build/autoware-lock.repos | cut -d ' ' -f1)
+  [ "${actual_lock_sha}" = "${metadata_lock_sha}" ] \
+    || fail "Autoware lock SHA ${actual_lock_sha} does not match metadata SHA ${metadata_lock_sha}"
+
+  [ -f release-input/build/image-inventory.json ] || fail "Build metadata is missing image-inventory.json"
+  metadata_inventory_sha=$(jq -r '.image_inventory_sha256' release-input/build/build-metadata.json)
+  actual_inventory_sha=$(sha256sum release-input/build/image-inventory.json | cut -d ' ' -f1)
+  [ "${actual_inventory_sha}" = "${metadata_inventory_sha}" ] \
+    || fail "Image inventory SHA ${actual_inventory_sha} does not match metadata SHA ${metadata_inventory_sha}"
+
+  [ -f release-input/build/upstream-images.json ] || fail "Build metadata is missing upstream-images.json"
+  metadata_upstream_sha=$(jq -r '.upstream_images_sha256' release-input/build/build-metadata.json)
+  actual_upstream_sha=$(sha256sum release-input/build/upstream-images.json | cut -d ' ' -f1)
+  [ "${actual_upstream_sha}" = "${metadata_upstream_sha}" ] \
+    || fail "Upstream image metadata SHA ${actual_upstream_sha} does not match metadata SHA ${metadata_upstream_sha}"
+  cmp <(jq -S . release-input/build/upstream-images.json) \
+    <(jq -S '.upstream_images' release-input/build/build-metadata.json) \
+    || fail "Embedded upstream image metadata does not match upstream-images.json"
+}
+
+validate_inventory_coverage() {
+  local expected_inventory actual_inventory expected_count actual_count actual_unique_count
+  local missing_inventory extra_inventory
+
+  expected_inventory=$(mktemp)
+  actual_inventory=$(mktemp)
+  jq -r \
+    --arg common_repo "${IMAGE_PREFIX_COMMON}" \
+    --arg component_repo "${IMAGE_PREFIX_COMPONENT}" '
+    def repo_for($kind): if $kind == "common" then $common_repo elif $kind == "component" then $component_repo else error("unsupported repo kind") end;
+    def image_distros($global): .ros_distros // $global;
+    .ros_distros as $global |
+    .images[] |
+    image_distros($global)[] as $distro |
+    [repo_for(.repo), .target, $distro, (.platforms | sort | join(","))] |
+    @tsv
+  ' release-input/build/image-inventory.json | sort -u > "${expected_inventory}"
+  jq -r '
+    .images[] |
+    [.repo, .target, .ros_distro, (.platforms | sort | join(","))] |
+    @tsv
+  ' release-input/build/build-metadata.json | sort -u > "${actual_inventory}"
+
+  expected_count=$(wc -l < "${expected_inventory}" | tr -d ' ')
+  actual_count=$(jq -r '.images | length' release-input/build/build-metadata.json)
+  actual_unique_count=$(wc -l < "${actual_inventory}" | tr -d ' ')
+  missing_inventory=$(comm -23 "${expected_inventory}" "${actual_inventory}" || true)
+  extra_inventory=$(comm -13 "${expected_inventory}" "${actual_inventory}" || true)
+  rm -f "${expected_inventory}" "${actual_inventory}"
+
+  [ "${actual_count}" = "${actual_unique_count}" ] || fail "Build metadata contains duplicate image entries"
+  [ "${actual_count}" = "${expected_count}" ] \
+    || fail "Build metadata image count ${actual_count} does not match inventory count ${expected_count}"
+  if [ -n "${missing_inventory}" ]; then
+    echo "Build metadata is missing inventory entries:" >&2
+    printf '%s\n' "${missing_inventory}" >&2
+    exit 1
+  fi
+  if [ -n "${extra_inventory}" ]; then
+    echo "Build metadata contains entries outside inventory:" >&2
+    printf '%s\n' "${extra_inventory}" >&2
+    exit 1
+  fi
+}
+
+validate_upstream_coverage() {
+  local expected actual base_version expected_count actual_count
+  expected=$(mktemp)
+  actual=$(mktemp)
+  base_version=$(jq -r '.autoware_base_version' release-input/build/build-metadata.json)
+
+  jq -r --arg version "${base_version}" '
+    .ros_distros[] as $distro |
+    ["core-devel", "base", "base-cuda-runtime", "base-cuda-devel"][] as $name |
+    [$name, $distro, ("ghcr.io/autowarefoundation/autoware:" + $name + "-" + $distro + "-" + $version)] |
+    @tsv
+  ' release-input/build/image-inventory.json | sort -u >"${expected}"
+  jq -r '.upstream_images[] | [.name, .ros_distro, .ref] | @tsv' \
+    release-input/build/build-metadata.json | sort -u >"${actual}"
+
+  expected_count=$(wc -l <"${expected}" | tr -d ' ')
+  actual_count=$(jq '.upstream_images | length' release-input/build/build-metadata.json)
+  if [ "${actual_count}" != "${expected_count}" ] || ! cmp "${expected}" "${actual}"; then
+    diff -u "${expected}" "${actual}" >&2 || true
+    rm -f "${expected}" "${actual}"
+    fail "Upstream image metadata does not cover every required Autoware base"
+  fi
+  rm -f "${expected}" "${actual}"
+}
+
+validate_scan_coverage() {
+  local build_coverage scan_coverage missing_coverage extra_coverage build_sha policy_sha
+
+  build_sha=$(jq -r '.openadkit_sha' release-input/build/build-metadata.json)
+  policy_sha=$(jq -r '.policy_sha' release-input/scan/scan-metadata.json)
+  [ "${policy_sha}" = "${build_sha}" ] \
+    || fail "Scan policy SHA ${policy_sha} does not match build SHA ${build_sha}"
+
+  build_coverage=$(mktemp)
+  scan_coverage=$(mktemp)
+  jq -r '
+    .images[] as $image |
+    $image.platforms[] |
+    [$image.repo, $image.target, $image.ros_distro, $image.digest, .] |
+    @tsv
+  ' release-input/build/build-metadata.json | sort -u > "${build_coverage}"
+  jq -r '
+    .scanned_images[] |
+    [.repo, .target, .ros_distro, .digest, .platform] |
+    @tsv
+  ' release-input/scan/scan-metadata.json | sort -u > "${scan_coverage}"
+
+  missing_coverage=$(comm -23 "${build_coverage}" "${scan_coverage}" || true)
+  extra_coverage=$(comm -13 "${build_coverage}" "${scan_coverage}" || true)
+  rm -f "${build_coverage}" "${scan_coverage}"
+  if [ -n "${missing_coverage}" ]; then
+    echo "Scan metadata is missing build digest/platform coverage:" >&2
+    printf '%s\n' "${missing_coverage}" >&2
+    exit 1
+  fi
+  if [ -n "${extra_coverage}" ]; then
+    echo "Scan metadata contains digest/platform entries outside build metadata:" >&2
+    printf '%s\n' "${extra_coverage}" >&2
+    exit 1
+  fi
+}
+
+validate_release_rules() {
+  local metadata_sha autoware_input_ref autoware_ref_type autoware_base_version
+
+  metadata_sha=$(jq -r '.openadkit_sha' release-input/build/build-metadata.json)
+  [ "${metadata_sha}" = "${release_sha}" ] \
+    || fail "Build metadata SHA ${metadata_sha} does not match workflow SHA ${release_sha}"
+
+  autoware_input_ref=$(jq -r '.autoware_input_ref' release-input/build/build-metadata.json)
+  autoware_ref_type=$(jq -r '.autoware_ref_type' release-input/build/build-metadata.json)
+  autoware_base_version=$(jq -r '.autoware_base_version' release-input/build/build-metadata.json)
+  if [ "${autoware_ref_type}" = "tag" ]; then
+    printf '%s\n' "${autoware_input_ref}" | grep -Eq "${autoware_stable_re}" \
+      || fail "Autoware release tags must use X.Y.Z format (got ${autoware_input_ref})"
+    [ "${autoware_base_version}" = "${autoware_input_ref}" ] \
+      || fail "Autoware base version ${autoware_base_version} does not match release tag ${autoware_input_ref}"
+  elif ! printf '%s\n' "${VERSION}" | grep -Eq "${openadkit_stable_re}" \
+    && [ "${autoware_ref_type}" = "sha" ] \
+    && printf '%s\n' "${autoware_input_ref}" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+    :
+  elif printf '%s\n' "${VERSION}" | grep -Eq "${openadkit_stable_re}"; then
+    fail "Stable releases must be built from an Autoware release tag (got ${autoware_ref_type}:${autoware_input_ref})"
+  else
+    fail "Pre-releases must be built from an Autoware release tag or full SHA (got ${autoware_ref_type}:${autoware_input_ref})"
+  fi
+}
+
+validate_git_tag() {
+  local lookup_status tag_sha
+
+  if tag_sha=$(release_tag_sha); then
+    if [ "${tag_sha}" != "${release_sha}" ]; then
+      fail "Tag ${VERSION} already exists at ${tag_sha}, expected ${release_sha}"
+    fi
+  else
+    lookup_status=$?
+    [ "${lookup_status}" -eq 1 ] || return "${lookup_status}"
+  fi
+}
+
+validate_registry_conflicts() {
+  local conflicts repo target distro ref digest source_digest release_ref existing_digest lookup_status
+
+  conflicts=0
+  while IFS=$'\t' read -r repo target distro ref digest; do
+    lookup_status=0
+    source_digest=$(registry_manifest_digest "${ref}") || lookup_status=$?
+    if [ "${lookup_status}" -eq 1 ]; then
+      echo "Source image not found: ${ref}" >&2
+      return 1
+    elif [ "${lookup_status}" -ne 0 ]; then
+      return "${lookup_status}"
+    fi
+    if [ "${source_digest}" != "${digest}" ]; then
+      echo "Source digest mismatch for ${ref}: ${source_digest} != ${digest}" >&2
+      conflicts=1
+    fi
+
+    release_ref="${repo}:${target}-${distro}-${VERSION}"
+    lookup_status=0
+    existing_digest=$(registry_manifest_digest "${release_ref}") || lookup_status=$?
+    if [ "${lookup_status}" -eq 0 ]; then
+      if [ "${existing_digest}" != "${digest}" ]; then
+        echo "Release tag conflict: ${release_ref} points to ${existing_digest}, expected ${digest}" >&2
+        conflicts=1
+      fi
+    elif [ "${lookup_status}" -ne 1 ]; then
+      return "${lookup_status}"
+    fi
+  done < <(jq -r '.images[] | [.repo, .target, .ros_distro, .ref, .digest] | @tsv' release-input/build/build-metadata.json)
+
+  [ "${conflicts}" -eq 0 ] || exit 1
+}
+
+write_outputs() {
+  {
+    echo "release_sha=${release_sha}"
+    echo "publish_latest_aliases=${publish_latest_aliases}"
+    echo "is_stable_release=${is_stable_release}"
+  } >> "${GITHUB_OUTPUT}"
+}
+
+main() {
+  validate_inputs
+  resolve_latest_alias_policy
+  validate_build_run
+  download_build_metadata
+  select_scan_metadata
+  validate_build_metadata_schema
+  validate_metadata_files
+  validate_inventory_coverage
+  validate_upstream_coverage
+  validate_scan_coverage
+  validate_release_rules
+  validate_git_tag
+  validate_registry_conflicts
+  write_outputs
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  main
+fi

--- a/.github/scripts/write_release_notes.sh
+++ b/.github/scripts/write_release_notes.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Write release-metadata.json and release-notes.md from validated metadata.
+set -euo pipefail
+
+: "${VERSION:?VERSION is required}"
+: "${RELEASE_SHA:?RELEASE_SHA is required}"
+: "${DEFAULT_ROS_DISTRO:?DEFAULT_ROS_DISTRO is required}"
+: "${PUBLISH_LATEST_ALIASES:?PUBLISH_LATEST_ALIASES is required}"
+: "${STABLE_RELEASE:?STABLE_RELEASE is required}"
+: "${PACKAGER_SHA:?PACKAGER_SHA is required}"
+
+stable_release="${STABLE_RELEASE}"
+tab=$(printf "\t")
+bundles_file=$(mktemp)
+trap 'rm -f "${bundles_file}"' EXIT
+
+for bundle in dist/*.tar.gz; do
+  [ -f "${bundle}" ] || {
+    echo "No release bundles found under dist/" >&2
+    exit 1
+  }
+  jq -n \
+    --arg name "$(basename "${bundle}")" \
+    --arg sha256 "$(sha256sum "${bundle}" | cut -d ' ' -f1)" \
+    '{name: $name, sha256: $sha256}'
+done | jq -s 'sort_by(.name)' >"${bundles_file}"
+
+jq \
+  --arg version "${VERSION}" \
+  --arg release_sha "${RELEASE_SHA}" \
+  --arg default_ros_distro "${DEFAULT_ROS_DISTRO}" \
+  --arg packager_sha "${PACKAGER_SHA}" \
+  --argjson publish_latest_aliases "${PUBLISH_LATEST_ALIASES}" \
+  --slurpfile bundles "${bundles_file}" \
+  --slurpfile scan release-input/scan/scan-metadata.json \
+  '. + {openadkit_version: $version, release_sha: $release_sha, default_ros_distro: $default_ros_distro, packager_sha: $packager_sha, bundles: $bundles[0], latest_aliases_updated: $publish_latest_aliases, scan: $scan[0]}' \
+  release-input/build/build-metadata.json > release-metadata.json
+
+jq -e '
+  (.release_sha | test("^[0-9a-f]{40}$")) and
+  (.packager_sha | test("^[0-9a-f]{40}$")) and
+  .release_sha == .openadkit_sha and
+  (.latest_aliases_updated | type == "boolean") and
+  (.bundles | type == "array" and length > 0) and
+  ([.bundles[].name] | length == (unique | length)) and
+  all(.bundles[];
+    (.name | test("^[^/]+\\.tar\\.gz$")) and
+    (.sha256 | test("^[0-9a-f]{64}$"))
+  )
+' release-metadata.json >/dev/null
+
+autoware_input_ref=$(jq -r '.autoware_input_ref' release-metadata.json)
+autoware_ref_type=$(jq -r '.autoware_ref_type' release-metadata.json)
+autoware_ref=$(jq -r '.autoware_ref' release-metadata.json)
+autoware_base_version=$(jq -r '.autoware_base_version' release-metadata.json)
+autoware_lock_sha256=$(jq -r '.autoware_lock_sha256' release-metadata.json)
+upstream_images_sha256=$(jq -r '.upstream_images_sha256' release-metadata.json)
+openadkit_sha=$(jq -r '.openadkit_sha' release-metadata.json)
+build_tag=$(jq -r '.build_tag' release-metadata.json)
+
+{
+  echo '<!-- openadkit-release-workflow:v1 -->'
+  echo ""
+  echo "## Provenance"
+  echo "| Key | Value |"
+  echo "|-----|-------|"
+  echo "| OpenADKit version | \`${VERSION}\` |"
+  echo "| OpenADKit SHA | \`${openadkit_sha}\` |"
+  echo "| Build tag | \`${build_tag}\` |"
+  echo "| Packager SHA | \`${PACKAGER_SHA}\` |"
+  echo "| Autoware input ref | \`${autoware_input_ref}\` |"
+  echo "| Autoware ref type | \`${autoware_ref_type}\` |"
+  echo "| Autoware resolved SHA | \`${autoware_ref}\` |"
+  echo "| Autoware base version | \`${autoware_base_version}\` |"
+  echo "| Autoware lock SHA256 | \`${autoware_lock_sha256}\` |"
+  echo "| Upstream images SHA256 | \`${upstream_images_sha256}\` |"
+  echo ""
+  echo "## Deployment Bundles"
+  echo "| Asset | SHA256 |"
+  echo "|-------|--------|"
+  while IFS="${tab}" read -r name sha256; do
+    printf '| `%s` | `%s` |\n' "${name}" "${sha256}"
+  done < <(jq -r '.bundles[] | [.name, .sha256] | @tsv' release-metadata.json)
+  echo ""
+  echo "## Images"
+  while IFS="${tab}" read -r repo target distro digest; do
+    printf -- "- \`%s:%s-%s-%s\` -> \`%s\`\n" "${repo}" "${target}" "${distro}" "${VERSION}" "${digest}"
+  done < <(jq -r '.images[] | [.repo, .target, .ros_distro, .digest] | @tsv' release-metadata.json)
+
+  if [ "${stable_release}" = "true" ] && [ "${PUBLISH_LATEST_ALIASES}" = "true" ]; then
+    echo ""
+    echo "## Stable Aliases"
+    while IFS="${tab}" read -r repo target distro digest; do
+      printf -- "- \`%s:%s-%s\` -> \`%s\`\n" "${repo}" "${target}" "${distro}" "${digest}"
+      printf -- "- \`%s:%s-%s-latest\` -> \`%s\`\n" "${repo}" "${target}" "${distro}" "${digest}"
+      if [ "${distro}" = "${DEFAULT_ROS_DISTRO}" ]; then
+        printf -- "- \`%s:%s\` -> \`%s\`\n" "${repo}" "${target}" "${digest}"
+        printf -- "- \`%s:%s-latest\` -> \`%s\`\n" "${repo}" "${target}" "${digest}"
+      fi
+    done < <(jq -r '.images[] | [.repo, .target, .ros_distro, .digest] | @tsv' release-metadata.json)
+  elif [ "${stable_release}" = "true" ]; then
+    echo ""
+    echo "## Stable Aliases"
+    echo "Not updated because a newer stable OpenADKit release already exists."
+  fi
+} > release-notes.md

--- a/.github/scripts/write_release_notes.sh
+++ b/.github/scripts/write_release_notes.sh
@@ -1,48 +1,78 @@
 #!/usr/bin/env bash
-# Write release-metadata.json and release-notes.md from validated metadata.
+# Write release metadata and notes from the immutable release plan.
 set -euo pipefail
 
-: "${VERSION:?VERSION is required}"
-: "${RELEASE_SHA:?RELEASE_SHA is required}"
-: "${DEFAULT_ROS_DISTRO:?DEFAULT_ROS_DISTRO is required}"
-: "${PUBLISH_LATEST_ALIASES:?PUBLISH_LATEST_ALIASES is required}"
-: "${STABLE_RELEASE:?STABLE_RELEASE is required}"
-: "${PACKAGER_SHA:?PACKAGER_SHA is required}"
+plan_file=${RELEASE_PLAN_FILE:-release-plan.json}
+jq -e '
+  .schemaVersion == 1 and
+  (.release.version | type == "string") and
+  (.release.releaseSha | test("^[0-9a-f]{40}$")) and
+  (.release.packagerSha | test("^[0-9a-f]{40}$")) and
+  (.bundle.asset | type == "string") and
+  (.bundle.root | type == "string") and
+  (.releaseContext.images.humble | length == 8) and
+  (.releaseContext.images.jazzy | length == 8) and
+  (.releaseContext.deployments | length == 3) and
+  (.releaseContext.shared | length == 1)
+' "${plan_file}" >/dev/null
 
-stable_release="${STABLE_RELEASE}"
-tab=$(printf "\t")
-bundles_file=$(mktemp)
-trap 'rm -f "${bundles_file}"' EXIT
+VERSION=$(jq -r '.release.version' "${plan_file}")
+RELEASE_SHA=$(jq -r '.release.releaseSha' "${plan_file}")
+DEFAULT_ROS_DISTRO=$(jq -r '.release.defaultRosDistro' "${plan_file}")
+PACKAGER_SHA=$(jq -r '.release.packagerSha' "${plan_file}")
+PUBLISH_LATEST_ALIASES=$(jq -r '.release.publishLatestAliases' "${plan_file}")
+bundle_name=$(jq -r '.bundle.asset' "${plan_file}")
+bundle_root=$(jq -r '.bundle.root' "${plan_file}")
+bundle="dist/${bundle_name}"
 
-for bundle in dist/*.tar.gz; do
-  [ -f "${bundle}" ] || {
-    echo "No release bundles found under dist/" >&2
-    exit 1
-  }
-  jq -n \
-    --arg name "$(basename "${bundle}")" \
-    --arg sha256 "$(sha256sum "${bundle}" | cut -d ' ' -f1)" \
-    '{name: $name, sha256: $sha256}'
-done | jq -s 'sort_by(.name)' >"${bundles_file}"
+[ -f "${bundle}" ] || {
+  echo "Expected release bundle is missing: ${bundle}" >&2
+  exit 1
+}
+mapfile -t archives < <(find dist -maxdepth 1 -type f -name '*.tar.gz' -printf '%f\n' | sort)
+if [ "${#archives[@]}" -ne 1 ] || [ "${archives[0]}" != "${bundle_name}" ]; then
+  echo "dist/ must contain exactly the planned release bundle" >&2
+  exit 1
+fi
 
+temporary=$(mktemp -d)
+trap 'rm -rf "${temporary}"' EXIT
+tar -xOf "${bundle}" "${bundle_root}/openadkit.d/context.json" \
+  | jq -S . >"${temporary}/bundle-context.json"
+jq -S '.releaseContext' "${plan_file}" >"${temporary}/plan-context.json"
+cmp "${temporary}/plan-context.json" "${temporary}/bundle-context.json"
+
+bundle_sha256=$(sha256sum "${bundle}" | cut -d ' ' -f1)
+plan_sha256=$(sha256sum "${plan_file}" | cut -d ' ' -f1)
 jq \
   --arg version "${VERSION}" \
   --arg release_sha "${RELEASE_SHA}" \
   --arg default_ros_distro "${DEFAULT_ROS_DISTRO}" \
   --arg packager_sha "${PACKAGER_SHA}" \
+  --arg plan_sha256 "${plan_sha256}" \
+  --arg bundle_name "${bundle_name}" \
+  --arg bundle_sha256 "${bundle_sha256}" \
   --argjson publish_latest_aliases "${PUBLISH_LATEST_ALIASES}" \
-  --slurpfile bundles "${bundles_file}" \
   --slurpfile scan release-input/scan/scan-metadata.json \
-  '. + {openadkit_version: $version, release_sha: $release_sha, default_ros_distro: $default_ros_distro, packager_sha: $packager_sha, bundles: $bundles[0], latest_aliases_updated: $publish_latest_aliases, scan: $scan[0]}' \
-  release-input/build/build-metadata.json > release-metadata.json
+  '. + {
+    openadkit_version: $version,
+    release_sha: $release_sha,
+    default_ros_distro: $default_ros_distro,
+    packager_sha: $packager_sha,
+    release_plan_sha256: $plan_sha256,
+    bundles: [{name: $bundle_name, sha256: $bundle_sha256}],
+    latest_aliases_updated: $publish_latest_aliases,
+    scan: $scan[0]
+  }' \
+  release-input/build/build-metadata.json >release-metadata.json
 
 jq -e '
   (.release_sha | test("^[0-9a-f]{40}$")) and
   (.packager_sha | test("^[0-9a-f]{40}$")) and
+  (.release_plan_sha256 | test("^[0-9a-f]{64}$")) and
   .release_sha == .openadkit_sha and
   (.latest_aliases_updated | type == "boolean") and
-  (.bundles | type == "array" and length > 0) and
-  ([.bundles[].name] | length == (unique | length)) and
+  (.bundles | type == "array" and length == 1) and
   all(.bundles[];
     (.name | test("^[^/]+\\.tar\\.gz$")) and
     (.sha256 | test("^[0-9a-f]{64}$"))
@@ -68,6 +98,7 @@ build_tag=$(jq -r '.build_tag' release-metadata.json)
   echo "| OpenADKit SHA | \`${openadkit_sha}\` |"
   echo "| Build tag | \`${build_tag}\` |"
   echo "| Packager SHA | \`${PACKAGER_SHA}\` |"
+  echo "| Release plan SHA256 | \`${plan_sha256}\` |"
   echo "| Autoware input ref | \`${autoware_input_ref}\` |"
   echo "| Autoware ref type | \`${autoware_ref_type}\` |"
   echo "| Autoware resolved SHA | \`${autoware_ref}\` |"
@@ -75,32 +106,25 @@ build_tag=$(jq -r '.build_tag' release-metadata.json)
   echo "| Autoware lock SHA256 | \`${autoware_lock_sha256}\` |"
   echo "| Upstream images SHA256 | \`${upstream_images_sha256}\` |"
   echo ""
-  echo "## Deployment Bundles"
+  echo "## Open AD Kit Bundle"
   echo "| Asset | SHA256 |"
   echo "|-------|--------|"
-  while IFS="${tab}" read -r name sha256; do
-    printf '| `%s` | `%s` |\n' "${name}" "${sha256}"
-  done < <(jq -r '.bundles[] | [.name, .sha256] | @tsv' release-metadata.json)
+  printf '%s\n' "| \`${bundle_name}\` | \`${bundle_sha256}\` |"
   echo ""
   echo "## Images"
-  while IFS="${tab}" read -r repo target distro digest; do
-    printf -- "- \`%s:%s-%s-%s\` -> \`%s\`\n" "${repo}" "${target}" "${distro}" "${VERSION}" "${digest}"
-  done < <(jq -r '.images[] | [.repo, .target, .ros_distro, .digest] | @tsv' release-metadata.json)
+  while IFS=$'\t' read -r release_ref digest; do
+    printf '%s\n' "- \`${release_ref}\` -> \`${digest}\`"
+  done < <(jq -r '.images[] | [.releaseRef, .digest] | @tsv' "${plan_file}")
 
-  if [ "${stable_release}" = "true" ] && [ "${PUBLISH_LATEST_ALIASES}" = "true" ]; then
+  if [ "${PUBLISH_LATEST_ALIASES}" = true ]; then
     echo ""
     echo "## Stable Aliases"
-    while IFS="${tab}" read -r repo target distro digest; do
-      printf -- "- \`%s:%s-%s\` -> \`%s\`\n" "${repo}" "${target}" "${distro}" "${digest}"
-      printf -- "- \`%s:%s-%s-latest\` -> \`%s\`\n" "${repo}" "${target}" "${distro}" "${digest}"
-      if [ "${distro}" = "${DEFAULT_ROS_DISTRO}" ]; then
-        printf -- "- \`%s:%s\` -> \`%s\`\n" "${repo}" "${target}" "${digest}"
-        printf -- "- \`%s:%s-latest\` -> \`%s\`\n" "${repo}" "${target}" "${digest}"
-      fi
-    done < <(jq -r '.images[] | [.repo, .target, .ros_distro, .digest] | @tsv' release-metadata.json)
-  elif [ "${stable_release}" = "true" ]; then
+    while IFS=$'\t' read -r alias digest; do
+      printf '%s\n' "- \`${alias}\` -> \`${digest}\`"
+    done < <(jq -r '.images[] | .digest as $digest | .aliases[] | [., $digest] | @tsv' "${plan_file}")
+  elif [ "$(jq -r '.release.stable' "${plan_file}")" = true ]; then
     echo ""
     echo "## Stable Aliases"
     echo "Not updated because a newer stable OpenADKit release already exists."
   fi
-} > release-notes.md
+} >release-notes.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,6 +91,7 @@ jobs:
       contents: read
     outputs:
       packager_sha: ${{ steps.packager.outputs.packager_sha }}
+      release_plan_sha256: ${{ steps.package.outputs.release_plan_sha256 }}
     steps:
       - name: Check out release scripts
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -99,7 +100,7 @@ jobs:
           sparse-checkout: |
             .github/scripts/install-compose.sh
             .github/scripts/package_release_bundles.sh
-            .github/scripts/registry_lookup.sh
+            .github/scripts/release_plan.py
 
       - name: Verify packager revision
         id: packager
@@ -121,7 +122,8 @@ jobs:
           ref: ${{ needs.validate.outputs.release_sha }}
           path: src
           sparse-checkout: |
-            install.sh
+            openadkit
+            openadkit.d
             deployments
 
       - name: Download validated release metadata
@@ -139,17 +141,27 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Package and validate deployment bundles
+        id: package
         env:
           VERSION: ${{ inputs.version }}
+          RELEASE_SHA: ${{ needs.validate.outputs.release_sha }}
+          PACKAGER_SHA: ${{ steps.packager.outputs.packager_sha }}
           DEFAULT_ROS_DISTRO: ${{ inputs.default_ros_distro }}
-        run: bash .github/scripts/package_release_bundles.sh
+          PUBLISH_LATEST_ALIASES: ${{ needs.validate.outputs.publish_latest_aliases }}
+          STABLE_RELEASE: ${{ needs.validate.outputs.is_stable_release }}
+        run: |
+          bash .github/scripts/package_release_bundles.sh
+          echo "release_plan_sha256=$(sha256sum release-plan.json | cut -d ' ' -f1)" \
+            >> "${GITHUB_OUTPUT}"
         shell: bash
 
       - name: Upload deployment bundles
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-bundles-${{ inputs.build_tag }}
-          path: dist/*.tar.gz
+          path: |
+            release-plan.json
+            dist/openadkit-${{ inputs.version }}.tar.gz
           if-no-files-found: error
           retention-days: 7
           overwrite: true
@@ -168,18 +180,30 @@ jobs:
           ref: ${{ github.workflow_sha }}
           sparse-checkout: .github/scripts/release_tag.sh
 
+      - name: Download immutable release plan
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-bundles-${{ inputs.build_tag }}
+          path: release-output
+
       - name: Create or verify git tag
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          VERSION: ${{ inputs.version }}
-          RELEASE_SHA: ${{ needs.validate.outputs.release_sha }}
-        run: bash .github/scripts/release_tag.sh
+          EXPECTED_PLAN_SHA256: ${{ needs.package-bundles.outputs.release_plan_sha256 }}
+        run: |
+          set -euo pipefail
+          plan=release-output/release-plan.json
+          test "$(sha256sum "${plan}" | cut -d ' ' -f1)" = "${EXPECTED_PLAN_SHA256}"
+          VERSION=$(jq -r '.release.version' "${plan}")
+          RELEASE_SHA=$(jq -r '.release.releaseSha' "${plan}")
+          export VERSION RELEASE_SHA
+          bash .github/scripts/release_tag.sh
         shell: bash
 
   release-images:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    needs: [validate, prepare-github-release]
+    needs: [validate, package-bundles, prepare-github-release]
     environment: release
     permissions:
       actions: read
@@ -195,11 +219,18 @@ jobs:
             .github/scripts/registry_lookup.sh
             .github/scripts/stable_alias_policy.sh
 
-      - name: Download validated release metadata
+      - name: Download immutable release plan
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: validated-release-${{ inputs.build_tag }}
-          path: release-input
+          name: release-bundles-${{ inputs.build_tag }}
+          path: release-output
+
+      - name: Verify immutable release plan
+        env:
+          EXPECTED_PLAN_SHA256: ${{ needs.package-bundles.outputs.release_plan_sha256 }}
+        run: |
+          test "$(sha256sum release-output/release-plan.json | cut -d ' ' -f1)" \
+            = "${EXPECTED_PLAN_SHA256}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -213,11 +244,8 @@ jobs:
 
       - name: Promote image digests
         env:
-          VERSION: ${{ inputs.version }}
-          DEFAULT_ROS_DISTRO: ${{ inputs.default_ros_distro }}
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          PUBLISH_LATEST_ALIASES: ${{ needs.validate.outputs.publish_latest_aliases }}
-          STABLE_RELEASE: ${{ needs.validate.outputs.is_stable_release }}
+          RELEASE_PLAN_FILE: release-output/release-plan.json
         run: bash .github/scripts/promote_release_images.sh
         shell: bash
 
@@ -253,16 +281,18 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: release-bundles-${{ inputs.build_tag }}
-          path: dist
+          path: .
+
+      - name: Verify immutable release plan
+        env:
+          EXPECTED_PLAN_SHA256: ${{ needs.package-bundles.outputs.release_plan_sha256 }}
+        run: |
+          test "$(sha256sum release-plan.json | cut -d ' ' -f1)" \
+            = "${EXPECTED_PLAN_SHA256}"
 
       - name: Create release metadata and notes
         env:
-          VERSION: ${{ inputs.version }}
-          RELEASE_SHA: ${{ needs.validate.outputs.release_sha }}
-          DEFAULT_ROS_DISTRO: ${{ inputs.default_ros_distro }}
-          PACKAGER_SHA: ${{ needs.package-bundles.outputs.packager_sha }}
-          PUBLISH_LATEST_ALIASES: ${{ needs.validate.outputs.publish_latest_aliases }}
-          STABLE_RELEASE: ${{ needs.validate.outputs.is_stable_release }}
+          RELEASE_PLAN_FILE: release-plan.json
         run: bash .github/scripts/write_release_notes.sh
         shell: bash
 
@@ -270,9 +300,7 @@ jobs:
         id: prepare-release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          VERSION: ${{ inputs.version }}
-          RELEASE_SHA: ${{ needs.validate.outputs.release_sha }}
-          STABLE_RELEASE: ${{ needs.validate.outputs.is_stable_release }}
+          RELEASE_PLAN_FILE: release-plan.json
         run: bash .github/scripts/manage_github_release.sh prepare
         shell: bash
 
@@ -288,7 +316,7 @@ jobs:
   release-github:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
-    needs: [validate, prepare-github-release, release-images]
+    needs: [validate, package-bundles, prepare-github-release, release-images]
     environment: release
     permissions:
       actions: read
@@ -308,16 +336,26 @@ jobs:
           name: release-asset-manifest-${{ inputs.build_tag }}
           path: release-asset-manifest
 
+      - name: Download immutable release plan
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-bundles-${{ inputs.build_tag }}
+          path: release-output
+
+      - name: Verify immutable release plan
+        env:
+          EXPECTED_PLAN_SHA256: ${{ needs.package-bundles.outputs.release_plan_sha256 }}
+        run: |
+          test "$(sha256sum release-output/release-plan.json | cut -d ' ' -f1)" \
+            = "${EXPECTED_PLAN_SHA256}"
+
       - name: Publish prepared GitHub Release
         if: needs.prepare-github-release.outputs.created == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          VERSION: ${{ inputs.version }}
           RELEASE_ID: ${{ needs.prepare-github-release.outputs.release_id }}
           RELEASE_BODY_SHA256: ${{ needs.prepare-github-release.outputs.release_body_sha256 }}
           RELEASE_ASSET_MANIFEST: release-asset-manifest/release-assets.sha256
-          RELEASE_SHA: ${{ needs.validate.outputs.release_sha }}
-          PUBLISH_LATEST_ALIASES: ${{ needs.validate.outputs.publish_latest_aliases }}
-          STABLE_RELEASE: ${{ needs.validate.outputs.is_stable_release }}
+          RELEASE_PLAN_FILE: release-output/release-plan.json
         run: bash .github/scripts/manage_github_release.sh publish
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,14 @@ on:
       build_tag:
         description: 'Build tag to promote (e.g. 123456789-1)'
         required: true
+      default_ros_distro:
+        description: 'ROS distro to use for bare tag aliases'
+        required: false
+        type: choice
+        options:
+          - humble
+          - jazzy
+        default: humble
 
 concurrency:
   group: release
@@ -22,11 +30,11 @@ env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX_COMMON: ghcr.io/${{ github.repository_owner }}/openadkit-common
   IMAGE_PREFIX_COMPONENT: ghcr.io/${{ github.repository_owner }}/openadkit
-  DEFAULT_ROS_DISTRO: humble
 
 jobs:
   validate:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     permissions:
       actions: read
       contents: read
@@ -34,12 +42,23 @@ jobs:
     outputs:
       release_sha: ${{ steps.validate.outputs.release_sha }}
       publish_latest_aliases: ${{ steps.validate.outputs.publish_latest_aliases }}
+      is_stable_release: ${{ steps.validate.outputs.is_stable_release }}
     steps:
+      - name: Check out release scripts
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          sparse-checkout: |
+            .github/scripts/release_tag.sh
+            .github/scripts/registry_lookup.sh
+            .github/scripts/stable_alias_policy.sh
+            .github/scripts/validate_release.sh
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -50,367 +69,143 @@ jobs:
         env:
           BUILD_TAG: ${{ inputs.build_tag }}
           VERSION: ${{ inputs.version }}
+          DEFAULT_ROS_DISTRO: ${{ inputs.default_ros_distro }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          openadkit_semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z]*))*)?$'
-          openadkit_stable_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
-          autoware_stable_re='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
-
-          if ! printf '%s\n' "${VERSION}" | grep -Eq "${openadkit_semver_re}"; then
-            echo "Invalid version format '${VERSION}': must be strict SemVer vX.Y.Z or vX.Y.Z-prerelease" >&2
-            exit 1
-          fi
-          if ! printf '%s\n' "${BUILD_TAG}" | grep -Eq '^[0-9]+-[0-9]+$'; then
-            echo "Invalid build_tag format '${BUILD_TAG}': must be RUN_ID-RUN_ATTEMPT" >&2
-            exit 1
-          fi
-          [ "${GITHUB_REF}" = "refs/heads/main" ] \
-            || (echo "Release must be triggered from main branch (got ${GITHUB_REF})" >&2 && exit 1)
-
-          publish_latest_aliases=false
-          if printf '%s\n' "${VERSION}" | grep -Eq "${openadkit_stable_re}"; then
-            existing_tag_refs=$(
-              gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/v" \
-                --jq '.[].ref | sub("^refs/tags/"; "")'
-            )
-            existing_stable_tags=$(
-              printf '%s\n' "${existing_tag_refs}" | grep -E "${openadkit_stable_re}" || true
-            )
-            highest_stable=$(
-              {
-                printf '%s\n' "${VERSION}"
-                printf '%s\n' "${existing_stable_tags}"
-              } | grep -E "${openadkit_stable_re}" | sort -V | tail -n 1
-            )
-            if [ "${highest_stable}" = "${VERSION}" ]; then
-              publish_latest_aliases=true
-            else
-              echo "Stable aliases will not be updated: ${highest_stable} is newer than ${VERSION}"
-            fi
-          fi
-
-          run_id="${BUILD_TAG%%-*}"
-          run_attempt="${BUILD_TAG##*-}"
-          run_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/attempts/${run_attempt}")
-
-          workflow_name=$(printf '%s' "${run_json}" | jq -r '.name')
-          workflow_path=$(printf '%s' "${run_json}" | jq -r '.path')
-          head_branch=$(printf '%s' "${run_json}" | jq -r '.head_branch')
-          status=$(printf '%s' "${run_json}" | jq -r '.status')
-          conclusion=$(printf '%s' "${run_json}" | jq -r '.conclusion')
-          release_sha=$(printf '%s' "${run_json}" | jq -r '.head_sha')
-          created_at=$(printf '%s' "${run_json}" | jq -r '.created_at')
-
-          [ "${workflow_name}" = "build-all-images" ] || (echo "Expected build-all-images run, got '${workflow_name}'" >&2 && exit 1)
-          [ "${workflow_path}" = ".github/workflows/build-all-images.yaml" ] || (echo "Unexpected workflow path '${workflow_path}'" >&2 && exit 1)
-          [ "${head_branch}" = "main" ] || (echo "Source build must come from main branch (got '${head_branch}')" >&2 && exit 1)
-          [ "${status}" = "completed" ] || (echo "Source build must be completed (got '${status}')" >&2 && exit 1)
-          [ "${conclusion}" = "success" ] || (echo "Source build must succeed (got '${conclusion}')" >&2 && exit 1)
-
-          created_epoch=$(date -u -d "${created_at}" +%s)
-          now_epoch=$(date -u +%s)
-          max_age_seconds=$((90 * 24 * 60 * 60))
-          if [ $((now_epoch - created_epoch)) -gt "${max_age_seconds}" ]; then
-            echo "Build ${BUILD_TAG} is older than 90 days and is no longer promotable" >&2
-            exit 1
-          fi
-
-          mkdir -p release-input/build release-input/scan
-          gh run download "${run_id}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --name "build-metadata-${BUILD_TAG}" \
-            --dir release-input/build
-
-          scan_artifact_ids=$(
-            gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=scan-metadata-${BUILD_TAG}" \
-              --jq '.artifacts[] | select(.expired == false) | [.id, .created_at] | @tsv' \
-              | sort -k2,2r \
-              | cut -f1
-          )
-          [ -n "${scan_artifact_ids}" ] || (echo "No non-expired full scan metadata found for ${BUILD_TAG}" >&2 && exit 1)
-
-          selected_scan_artifact_id=""
-          selected_scan_run_id=""
-          selected_scan_run_attempt=""
-          selected_scan_status=""
-          selected_scan_conclusion=""
-          while IFS= read -r scan_artifact_id; do
-            [ -n "${scan_artifact_id}" ] || continue
-
-            rm -rf release-input/scan
-            mkdir -p release-input/scan
-            rm -f scan-metadata.zip
-
-            artifact_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${scan_artifact_id}")
-            artifact_run_id=$(printf '%s' "${artifact_json}" | jq -r '.workflow_run.id // empty')
-            gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${scan_artifact_id}/zip" > scan-metadata.zip
-            unzip -q scan-metadata.zip -d release-input/scan
-
-            if ! jq -e --arg build_tag "${BUILD_TAG}" '
-              .build_tag == $build_tag and
-              .scan_scope == "all" and
-              (.scan_status == "passed" or .scan_status == "failed") and
-              (.run_id | test("^[0-9]+$")) and
-              (.run_attempt | test("^[0-9]+$")) and
-              (.scanned_images | type == "array" and length > 0) and
-              all(.scanned_images[];
-                (.repo | type == "string" and length > 0) and
-                (.target | type == "string" and length > 0) and
-                (.ros_distro | type == "string" and length > 0) and
-                (.digest | test("^sha256:[0-9a-f]{64}$")) and
-                (.platform | test("^linux/(amd64|arm64)$")) and
-                (.image_ref == (.repo + "@" + .digest))
-              )
-            ' release-input/scan/scan-metadata.json >/dev/null 2>&1; then
-              echo "Ignoring scan artifact ${scan_artifact_id}: metadata is not full scan metadata for ${BUILD_TAG}" >&2
-              continue
-            fi
-
-            scan_run_id=$(jq -r '.run_id' release-input/scan/scan-metadata.json)
-            scan_run_attempt=$(jq -r '.run_attempt' release-input/scan/scan-metadata.json)
-            if [ "${artifact_run_id}" != "${scan_run_id}" ]; then
-              echo "Ignoring scan artifact ${scan_artifact_id}: artifact run ${artifact_run_id} does not match metadata run ${scan_run_id}" >&2
-              continue
-            fi
-
-            if ! scan_run_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${scan_run_id}/attempts/${scan_run_attempt}" 2>/dev/null); then
-              echo "Ignoring scan artifact ${scan_artifact_id}: could not read scan run ${scan_run_id}-${scan_run_attempt}" >&2
-              continue
-            fi
-
-            scan_workflow_name=$(printf '%s' "${scan_run_json}" | jq -r '.name')
-            scan_workflow_path=$(printf '%s' "${scan_run_json}" | jq -r '.path')
-            scan_head_branch=$(printf '%s' "${scan_run_json}" | jq -r '.head_branch')
-            scan_status=$(printf '%s' "${scan_run_json}" | jq -r '.status')
-            scan_conclusion=$(printf '%s' "${scan_run_json}" | jq -r '.conclusion')
-
-            if [ "${scan_workflow_name}" != "scan-images" ] || \
-              [ "${scan_workflow_path}" != ".github/workflows/scan.yaml" ] || \
-              [ "${scan_head_branch}" != "main" ] || \
-              [ "${scan_status}" != "completed" ]; then
-              echo "Ignoring scan artifact ${scan_artifact_id}: scan run ${scan_run_id}-${scan_run_attempt} is not a completed scan-images run on main" >&2
-              continue
-            fi
-
-            selected_scan_artifact_id="${scan_artifact_id}"
-            selected_scan_run_id="${scan_run_id}"
-            selected_scan_run_attempt="${scan_run_attempt}"
-            selected_scan_status=$(jq -r '.scan_status' release-input/scan/scan-metadata.json)
-            selected_scan_conclusion="${scan_conclusion}"
-            break
-          done <<< "${scan_artifact_ids}"
-
-          [ -n "${selected_scan_artifact_id}" ] || (echo "No validated full scan metadata found for ${BUILD_TAG}" >&2 && exit 1)
-          if [ "${selected_scan_status}" != "passed" ] || [ "${selected_scan_conclusion}" != "success" ]; then
-            echo "Latest full scan for ${BUILD_TAG} did not pass: scan run ${selected_scan_run_id}-${selected_scan_run_attempt} has metadata status '${selected_scan_status}' and conclusion '${selected_scan_conclusion}'" >&2
-            exit 1
-          fi
-
-          if ! jq -e \
-            --arg build_tag "${BUILD_TAG}" \
-            --arg run_id "${run_id}" \
-            --arg run_attempt "${run_attempt}" '
-            .build_tag == $build_tag and
-            .run_id == $run_id and
-            .run_attempt == $run_attempt and
-            (.openadkit_sha | test("^[0-9a-f]{40}$")) and
-            (.autoware_input_ref | type == "string" and length > 0) and
-            (.autoware_ref_type as $type | ["branch", "tag", "sha", "ref"] | index($type) != null) and
-            (.autoware_ref | test("^[0-9a-f]{40}$")) and
-            (.autoware_base_version | test("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$")) and
-            (.autoware_lock_sha256 | test("^[0-9a-f]{64}$")) and
-            (.image_inventory_sha256 | test("^[0-9a-f]{64}$")) and
-            (.scan_requested | type == "boolean") and
-            (.images | type == "array" and length > 0) and
-            all(.images[];
-              (.repo | type == "string" and length > 0) and
-              (.target | type == "string" and length > 0) and
-              (.ros_distro | type == "string" and length > 0) and
-              (.digest | test("^sha256:[0-9a-f]{64}$")) and
-              (.ref == (.repo + ":" + .target + "-" + .ros_distro + "-" + $build_tag)) and
-              (.platforms | type == "array" and length > 0) and
-              all(.platforms[]; test("^linux/(amd64|arm64)$"))
-            )
-          ' release-input/build/build-metadata.json >/dev/null; then
-            echo "Build metadata failed schema validation" >&2
-            exit 1
-          fi
-
-          if [ ! -f release-input/build/autoware-lock.repos ]; then
-            echo "Build metadata is missing autoware-lock.repos" >&2
-            exit 1
-          fi
-          metadata_lock_sha=$(jq -r '.autoware_lock_sha256' release-input/build/build-metadata.json)
-          actual_lock_sha=$(sha256sum release-input/build/autoware-lock.repos | cut -d ' ' -f1)
-          [ "${actual_lock_sha}" = "${metadata_lock_sha}" ] \
-            || (echo "Autoware lock SHA ${actual_lock_sha} does not match metadata SHA ${metadata_lock_sha}" >&2 && exit 1)
-
-          if [ ! -f release-input/build/image-inventory.json ]; then
-            echo "Build metadata is missing image-inventory.json" >&2
-            exit 1
-          fi
-          metadata_inventory_sha=$(jq -r '.image_inventory_sha256' release-input/build/build-metadata.json)
-          actual_inventory_sha=$(sha256sum release-input/build/image-inventory.json | cut -d ' ' -f1)
-          [ "${actual_inventory_sha}" = "${metadata_inventory_sha}" ] \
-            || (echo "Image inventory SHA ${actual_inventory_sha} does not match metadata SHA ${metadata_inventory_sha}" >&2 && exit 1)
-
-          expected_inventory=$(mktemp)
-          actual_inventory=$(mktemp)
-          jq -r \
-            --arg common_repo "${IMAGE_PREFIX_COMMON}" \
-            --arg component_repo "${IMAGE_PREFIX_COMPONENT}" '
-            def repo_for($kind): if $kind == "common" then $common_repo elif $kind == "component" then $component_repo else error("unsupported repo kind") end;
-            def image_distros($global): (.ros_distros // $global)[];
-            .ros_distros as $global |
-            .images[] |
-            image_distros($global)[] as $distro |
-            [repo_for(.repo), .target, $distro, (.platforms | sort | join(","))] |
-            @tsv
-          ' release-input/build/image-inventory.json | sort -u > "${expected_inventory}"
-          jq -r '
-            .images[] |
-            [.repo, .target, .ros_distro, (.platforms | sort | join(","))] |
-            @tsv
-          ' release-input/build/build-metadata.json | sort -u > "${actual_inventory}"
-
-          expected_count=$(wc -l < "${expected_inventory}" | tr -d ' ')
-          actual_count=$(jq -r '.images | length' release-input/build/build-metadata.json)
-          actual_unique_count=$(wc -l < "${actual_inventory}" | tr -d ' ')
-          missing_inventory=$(comm -23 "${expected_inventory}" "${actual_inventory}" || true)
-          extra_inventory=$(comm -13 "${expected_inventory}" "${actual_inventory}" || true)
-          rm -f "${expected_inventory}" "${actual_inventory}"
-          if [ "${actual_count}" != "${actual_unique_count}" ]; then
-            echo "Build metadata contains duplicate image entries" >&2
-            exit 1
-          fi
-          if [ "${actual_count}" != "${expected_count}" ]; then
-            echo "Build metadata image count ${actual_count} does not match inventory count ${expected_count}" >&2
-            exit 1
-          fi
-          if [ -n "${missing_inventory}" ]; then
-            echo "Build metadata is missing inventory entries:" >&2
-            printf '%s\n' "${missing_inventory}" >&2
-            exit 1
-          fi
-          if [ -n "${extra_inventory}" ]; then
-            echo "Build metadata contains entries outside inventory:" >&2
-            printf '%s\n' "${extra_inventory}" >&2
-            exit 1
-          fi
-
-          build_coverage=$(mktemp)
-          scan_coverage=$(mktemp)
-          jq -r '
-            .images[] as $image |
-            $image.platforms[] |
-            [$image.repo, $image.target, $image.ros_distro, $image.digest, .] |
-            @tsv
-          ' release-input/build/build-metadata.json | sort -u > "${build_coverage}"
-          jq -r '
-            .scanned_images[] |
-            [.repo, .target, .ros_distro, .digest, .platform] |
-            @tsv
-          ' release-input/scan/scan-metadata.json | sort -u > "${scan_coverage}"
-
-          missing_coverage=$(comm -23 "${build_coverage}" "${scan_coverage}" || true)
-          extra_coverage=$(comm -13 "${build_coverage}" "${scan_coverage}" || true)
-          rm -f "${build_coverage}" "${scan_coverage}"
-          if [ -n "${missing_coverage}" ]; then
-            echo "Scan metadata is missing build digest/platform coverage:" >&2
-            printf '%s\n' "${missing_coverage}" >&2
-            exit 1
-          fi
-          if [ -n "${extra_coverage}" ]; then
-            echo "Scan metadata contains digest/platform entries outside build metadata:" >&2
-            printf '%s\n' "${extra_coverage}" >&2
-            exit 1
-          fi
-
-          metadata_sha=$(jq -r '.openadkit_sha' release-input/build/build-metadata.json)
-          [ "${metadata_sha}" = "${release_sha}" ] \
-            || (echo "Build metadata SHA ${metadata_sha} does not match workflow SHA ${release_sha}" >&2 && exit 1)
-
-          autoware_input_ref=$(jq -r '.autoware_input_ref' release-input/build/build-metadata.json)
-          autoware_ref_type=$(jq -r '.autoware_ref_type' release-input/build/build-metadata.json)
-          autoware_base_version=$(jq -r '.autoware_base_version' release-input/build/build-metadata.json)
-          if printf '%s\n' "${VERSION}" | grep -Eq "${openadkit_stable_re}"; then
-            if [ "${autoware_ref_type}" != "tag" ] || ! printf '%s\n' "${autoware_input_ref}" | grep -Eq "${autoware_stable_re}"; then
-              echo "Stable releases must be built from an Autoware release tag (got ${autoware_ref_type}:${autoware_input_ref})" >&2
-              exit 1
-            fi
-            if [ "${autoware_base_version}" != "${autoware_input_ref}" ]; then
-              echo "Autoware base version ${autoware_base_version} does not match release tag ${autoware_input_ref}" >&2
-              exit 1
-            fi
-          else
-            if [ "${autoware_ref_type}" = "tag" ] && ! printf '%s\n' "${autoware_input_ref}" | grep -Eq "${autoware_stable_re}"; then
-              echo "Pre-release Autoware tags must use X.Y.Z format (got ${autoware_input_ref})" >&2
-              exit 1
-            elif [ "${autoware_ref_type}" != "tag" ] && [ "${autoware_ref_type}" != "sha" ]; then
-              echo "Pre-releases must be built from an Autoware release tag or full SHA (got ${autoware_ref_type}:${autoware_input_ref})" >&2
-              exit 1
-            fi
-          fi
-
-          tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${VERSION}" --jq '.object.sha' 2>/dev/null || true)
-          if [ -n "${tag_sha}" ] && [ "${tag_sha}" != "${release_sha}" ]; then
-            echo "Tag ${VERSION} already exists at ${tag_sha}, expected ${release_sha}" >&2
-            exit 1
-          fi
-
-          conflicts=0
-          while IFS=$'\t' read -r repo target distro ref digest; do
-            source_digest=$(docker buildx imagetools inspect "${ref}" --format '{{json .}}' | jq -r '.manifest.digest')
-            if [ "${source_digest}" != "${digest}" ]; then
-              echo "Source digest mismatch for ${ref}: ${source_digest} != ${digest}" >&2
-              conflicts=1
-            fi
-
-            release_ref="${repo}:${target}-${distro}-${VERSION}"
-            if existing_json=$(docker buildx imagetools inspect "${release_ref}" --format '{{json .}}' 2>/dev/null); then
-              existing_digest=$(printf '%s' "${existing_json}" | jq -r '.manifest.digest')
-              if [ "${existing_digest}" != "${digest}" ]; then
-                echo "Release tag conflict: ${release_ref} points to ${existing_digest}, expected ${digest}" >&2
-                conflicts=1
-              fi
-            fi
-          done < <(jq -r '.images[] | [.repo, .target, .ros_distro, .ref, .digest] | @tsv' release-input/build/build-metadata.json)
-
-          [ "${conflicts}" -eq 0 ] || exit 1
-          echo "release_sha=${release_sha}" >> "$GITHUB_OUTPUT"
-          echo "publish_latest_aliases=${publish_latest_aliases}" >> "$GITHUB_OUTPUT"
+        run: bash .github/scripts/validate_release.sh
         shell: bash
 
       - name: Upload validated release metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: validated-release-${{ inputs.build_tag }}
           path: release-input
           retention-days: 7
           overwrite: true
 
+  package-bundles:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    needs: validate
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      packager_sha: ${{ steps.packager.outputs.packager_sha }}
+    steps:
+      - name: Check out release scripts
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          sparse-checkout: |
+            .github/scripts/install-compose.sh
+            .github/scripts/package_release_bundles.sh
+            .github/scripts/registry_lookup.sh
+
+      - name: Verify packager revision
+        id: packager
+        env:
+          EXPECTED_PACKAGER_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          packager_sha=$(git rev-parse HEAD)
+          if [ "${packager_sha}" != "${EXPECTED_PACKAGER_SHA}" ]; then
+            echo "Packager checkout ${packager_sha} does not match workflow ${EXPECTED_PACKAGER_SHA}" >&2
+            exit 1
+          fi
+          echo "packager_sha=${packager_sha}" >> "${GITHUB_OUTPUT}"
+        shell: bash
+
+      - name: Check out repository at release SHA
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ needs.validate.outputs.release_sha }}
+          path: src
+          sparse-checkout: |
+            install.sh
+            deployments
+
+      - name: Download validated release metadata
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: validated-release-${{ inputs.build_tag }}
+          path: release-input
+
+      - name: Install Docker Compose v5.2+
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/install-compose.sh
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Package and validate deployment bundles
+        env:
+          VERSION: ${{ inputs.version }}
+          DEFAULT_ROS_DISTRO: ${{ inputs.default_ros_distro }}
+        run: bash .github/scripts/package_release_bundles.sh
+        shell: bash
+
+      - name: Upload deployment bundles
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-bundles-${{ inputs.build_tag }}
+          path: dist/*.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+          overwrite: true
+
+  release-tag:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    needs: [validate, package-bundles]
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - name: Check out release tag helper
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          sparse-checkout: .github/scripts/release_tag.sh
+
+      - name: Create or verify git tag
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          RELEASE_SHA: ${{ needs.validate.outputs.release_sha }}
+        run: bash .github/scripts/release_tag.sh
+        shell: bash
+
   release-images:
     runs-on: ubuntu-22.04
-    needs: validate
+    timeout-minutes: 30
+    needs: [validate, prepare-github-release]
     environment: release
     permissions:
       actions: read
       contents: read
       packages: write
     steps:
+      - name: Check out release scripts
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          sparse-checkout: |
+            .github/scripts/promote_release_images.sh
+            .github/scripts/registry_lookup.sh
+            .github/scripts/stable_alias_policy.sh
+
       - name: Download validated release metadata
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: validated-release-${{ inputs.build_tag }}
           path: release-input
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -419,194 +214,110 @@ jobs:
       - name: Promote image digests
         env:
           VERSION: ${{ inputs.version }}
-          DEFAULT_ROS_DISTRO: ${{ env.DEFAULT_ROS_DISTRO }}
+          DEFAULT_ROS_DISTRO: ${{ inputs.default_ros_distro }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           PUBLISH_LATEST_ALIASES: ${{ needs.validate.outputs.publish_latest_aliases }}
-        run: |
-          set -euo pipefail
-
-          openadkit_stable_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
-          stable_release=false
-          if printf '%s\n' "${VERSION}" | grep -Eq "${openadkit_stable_re}"; then
-            stable_release=true
-          fi
-
-          promote_tag() {
-            local ref="$1"
-            local repo="$2"
-            local digest="$3"
-            local mode="$4"
-
-            if existing_json=$(docker buildx imagetools inspect "${ref}" --format '{{json .}}' 2>/dev/null); then
-              existing_digest=$(printf '%s' "${existing_json}" | jq -r '.manifest.digest')
-              if [ "${existing_digest}" = "${digest}" ]; then
-                echo "${ref} already points to ${digest}; skipping"
-                return
-              fi
-              if [ "${mode}" = "immutable" ]; then
-                echo "Release tag conflict: ${ref} points to ${existing_digest}, expected ${digest}" >&2
-                exit 1
-              fi
-              echo "Updating ${ref}: ${existing_digest} -> ${digest}"
-            else
-              echo "Promoting ${repo}@${digest} -> ${ref}"
-            fi
-
-            docker buildx imagetools create -t "${ref}" "${repo}@${digest}"
-          }
-
-          while IFS=$'\t' read -r repo target distro digest; do
-            release_ref="${repo}:${target}-${distro}-${VERSION}"
-            promote_tag "${release_ref}" "${repo}" "${digest}" immutable
-
-            if [ "${stable_release}" = "true" ] && [ "${PUBLISH_LATEST_ALIASES}" = "true" ]; then
-              promote_tag "${repo}:${target}-${distro}" "${repo}" "${digest}" alias
-              promote_tag "${repo}:${target}-${distro}-latest" "${repo}" "${digest}" alias
-
-              if [ "${distro}" = "${DEFAULT_ROS_DISTRO}" ]; then
-                promote_tag "${repo}:${target}" "${repo}" "${digest}" alias
-                promote_tag "${repo}:${target}-latest" "${repo}" "${digest}" alias
-              fi
-            fi
-          done < <(jq -r '.images[] | [.repo, .target, .ros_distro, .digest] | @tsv' release-input/build/build-metadata.json)
+          STABLE_RELEASE: ${{ needs.validate.outputs.is_stable_release }}
+        run: bash .github/scripts/promote_release_images.sh
         shell: bash
 
-  release-github:
+  prepare-github-release:
     runs-on: ubuntu-22.04
-    needs: [validate, release-images]
+    timeout-minutes: 15
+    needs: [validate, package-bundles, release-tag]
+    environment: release
     permissions:
       actions: read
       contents: write
+    outputs:
+      created: ${{ steps.prepare-release.outputs.created }}
+      release_body_sha256: ${{ steps.prepare-release.outputs.release_body_sha256 }}
+      release_id: ${{ steps.prepare-release.outputs.release_id }}
     steps:
+      - name: Check out release scripts
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          sparse-checkout: |
+            .github/scripts/manage_github_release.sh
+            .github/scripts/release_tag.sh
+            .github/scripts/write_release_notes.sh
+
       - name: Download validated release metadata
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: validated-release-${{ inputs.build_tag }}
           path: release-input
+
+      - name: Download deployment bundles
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-bundles-${{ inputs.build_tag }}
+          path: dist
 
       - name: Create release metadata and notes
         env:
           VERSION: ${{ inputs.version }}
           RELEASE_SHA: ${{ needs.validate.outputs.release_sha }}
-          DEFAULT_ROS_DISTRO: ${{ env.DEFAULT_ROS_DISTRO }}
+          DEFAULT_ROS_DISTRO: ${{ inputs.default_ros_distro }}
+          PACKAGER_SHA: ${{ needs.package-bundles.outputs.packager_sha }}
           PUBLISH_LATEST_ALIASES: ${{ needs.validate.outputs.publish_latest_aliases }}
-        run: |
-          set -euo pipefail
-
-          openadkit_stable_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
-          stable_release=false
-          if printf '%s\n' "${VERSION}" | grep -Eq "${openadkit_stable_re}"; then
-            stable_release=true
-          fi
-          tab=$(printf "\t")
-
-          jq \
-            --arg version "${VERSION}" \
-            --arg release_sha "${RELEASE_SHA}" \
-            --arg default_ros_distro "${DEFAULT_ROS_DISTRO}" \
-            --argjson publish_latest_aliases "${PUBLISH_LATEST_ALIASES}" \
-            --slurpfile scan release-input/scan/scan-metadata.json \
-            ". + {openadkit_version: \$version, release_sha: \$release_sha, default_ros_distro: \$default_ros_distro, latest_aliases_updated: \$publish_latest_aliases, scan: \$scan[0]}" \
-            release-input/build/build-metadata.json > release-metadata.json
-
-          autoware_input_ref=$(jq -r '.autoware_input_ref' release-metadata.json)
-          autoware_ref_type=$(jq -r '.autoware_ref_type' release-metadata.json)
-          autoware_ref=$(jq -r '.autoware_ref' release-metadata.json)
-          autoware_base_version=$(jq -r '.autoware_base_version' release-metadata.json)
-          autoware_lock_sha256=$(jq -r '.autoware_lock_sha256' release-metadata.json)
-          openadkit_sha=$(jq -r '.openadkit_sha' release-metadata.json)
-          build_tag=$(jq -r '.build_tag' release-metadata.json)
-
-          {
-            echo "## Provenance"
-            echo "| Key | Value |"
-            echo "|-----|-------|"
-            echo "| OpenADKit version | \`${VERSION}\` |"
-            echo "| OpenADKit SHA | \`${openadkit_sha}\` |"
-            echo "| Build tag | \`${build_tag}\` |"
-            echo "| Autoware input ref | \`${autoware_input_ref}\` |"
-            echo "| Autoware ref type | \`${autoware_ref_type}\` |"
-            echo "| Autoware resolved SHA | \`${autoware_ref}\` |"
-            echo "| Autoware base version | \`${autoware_base_version}\` |"
-            echo "| Autoware lock SHA256 | \`${autoware_lock_sha256}\` |"
-            echo ""
-            echo "## Images"
-            while IFS="${tab}" read -r repo target distro digest; do
-              printf -- "- \`%s:%s-%s-%s\` -> \`%s\`\n" "${repo}" "${target}" "${distro}" "${VERSION}" "${digest}"
-            done < <(jq -r ".images[] | [.repo, .target, .ros_distro, .digest] | @tsv" release-metadata.json)
-
-            if [ "${stable_release}" = "true" ] && [ "${PUBLISH_LATEST_ALIASES}" = "true" ]; then
-              echo ""
-              echo "## Stable Aliases"
-              while IFS="${tab}" read -r repo target distro digest; do
-                printf -- "- \`%s:%s-%s\` -> \`%s\`\n" "${repo}" "${target}" "${distro}" "${digest}"
-                printf -- "- \`%s:%s-%s-latest\` -> \`%s\`\n" "${repo}" "${target}" "${distro}" "${digest}"
-                if [ "${distro}" = "${DEFAULT_ROS_DISTRO}" ]; then
-                  printf -- "- \`%s:%s\` -> \`%s\`\n" "${repo}" "${target}" "${digest}"
-                  printf -- "- \`%s:%s-latest\` -> \`%s\`\n" "${repo}" "${target}" "${digest}"
-                fi
-              done < <(jq -r ".images[] | [.repo, .target, .ros_distro, .digest] | @tsv" release-metadata.json)
-            elif [ "${stable_release}" = "true" ]; then
-              echo ""
-              echo "## Stable Aliases"
-              echo "Not updated because a newer stable OpenADKit release already exists."
-            fi
-          } > release-notes.md
+          STABLE_RELEASE: ${{ needs.validate.outputs.is_stable_release }}
+        run: bash .github/scripts/write_release_notes.sh
         shell: bash
 
-      - name: Create or verify git tag
+      - name: Verify existing release or create draft
+        id: prepare-release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
           RELEASE_SHA: ${{ needs.validate.outputs.release_sha }}
-        run: |
-          set -euo pipefail
-
-          tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${VERSION}" --jq '.object.sha' 2>/dev/null || true)
-          if [ -z "${tag_sha}" ]; then
-            gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
-              -f ref="refs/tags/${VERSION}" \
-              -f sha="${RELEASE_SHA}" >/dev/null
-            echo "Created tag ${VERSION} at ${RELEASE_SHA}"
-          elif [ "${tag_sha}" = "${RELEASE_SHA}" ]; then
-            echo "Tag ${VERSION} already exists at ${RELEASE_SHA}; continuing"
-          else
-            echo "Tag ${VERSION} exists at ${tag_sha}, expected ${RELEASE_SHA}" >&2
-            exit 1
-          fi
+          STABLE_RELEASE: ${{ needs.validate.outputs.is_stable_release }}
+        run: bash .github/scripts/manage_github_release.sh prepare
         shell: bash
 
-      - name: Create or update GitHub Release
+      - name: Upload expected release asset manifest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-asset-manifest-${{ inputs.build_tag }}
+          path: release-assets.sha256
+          if-no-files-found: error
+          retention-days: 7
+          overwrite: true
+
+  release-github:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    needs: [validate, prepare-github-release, release-images]
+    environment: release
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Check out release manager
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          sparse-checkout: |
+            .github/scripts/manage_github_release.sh
+            .github/scripts/release_tag.sh
+
+      - name: Download expected release asset manifest
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-asset-manifest-${{ inputs.build_tag }}
+          path: release-asset-manifest
+
+      - name: Publish prepared GitHub Release
+        if: needs.prepare-github-release.outputs.created == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
+          RELEASE_ID: ${{ needs.prepare-github-release.outputs.release_id }}
+          RELEASE_BODY_SHA256: ${{ needs.prepare-github-release.outputs.release_body_sha256 }}
+          RELEASE_ASSET_MANIFEST: release-asset-manifest/release-assets.sha256
           RELEASE_SHA: ${{ needs.validate.outputs.release_sha }}
           PUBLISH_LATEST_ALIASES: ${{ needs.validate.outputs.publish_latest_aliases }}
-        run: |
-          set -euo pipefail
-
-          openadkit_stable_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
-          release_flags=()
-          if printf '%s\n' "${VERSION}" | grep -Eq "${openadkit_stable_re}"; then
-            if [ "${PUBLISH_LATEST_ALIASES}" = "true" ]; then
-              release_flags+=(--latest)
-            else
-              release_flags+=(--latest=false)
-            fi
-          else
-            release_flags+=(--prerelease --latest=false)
-          fi
-
-          if gh release view "${VERSION}" >/dev/null 2>&1; then
-            gh release edit "${VERSION}" \
-              --title "OpenADKit ${VERSION}" \
-              --notes-file release-notes.md \
-              "${release_flags[@]}"
-          else
-            gh release create "${VERSION}" \
-              --target "${RELEASE_SHA}" \
-              --title "OpenADKit ${VERSION}" \
-              --notes-file release-notes.md \
-              "${release_flags[@]}"
-          fi
-          gh release upload "${VERSION}" release-metadata.json release-input/build/autoware-lock.repos --clobber
+          STABLE_RELEASE: ${{ needs.validate.outputs.is_stable_release }}
+        run: bash .github/scripts/manage_github_release.sh publish
         shell: bash

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 # Full image scan workflow for an existing build-all-images run.
 # It runs automatically only when the build requested scanning, or manually for
 # any build_tag. A successful scan metadata artifact makes a build promotable.
@@ -25,11 +28,13 @@ jobs:
   prepare:
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
     outputs:
       build_tag: ${{ steps.prepare.outputs.build_tag }}
+      policy_sha: ${{ steps.prepare.outputs.policy_sha }}
       matrix: ${{ steps.prepare.outputs.matrix }}
       should_scan: ${{ steps.prepare.outputs.should_scan }}
     steps:
@@ -65,6 +70,11 @@ jobs:
           else
             should_scan=true
           fi
+          policy_sha=$(jq -r '.openadkit_sha' build-metadata/build-metadata.json)
+          if ! printf '%s\n' "${policy_sha}" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "Invalid OpenADKit SHA in build metadata: ${policy_sha}" >&2
+            exit 1
+          fi
 
           matrix=$(
             jq -c '{include: [.images[] as $image | $image.platforms[] | {
@@ -80,6 +90,7 @@ jobs:
 
           {
             echo "build_tag=${build_tag}"
+            echo "policy_sha=${policy_sha}"
             echo "should_scan=${should_scan}"
             echo "matrix=${matrix}"
           } >> "$GITHUB_OUTPUT"
@@ -89,6 +100,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.should_scan == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: read
@@ -98,15 +110,25 @@ jobs:
       max-parallel: 6
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
+      - name: Checkout OpenADKit repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ needs.prepare.outputs.policy_sha }}
+          sparse-checkout: .trivyignore
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Scan ${{ matrix.target }}-${{ matrix.ros_distro }} (${{ matrix.platform }})
-        uses: aquasecurity/trivy-action@0.30.0
+        id: trivy-scan
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_PLATFORM: ${{ matrix.platform }}
         with:
@@ -115,11 +137,32 @@ jobs:
           output: trivy-${{ matrix.target }}-${{ matrix.ros_distro }}-${{ matrix.platform_label }}.sarif
           exit-code: '1'
           severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          scanners: vuln
+          timeout: 15m
+          trivyignores: .trivyignore
+          limit-severities-for-sarif: true
+
+      - name: Retry scan after transient failure
+        if: steps.trivy-scan.outcome == 'failure'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_PLATFORM: ${{ matrix.platform }}
+        with:
+          image-ref: ${{ matrix.image_ref }}
+          format: sarif
+          output: trivy-${{ matrix.target }}-${{ matrix.ros_distro }}-${{ matrix.platform_label }}.sarif
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          scanners: vuln
+          timeout: 15m
+          trivyignores: .trivyignore
           limit-severities-for-sarif: true
 
       - name: Upload scan results to GitHub Security
-        if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        if: ${{ always() && hashFiles(format('trivy-{0}-{1}-{2}.sarif', matrix.target, matrix.ros_distro, matrix.platform_label)) != '' }}
+        uses: github/codeql-action/upload-sarif@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
         with:
           sarif_file: trivy-${{ matrix.target }}-${{ matrix.ros_distro }}-${{ matrix.platform_label }}.sarif
           category: ${{ matrix.target }}-${{ matrix.ros_distro }}-${{ matrix.platform_label }}
@@ -128,12 +171,15 @@ jobs:
     needs: [prepare, scan]
     if: always() && needs.prepare.outputs.should_scan == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     permissions:
+      actions: write
       contents: read
     steps:
       - name: Write scan metadata
         env:
           BUILD_TAG: ${{ needs.prepare.outputs.build_tag }}
+          POLICY_SHA: ${{ needs.prepare.outputs.policy_sha }}
           SCAN_RESULT: ${{ needs.scan.result }}
           SCAN_MATRIX: ${{ needs.prepare.outputs.matrix }}
         run: |
@@ -147,6 +193,7 @@ jobs:
 
           jq -n \
             --arg build_tag "${BUILD_TAG}" \
+            --arg policy_sha "${POLICY_SHA}" \
             --arg scan_status "${status}" \
             --arg scan_result "${SCAN_RESULT}" \
             --arg run_id "${GITHUB_RUN_ID}" \
@@ -154,6 +201,7 @@ jobs:
             --argjson scan_matrix "${SCAN_MATRIX}" \
             '{
               build_tag: $build_tag,
+              policy_sha: $policy_sha,
               scan_scope: "all",
               scan_status: $scan_status,
               scan_result: $scan_result,
@@ -171,7 +219,7 @@ jobs:
         shell: bash
 
       - name: Upload scan metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: scan-metadata-${{ needs.prepare.outputs.build_tag }}
           path: scan-metadata/scan-metadata.json


### PR DESCRIPTION
Split from the former #113 (closed) so the runtime and release layers are independently reviewable. Depends on #138 (manifest runtime CLI).

Tracking: https://github.com/autowarefoundation/openadkit/issues/134

## Scope
- Immutable release planning (`release_plan.py`) and complete registry preflight.
- Exact image promotion (`promote_release_images.sh`) and stable alias policy.
- One deterministic dual-distro (Humble/Jazzy) runtime bundle (`package_release_bundles.sh`).
- Release validation (`validate_release.sh`), GitHub release management, release notes, and release tagging.
- Hardened scan and release promotion CI (`scan.yaml`, `release.yaml`).
- Packages the runtime, the three curated deployments, and shared base with digest-pinned context and deployment checksums.

## Validation
- Full Python test suite (116 tests including the CLI layer from #138) plus `test_release_pipeline.py` additions.
- Shellcheck, actionlint, yamllint, and compose render checks clean.

## Follow-up
- #111 aligns product documentation and publication with this runtime and release contract.