### PR TITLE
feat(x5h): npu bring-up enablement and the host compile inputs

### DIFF
--- a/platforms/autosd/x5h/README.md
+++ b/platforms/autosd/x5h/README.md
@@ -35,6 +35,13 @@ answered before board time.
 - [Companion host](companion-host.md) — always-on bench gateway that keeps
   the board reachable remotely and scopes external developers' access.
   Executed and verified on hardware, 2026-08-10.
+- [UIO](uio.md) — hand the SoC's accelerator blocks to userspace; why
+  `uio_pdrv_genirq` comes up loaded and bound to nothing without an `of_id`,
+  and how the bound blocks get `/dev` names a runtime can open.
+- [NPU bring-up](npu-bringup.md) — reach the NPU from AutoSD through the
+  ONNX Runtime Renesas execution provider: what the runtime needs, which
+  steps need no flash write, and which two writes would break the CR52
+  round trip and the self-boot partitions.
 
 ## Folder Structure
 
@@ -43,12 +50,16 @@ answered before board time.
   or staged alongside the rebuilt kernel (`60-nftables.conf`), plus the
   self-boot set: key-only sshd drop-in, `authorized_keys`, the
   NetworkManager drop-in keeping `tsn5` kernel-managed, static resolvers,
-  the rpmsg sample-driver blacklist and the sshd enable preset
+  the rpmsg sample-driver blacklist, the `uio_pdrv_genirq` `of_id` binding
+  and its udev naming rules (see [uio.md](uio.md)), and the sshd enable
+  preset
 - `kernel/`: rebuilt-kernel config fragments + build script, shared by the
   QEMU gate and the board — one build, two images: both boot an
   `Image-autosd` from the same source SHA, toolchain and fragments, and the
   only permitted config delta is the `CONFIG_EXTRA_FIRMWARE` pair (see "One
   build, two images")
+- `ai/`: host-side inputs for the NPU compiler and the board-side accuracy
+  check (see [ai/README.md](ai/README.md))
 - `scripts/`: QEMU gate harness and board staging/smoke scripts
 - `rpmsg-eth/`: the IP-over-RPMsg TAP bridge daemon (source, Makefile, and
   its own pty-mock unit test) — see [rpmsg-dualboot.md](rpmsg-dualboot.md)

--- a/platforms/autosd/x5h/ai/README.md
+++ b/platforms/autosd/x5h/ai/README.md
@@ -1,0 +1,126 @@
+# X5H NPU: the host-side inputs and the board-side checks
+
+What lives here is the part of NPU work that can live in a public repository:
+the scripts that turn public model weights into compiler inputs, and the checks
+that grade what the board does with the result. The procedure, the reasoning and
+the recovery paths are in [../npu-bringup.md](../npu-bringup.md); read that
+first if you are about to touch the board.
+
+**Read the status section of that document before quoting any of this as
+working.** As of 2026-08-26 the full three-branch VisionPilot pipeline runs on
+the NPU as a single fused subgraph, with no compute nodes left on the CPU. The
+model-load kernel fault reported here on 2026-08-21 is resolved and was not a
+model-size limit: the kernel had been loaded at an address the NPU runtime
+later writes over, which nothing in the runtime validates or reports. Load the
+kernel where the vendor documents and it does not occur.
+
+## What is not here, and why
+
+The compiler wrapper, the licence, the SDK paths and every vendor address stay
+outside this repository, exactly as in
+[../cr52-slot-update.md](../cr52-slot-update.md). That is not tidiness: the SDK
+is NDA-bound material. The scripts here take file paths as arguments and read
+vendor values from the SDK at the time you run them, so nothing needs to be
+copied in to make them work.
+
+Concretely, the NNAC compile step itself — `renesas_ep_gen_artifacts.py` from
+the runtime release, plus a local wrapper for the model that needs post-legalize
+surgery — is invoked from the working area, not from here.
+
+## Host: from public weights to compiler inputs
+
+| Step | Script | Marker |
+| --- | --- | --- |
+| Fetch the pinned VisionPilot models | `vp-models/export-models.sh [dest] [src]` | `VP_MODELS_OK` |
+| Pin the symbolic batch dimension | `vp-models/fix-static-shapes.py <src> <dst>` | `STATIC_SHAPES_OK` |
+| Build calibration data and replay feeds | `vp-models/calib-dump.py --model … --clip …` | `CALIB_DUMP_OK` |
+
+Order matters for the middle one: the models ship with a symbolic batch
+dimension on inputs *and* outputs, and the compiler frontend fails late, inside
+legalization, if it is left symbolic. Pinning the inputs alone is not enough.
+
+`calib-dump.py` mirrors the pinned VisionPilot C++ preprocessing rather than a
+reasonable-looking reconstruction of it, because the three models are **not**
+preprocessed the same way — one gets a perspective-warped image with ImageNet
+normalization, the other two share a top-cropped resize with no normalization
+beyond `/255`. Feeding either model the other's tensors sets every quantization
+range wrong at once. Two of the model headers also document preprocessing the
+code does not perform; the code is what runs. The constants and their source
+lines are in the script's docstring.
+
+It writes two trees from one pass: a calibration tree in the layout
+`--calibration-path` expects (one directory per input, file names sorting into
+frame order, equal counts per input — the generator indexes inputs by position),
+and an ordered replay tree for the consistency check.
+
+## Board: grading what actually happened
+
+| Step | Script | Marker |
+| --- | --- | --- |
+| Prove the whole chain to the device node | `../scripts/npu-probe.sh [artifacts] [image]` | `NPU_PROBE_PASS` / `NPU_PROBE_FAIL reason=…` |
+| Compare NPU against CPU over replay feeds | `vp-models/consistency-check.py` | `CONSISTENCY_PASS` / `_FAIL` / `_CALIBRATED` |
+
+Run the probe first, and grade by its marker rather than by an exit status or by
+reading output. Three reasons, all measured rather than assumed:
+
+- The vendor's evaluation script catches every exception, prints
+  `Error occurred: …` and returns normally, so `$?` is 0 on a board with no NPU
+  at all.
+- A completed run is not an offloaded run: the provider list ends in
+  `CPUExecutionProvider`, so a board without a working NPU produces correct
+  results and a plausible latency.
+- A run can print correct numbers on a kernel that has **already** oopsed. The
+  probe refuses to measure on a damaged kernel and checks again afterwards;
+  nothing else in this directory does.
+
+`consistency-check.py` freezes an envelope rather than demanding equality — the
+NPU path is quantized, so it cannot match the CPU exactly, and the useful
+question is whether the difference has moved. Calibrate once per model
+(`--calibrate`), commit the resulting `tolerance.json`, then run without the
+flag to assert. Calibration merges into the existing file, so calibrating the
+second model does not evict the first.
+
+`tolerance.json` is **not** committed. The envelope is only meaningful once
+frozen against the model and board configuration it will be asserted on, so
+generate it with `--calibrate` for the model you are shipping rather than
+inheriting one from a different build.
+
+## Two findings that decide how a model is compiled and where it is decoded
+
+Neither is discoverable from the compiler output, and both cost real time, so
+they are written down here rather than left in a working area.
+
+**Sweep `--slice`; do not assume more is better.** The flag sets how many NPX
+slices execute the network, and the useful value is a property of the model,
+not of the board. Measured on the merged three-branch model at 1024x512: the
+best end-to-end time came from **3 of the 12 available slices**, and using all
+twelve was *worse than using one*. Two effects compose to produce that. The
+NPU-side compute stops improving once the network runs out of work to divide —
+past four slices it was flat to within 0.01 ms, which is what a 16x32
+bottleneck feature map should be expected to do — while dispatch and
+synchronisation cost about a millisecond per slice and simply keep
+accumulating. The sum therefore has a minimum in the middle. Sweep the values
+for the model in hand; the optimum moves with input resolution and batch size,
+so it has to be re-checked after any re-export rather than carried over.
+
+**Decode softmax-family heads on the host, not on the NPU.** A softmax output
+is quantized on a fixed [0,1] grid, so the per-position rounding of a
+soft-argmax head — softmax over positions, then a position-weighted
+expectation, the usual shape for lane offsets and for DFL box decoding — lands
+differently from frame to frame and shows up as a visibly jittering output on
+otherwise smooth input. No weight rescaling can fix it, because nothing changes
+a softmax's output range. Cutting the graph at the pre-softmax logits and doing
+softmax plus expectation on the host in float restored the jitter to the float
+reference exactly, for no measurable latency cost — the tensor crossing the
+boundary is small, and the arithmetic leaves the NPU with it.
+
+## Mounting artifacts, which is the trap that looks like a driver bug
+
+The backend opens the artifact path recorded in the manifest. The shipped
+samples record a path *relative* to the artifacts directory's parent and
+starting with that directory's own name, so the mount must preserve the
+directory name — mount it as `/work/artifacts` and the backend looks for
+`/work/<name>` and misses. Locally compiled artifacts instead record the
+*absolute* path of the machine that compiled them, which the backend opens
+verbatim, so there the mount point has to be that path. `npu-probe.sh` reads the
+manifest and picks the right form; do the same by hand.

--- a/platforms/autosd/x5h/ai/vp-models/calib-dump.py
+++ b/platforms/autosd/x5h/ai/vp-models/calib-dump.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Dump NNAC calibration data and ordered replay feeds for the VisionPilot models.
+
+Fidelity is the whole point: calibration is only as good as its agreement with
+what the vehicle actually feeds the model, and a plausible-looking
+normalization VisionPilot does not use produces quantization ranges that are
+wrong everywhere at once. Everything below mirrors the pinned VP C++ pipeline
+(commit bdbfc32), which does NOT preprocess uniformly -- it builds two
+different images per frame:
+
+  autodrive            <- BEV cv::warpPerspective(C, 1024x512, INTER_LINEAR,
+                          BORDER_REFLECT_101), BGR->RGB, /255, then ImageNet
+                          mean/std. Two inputs: the previous and current
+                          warped frame.
+  autosteer, autospeed <- top-crop to 2:1 then cv::resize to 1024x512
+                          (INTER_LINEAR), BGR->RGB, /255 and nothing else.
+                          They share one buffer, so one input each.
+
+    modules/sensing/image_preprocessing/src/image_preprocessor.cpp:10-22
+    modules/models/src/inference.cpp:18-54 (chw_imagenet / chw_01), 141-175
+    modules/common/include/common/utils.hpp:15-19 (the crop rule)
+
+Two headers document preprocessing the code does not do -- auto_speed.hpp
+claims a (114,114,114) letterbox, auto_drive.hpp says "resize" where the code
+warps. The code wins; do not restore either from the comments.
+
+C is derived here from the dataset ground homography, the same way
+VisionPilot/scripts/find_homography_C_matrix.py derives it, because the
+generated C yaml is gitignored in VP and so cannot be depended on. Note the
+shipped H.yaml is annotated for OpenLane 1920x1080 pixel space while the pinned
+smoke clip is 1920x1280: this is VP's own default calibration applied to the
+clip, not a per-clip calibration, and it shifts the BEV geometry. It does not
+shift the pixel statistics that set quantization ranges, which is what this
+dump is for.
+
+Two trees come out of one pass, from the same tensors:
+  <calib-out>/<model>/<input_name>/fNNNN.npy      what --calibration-path wants
+  <feeds-out>/<model>/frameNNNN/<input_name>.npy  ordered, for the consistency check
+
+The calibration layout is not a convention we chose: renesas_ep_utils.
+generate_calibration() globs <calibration-path>/<input_name>/*.npy, sorts it,
+and indexes every input by position -- so per-input file counts must match and
+the names must sort into frame order.
+
+DO NOT MERGE TWO OF THESE TREES BY COPYING DIRECTORIES TOGETHER. Each run
+starts at the first frame that model can actually be fed -- t=1 for a model
+that takes a history frame, t=0 for one that does not (see `start` below) --
+so sample i means a different source frame in the two trees. Concatenating
+them for a merged multi-branch model therefore feeds one branch frame i and
+another frame i+1, silently: every file is present, the counts match, the
+generator is happy, and nothing anywhere reports a skew. Measured in 2026-08,
+where it put a one-frame lag into a merged model's inputs and into every
+overlay rendered from them.
+
+To build calibration for a merged model, dump it in one pass against the
+merged model itself, so a single `start` governs all of its inputs.
+"""
+import argparse
+import pathlib
+import sys
+
+import cv2
+import numpy as np
+
+NET_W, NET_H = 1024, 512
+# ImageNet constants, applied after the /255 (inference.cpp:22-23).
+MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+# VisionPilot's fixed model-view homography (1024x512 pixel -> world), copied
+# verbatim from scripts/find_homography_C_matrix.py, where it is marked
+# "DO NOT MODIFY".
+V = np.array(
+    [
+        [0.00209514907, -0.000941721466, -9.24906396],
+        [0.00662758637, -0.000352940531, -3.33396502],
+        [0.000120077371, -0.00411343505, 1.0],
+    ],
+    dtype=np.float32,
+)
+CANONICAL_WORLD_PTS = np.array(
+    [[15, 5, 1], [150, 5, 1], [15, -5, 1], [150, -5, 1]], dtype=np.float32
+)
+
+# How each model is fed. "bev" and "crop" name the geometric stage; "imagenet"
+# selects the normalization. history=True means the model also takes frame t-1,
+# which is why its first usable sample is t=1.
+PREPROC = {
+    "autodrive": dict(geom="bev", imagenet=True, history=True),
+    "autosteer": dict(geom="crop", imagenet=False, history=False),
+    "autospeed": dict(geom="crop", imagenet=False, history=False),
+}
+
+
+def find_c_matrix(h_yaml):
+    """Rebuild VP's preprocess homography C from the dataset ground H."""
+    fs = cv2.FileStorage(str(h_yaml), cv2.FILE_STORAGE_READ)
+    h = fs.getNode("H").mat()
+    fs.release()
+    if h is None:
+        sys.exit(f"CALIB_DUMP_FAIL no H matrix in {h_yaml}")
+    uv = np.linalg.inv(h) @ CANONICAL_WORLD_PTS.T
+    pq = np.linalg.inv(V) @ CANONICAL_WORLD_PTS.T
+    c, _ = cv2.findHomography((uv[:2] / uv[2]).T, (pq[:2] / pq[2]).T, method=0)
+    return c
+
+
+def geom_bev(frame_bgr, c):
+    return cv2.warpPerspective(frame_bgr, c, (NET_W, NET_H), flags=cv2.INTER_LINEAR,
+                               borderMode=cv2.BORDER_REFLECT_101)
+
+
+def geom_crop(frame_bgr):
+    """Top-crop to 2:1, then resize -- utils.hpp compute_top_crop_2_1."""
+    h, w = frame_bgr.shape[:2]
+    crop_top = max(0, int(round(h - w / 2.0)))
+    return cv2.resize(frame_bgr[crop_top:, :], (NET_W, NET_H), interpolation=cv2.INTER_LINEAR)
+
+
+def tensorize(img_bgr, imagenet):
+    """BGR uint8 -> NCHW float32, /255, optionally ImageNet-normalized."""
+    rgb = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0
+    if imagenet:
+        rgb = (rgb - MEAN) / STD
+    return np.ascontiguousarray(np.transpose(rgb, (2, 0, 1))[None])
+
+
+def decode(clip, max_frames):
+    cap = cv2.VideoCapture(str(clip))
+    frames = []
+    while len(frames) < max_frames:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        frames.append(frame)
+    cap.release()
+    return frames
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--model", required=True, help="model .onnx (names the preprocessing)")
+    ap.add_argument("--clip", required=True)
+    ap.add_argument("--calib-out", required=True)
+    ap.add_argument("--feeds-out", required=True)
+    ap.add_argument("--ground-h", default="/tmp/vp-src/VisionPilot/config/H.yaml",
+                    help="dataset ground homography H (VP config/H.yaml)")
+    ap.add_argument("--max-frames", type=int, default=100)
+    a = ap.parse_args()
+
+    name = pathlib.Path(a.model).stem
+    key = name.split("_")[0]
+    if key not in PREPROC:
+        sys.exit(f"CALIB_DUMP_FAIL unknown model {name} (expected one of {sorted(PREPROC)})")
+    cfg = PREPROC[key]
+
+    import onnxruntime as ort  # after arg parsing: a bad path should fail fast
+
+    sess = ort.InferenceSession(a.model, providers=["CPUExecutionProvider"])
+    inputs = [i.name for i in sess.get_inputs()]
+    if cfg["history"] != (len(inputs) > 1):
+        sys.exit(f"CALIB_DUMP_FAIL {name} has inputs {inputs}, "
+                 f"which contradicts history={cfg['history']}")
+
+    frames = decode(a.clip, a.max_frames)
+    if len(frames) < 2:
+        sys.exit(f"CALIB_DUMP_FAIL decoded {len(frames)} frames from {a.clip}")
+
+    c = find_c_matrix(a.ground_h) if cfg["geom"] == "bev" else None
+    prepared = [geom_bev(f, c) if cfg["geom"] == "bev" else geom_crop(f) for f in frames]
+    tensors = [tensorize(img, cfg["imagenet"]) for img in prepared]
+
+    # VP holds a one-deep frame buffer and returns no inference for the first
+    # frame (inference.cpp:141-148), so the two-input model's first real sample
+    # is t=1 with prev=t0. Starting at t=0 with prev==curr would feed the
+    # calibration a zero-motion frame pair the vehicle never produces.
+    #
+    # This is per-model correct and cross-model INCOMPARABLE: sample i is
+    # source frame i+start, and start differs between models here. See the
+    # merge warning in the module docstring before combining two output trees.
+    start = 1 if cfg["history"] else 0
+    calib_root = pathlib.Path(a.calib_out) / name
+    feeds_root = pathlib.Path(a.feeds_out) / name
+    for idx, t in enumerate(range(start, len(tensors))):
+        feed = {}
+        for input_name in inputs:
+            feed[input_name] = tensors[t - 1] if "prev" in input_name else tensors[t]
+        frame_dir = feeds_root / f"frame{idx:04d}"
+        frame_dir.mkdir(parents=True, exist_ok=True)
+        for input_name, tensor in feed.items():
+            np.save(frame_dir / f"{input_name}.npy", tensor)
+            calib_dir = calib_root / input_name
+            calib_dir.mkdir(parents=True, exist_ok=True)
+            np.save(calib_dir / f"f{idx:04d}.npy", tensor)
+
+    samples = len(tensors) - start
+    stats = np.concatenate([t.ravel()[::997] for t in tensors])
+    print(f"  inputs={inputs} geom={cfg['geom']} imagenet={cfg['imagenet']} "
+          f"range=[{stats.min():.3f},{stats.max():.3f}] mean={stats.mean():.3f}")
+    print(f"CALIB_DUMP_OK model={name} samples={samples} frames={len(frames)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/platforms/autosd/x5h/ai/vp-models/consistency-check.py
+++ b/platforms/autosd/x5h/ai/vp-models/consistency-check.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Compare CPU-only against NPU-offloaded outputs over ordered replay feeds.
+
+Runs ON THE BOARD, inside the runtime container, so that both sessions see
+byte-identical inputs from the same files. Two modes:
+
+  --calibrate  record the observed per-output envelope into the tolerance file
+  default      assert every frame stays inside the frozen envelope
+
+The point is not that the NPU matches the CPU exactly -- it cannot, the NPU
+path is quantized -- but that the difference stays where it was when someone
+last looked at it. That is why the tolerances are frozen in git rather than
+computed at assert time.
+
+Two things this deliberately does not do:
+
+* It does not trust a completed run. The Renesas provider lists
+  CPUExecutionProvider as a fallback, so a board with no working NPU produces
+  correct results and a plausible latency; the provider list is asserted here,
+  and `scripts/npu-probe.sh` is what checks the layers underneath.
+* It does not check the kernel. A run can print correct numbers on a kernel
+  that has already oopsed (measured 2026-08-21), so run npu-probe.sh -- which
+  refuses a damaged kernel -- rather than reading a PASS here as "the board is
+  healthy".
+
+Mounting: the backend resolves the artifact path recorded in the manifest, which
+is relative for the shipped samples and absolute for locally compiled models.
+Mount the artifacts at the recorded path, not under a parent of your choosing;
+npu-probe.sh reads the manifest and does this correctly.
+"""
+import argparse
+import glob
+import json
+import pathlib
+import sys
+
+import numpy as np
+import onnxruntime as ort
+
+EP = "RenesasExecutionProvider"
+
+
+def cosine(a, b):
+    a, b = a.ravel().astype(np.float64), b.ravel().astype(np.float64)
+    denom = np.linalg.norm(a) * np.linalg.norm(b)
+    return 1.0 if denom == 0 else float(np.dot(a, b) / denom)
+
+
+def pick_model(artifacts):
+    """The compiled model to run, preferring the QDQ-inserted one.
+
+    That is the model the compile pipeline actually produces artifacts for, and
+    on a board copy trimmed for size it is often the only ONNX file present --
+    so globbing `legalized_*` alone finds nothing and fails late.
+    """
+    for pattern in ("qdq_inserted_legalized_*.onnx", "legalized_*.onnx", "*.onnx"):
+        hits = sorted(glob.glob(str(pathlib.Path(artifacts) / pattern)))
+        if hits:
+            return hits[0]
+    sys.exit(f"CONSISTENCY_FAIL reason=no_model_in_artifacts path={artifacts}")
+
+
+def load_feeds(feeds):
+    frames = sorted(pathlib.Path(feeds).glob("frame*"))
+    if not frames:
+        sys.exit(f"CONSISTENCY_FAIL reason=no_feeds path={feeds}")
+    return frames
+
+
+def freeze_tolerance(tol_path, name, stats, headroom):
+    """Write this model's envelope into the tolerance file, keeping the others.
+
+    Each model is calibrated in its own run, so a write that replaced the file
+    would evict whatever was frozen before it -- the failure mode is silent,
+    and it looks like the earlier model was never calibrated.
+    """
+    existing = {}
+    if tol_path.exists():
+        try:
+            existing = json.loads(tol_path.read_text())
+        except json.JSONDecodeError:
+            sys.exit(f"CONSISTENCY_FAIL reason=tolerance_unparseable path={tol_path}")
+    existing[name] = {
+        k: {"max_abs_diff": v["max_abs_diff"] * headroom,
+            "min_cosine": max(0.0, 1 - (1 - v["min_cosine"]) * headroom)}
+        for k, v in stats.items()
+    }
+    tol_path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n")
+    return existing
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--artifacts", required=True)
+    ap.add_argument("--feeds", required=True, help="dir of frameNNNN/<input>.npy")
+    ap.add_argument("--tolerance", required=True)
+    ap.add_argument("--calibrate", action="store_true")
+    ap.add_argument("--headroom", type=float, default=1.2,
+                    help="factor applied to the observed envelope when freezing")
+    a = ap.parse_args()
+
+    model = pick_model(a.artifacts)
+    name = pathlib.Path(a.artifacts).name.removesuffix("_artifacts")
+
+    so = ort.SessionOptions()
+    so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+    s_npu = ort.InferenceSession(model, so, providers=[EP, "CPUExecutionProvider"])
+    if EP not in s_npu.get_providers():
+        sys.exit(f"CONSISTENCY_FAIL reason=silent_cpu_fallback providers={s_npu.get_providers()}")
+    s_cpu = ort.InferenceSession(model, so, providers=["CPUExecutionProvider"])
+    out_names = [o.name for o in s_cpu.get_outputs()]
+
+    stats = {}
+    frames = load_feeds(a.feeds)
+    for frame_dir in frames:
+        feed = {p.stem: np.load(p) for p in sorted(frame_dir.glob("*.npy"))}
+        npu_out, cpu_out = s_npu.run(None, feed), s_cpu.run(None, feed)
+        for out_name, npu_t, cpu_t in zip(out_names, npu_out, cpu_out):
+            diff = float(np.max(np.abs(npu_t.astype(np.float64) - cpu_t.astype(np.float64))))
+            st = stats.setdefault(out_name, {"max_abs_diff": 0.0, "min_cosine": 1.0})
+            st["max_abs_diff"] = max(st["max_abs_diff"], diff)
+            st["min_cosine"] = min(st["min_cosine"], cosine(npu_t, cpu_t))
+
+    tol_path = pathlib.Path(a.tolerance)
+
+    if a.calibrate:
+        freeze_tolerance(tol_path, name, stats, a.headroom)
+        print(json.dumps({name: stats}, indent=2, sort_keys=True))
+        print(f"CONSISTENCY_CALIBRATED model={name} frames={len(frames)} headroom={a.headroom}")
+        return
+
+    if not tol_path.exists():
+        sys.exit(f"CONSISTENCY_FAIL reason=tolerance_missing path={tol_path}")
+    frozen = json.loads(tol_path.read_text()).get(name)
+    if not frozen:
+        sys.exit(f"CONSISTENCY_FAIL reason=model_not_in_tolerance model={name} path={tol_path}")
+
+    failed = False
+    for out_name, v in sorted(stats.items()):
+        limit = frozen.get(out_name)
+        if limit is None:
+            print(f"CONSISTENCY_FAIL model={name} output={out_name} reason=output_not_in_tolerance")
+            failed = True
+            continue
+        if v["max_abs_diff"] > limit["max_abs_diff"] or v["min_cosine"] < limit["min_cosine"]:
+            print(f"CONSISTENCY_FAIL model={name} output={out_name} observed={v} limit={limit}")
+            failed = True
+    if failed:
+        sys.exit(1)
+    print(f"CONSISTENCY_PASS model={name} frames={len(frames)} outputs={len(stats)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/platforms/autosd/x5h/ai/vp-models/export-models.sh
+++ b/platforms/autosd/x5h/ai/vp-models/export-models.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Fetch the VisionPilot commit pinned by fork PR #10 and extract the runtime
+# ONNX models (weights are regular files at that commit).
+#
+# The plan expected two models named EgoLanes_FP32/AutoSteer_FP32; at this pin
+# the pipeline is three models -- inference.cpp loads
+# "auto{drive,steer,speed}_<precision>.onnx" and vision_pilot.conf sets
+# model.precision = fp32 -- so those three fp32 files are what "the models
+# VisionPilot runs" means here.
+#
+# The extracted models declare a symbolic batch dimension, which the NNAC
+# frontend cannot compile. Pin it with fix-static-shapes.py (needs the host
+# venv's onnx) before compiling anything from them.
+set -euo pipefail
+VP_REPO=https://github.com/autowarefoundation/autoware_vision_pilot.git
+VP_COMMIT=bdbfc328b822f9820d0dc14a7979beb4dfb8f3a9
+DEST="${1:-/tmp/vp-models}"
+SRC="${2:-/tmp/vp-src}"
+if [ ! -d "$SRC/.git" ]; then
+  mkdir -p "$SRC" && cd "$SRC" && git init -q && git remote add origin "$VP_REPO"
+  git fetch -q --depth 1 origin "$VP_COMMIT" && git checkout -q FETCH_HEAD
+fi
+mkdir -p "$DEST"
+found=0
+while IFS= read -r f; do
+  case "$(basename "$f")" in
+    autodrive_fp32.onnx|autosteer_fp32.onnx|autospeed_fp32.onnx) cp "$f" "$DEST/"; found=$((found+1));;
+  esac
+done < <(find "$SRC" -name '*.onnx' -not -path '*/.git/*')
+[ "$found" -eq 3 ] || { echo "VP_MODELS_FAIL found=$found (expected 3)"; find "$SRC" -name '*.onnx' -not -path '*/.git/*'; exit 1; }
+sha256sum "$DEST"/*.onnx
+echo "VP_MODELS_OK"

--- a/platforms/autosd/x5h/ai/vp-models/fix-static-shapes.py
+++ b/platforms/autosd/x5h/ai/vp-models/fix-static-shapes.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Pin the batch dimension of the VisionPilot models to 1.
+
+The pinned VP models declare a symbolic `batch_size` on every graph input and
+output. The NNAC frontend needs concrete shapes: with a symbolic dim 0 the
+converter fails late, inside legalization, on a shape it cannot resolve. Fixing
+dim 0 on the inputs alone is not enough -- the outputs carry the same symbol and
+the frontend reads them too.
+
+Only dim 0 is touched. Intermediate value_info is left alone: ONNX Runtime
+re-infers it from the pinned inputs, and rewriting it by hand is how stale
+shapes get baked in.
+
+Usage: fix-static-shapes.py <src-dir> <dst-dir> [model.onnx ...]
+"""
+import pathlib
+import sys
+
+import onnx
+
+
+def pin_batch(tensor, batch=1):
+    """Set dim 0 of a ValueInfoProto to `batch`. Returns True if it changed."""
+    dim = tensor.type.tensor_type.shape.dim
+    if not dim:
+        return False
+    if dim[0].HasField("dim_value") and dim[0].dim_value == batch:
+        return False
+    dim[0].ClearField("dim_param")
+    dim[0].dim_value = batch
+    return True
+
+
+def main():
+    if len(sys.argv) < 3:
+        sys.exit(__doc__)
+    src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+    names = sys.argv[3:] or sorted(p.name for p in src.glob("*.onnx"))
+    if not names:
+        sys.exit(f"STATIC_SHAPES_FAIL no .onnx models in {src}")
+    dst.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        model = onnx.load(str(src / name))
+        changed = sum(pin_batch(t) for t in list(model.graph.input) + list(model.graph.output))
+        onnx.checker.check_model(model)
+        onnx.save(model, str(dst / name))
+        shapes = {
+            t.name: [d.dim_value or d.dim_param for d in t.type.tensor_type.shape.dim]
+            for t in list(model.graph.input) + list(model.graph.output)
+        }
+        print(f"  {name}: pinned={changed} {shapes}")
+    print(f"STATIC_SHAPES_OK models={len(names)} out={dst}")
+
+
+if __name__ == "__main__":
+    main()

--- a/platforms/autosd/x5h/aib/x5h-rootfs.aib.yml
+++ b/platforms/autosd/x5h/aib/x5h-rootfs.aib.yml
@@ -64,6 +64,9 @@ content:
     - path: /etc/modprobe.d
       parents: true
       exist_ok: true
+    - path: /etc/udev/rules.d
+      parents: true
+      exist_ok: true
   add_files:
     # add_files only permits /etc and /usr destinations (rehearsal finding).
     - source_path: ../config/50-x5h.conf
@@ -82,6 +85,15 @@ content:
       path: /etc/resolv.conf
     - source_path: ../config/x5h-rpmsg-diag.conf
       path: /etc/modprobe.d/x5h-rpmsg-diag.conf
+    # Without of_id, uio_pdrv_genirq loads but binds nothing -- see uio.md.
+    - source_path: ../config/x5h-uio.conf
+      path: /etc/modprobe.d/x5h-uio.conf
+    # Binding the UIO devices names them in sysfs only; these turn the names
+    # into /dev paths a runtime can open (uio.md, npu-bringup.md).
+    - source_path: ../config/51-x5h-uio.rules
+      path: /etc/udev/rules.d/51-x5h-uio.rules
+    - source_path: ../config/52-x5h-cmem.rules
+      path: /etc/udev/rules.d/52-x5h-cmem.rules
     - source_path: ../config/80-x5h.preset
       path: /etc/systemd/system-preset/80-x5h.preset
 

--- a/platforms/autosd/x5h/config/51-x5h-uio.rules
+++ b/platforms/autosd/x5h/config/51-x5h-uio.rules
@@ -1,0 +1,18 @@
+# Give the board's UIO devices their device-tree names in /dev.
+#
+# uio_pdrv_genirq names each device from its node's linux,uio-name, but that
+# name only ever reaches /sys/class/uio/uioN/name. The device node itself stays
+# /dev/uioN -- numbered by probe order, and 0600 root:root. So a runtime that
+# opens /dev/npuc0 fails with ENOENT on a board where the device tree, the
+# module binding and the sysfs name are all correct; nothing in the failure
+# points at the missing rule.
+#
+# One rule covers every device in uio.md's table at once. The mode line is
+# deliberately narrower than the vendor's reference rootfs, which relaxes all
+# 177 of them: only the NPU cluster is opened to a non-root process. If the
+# runtime turns out to need another block, widen that match rather than
+# dropping to a blanket 0666.
+#
+# See uio.md; the binding itself comes from x5h-uio.conf.
+SUBSYSTEM=="uio", SYMLINK+="$attr{name}"
+SUBSYSTEM=="uio", ATTR{name}=="npuc*", MODE="0666"

--- a/platforms/autosd/x5h/config/52-x5h-cmem.rules
+++ b/platforms/autosd/x5h/config/52-x5h-cmem.rules
@@ -1,0 +1,12 @@
+# Open the cmem devices to a non-root runtime.
+#
+# cmemdrv registers a class of its own rather than sitting on a bus, so the
+# match is the class name and not a subsystem in the usual sense. Its nodes
+# arrive 0600 root:root like any other class device.
+#
+# Two families appear, and they are sized by different mechanisms: cmem0..N
+# are carved out of the default CMA and sized by the driver's bsize parameter,
+# while cmem_other0..N come one per phandle in the /cmem node's memory-region
+# list and inherit each region's address and extent. npu-bringup.md explains
+# why that distinction matters when a device comes out the wrong size.
+SUBSYSTEM=="cmem", MODE="0666"

--- a/platforms/autosd/x5h/config/x5h-uio.conf
+++ b/platforms/autosd/x5h/config/x5h-uio.conf
@@ -1,0 +1,11 @@
+# Bind uio_pdrv_genirq to the board's generic-uio device-tree nodes.
+#
+# The module ships wildcard OF aliases (of:N*T*C*), so udev autoloads it on
+# any unmatched device-tree node -- but its of_match_table is empty until
+# of_id names a compatible, so without this it comes up loaded and bound to
+# nothing, and no /dev/uio* appears. Because it is modprobe-loaded, an
+# options line here is what reaches it; no kernel command line change is
+# needed (bootargs are coupled to the self-boot PARTUUIDs, see selfboot.md).
+#
+# See uio.md for what this exposes and how to verify it.
+options uio_pdrv_genirq of_id=generic-uio

--- a/platforms/autosd/x5h/npu-bringup.md
+++ b/platforms/autosd/x5h/npu-bringup.md
@@ -1,0 +1,436 @@
+# X5H NPU bring-up
+
+What has to be true before the ONNX Runtime Renesas execution provider can
+reach the NPU from AutoSD, in what order to do it, and how to get back if a
+step goes wrong.
+
+> **Status: the NPU runs on hardware.** Stage 0 (capture) executed 2026-08-10,
+> Stage 1 reached NPU execution 2026-08-21, and Stage 2 — the AI-package
+> bootloader — was flashed 2026-08-25, which is what made the NPU useful
+> rather than merely reachable. Everything stated below as measured was
+> measured on the board.
+>
+> **The kernel load address matters and nothing reports it.** Loading the
+> kernel where the vendor documents is required; at other addresses the NPU
+> runtime writes over it and the kernel takes an undefined-instruction oops
+> during model load, with no diagnostic pointing anywhere near the cause.
+>
+> **The NPU device tree and the realtime cores are mutually exclusive.** The
+> vendor NPU device tree omits the realtime core's reserved memory, so the two
+> cannot run in one configuration — see [Where this stops](#where-this-stops).
+> The NULL dereference that omission triggers in the BSP remoteproc driver is
+> a vendor defect in its own right. In practice NPU verification runs on a
+> separate board rather than reconciling the two; board roles are in
+> [companion-host.md](companion-host.md).
+>
+> Measured NPU figures stay in the working area, outside this repository.
+
+> **Numbers live elsewhere.** Flash offsets, device-tree addresses and
+> interrupt numbers come from the vendor SDK and are not in this repository —
+> same boundary as [cr52-slot-update.md](cr52-slot-update.md). This document
+> carries the procedure, the reasoning and the traps. Read the values from
+> the SDK's own flash-target definition at the time you run the steps.
+
+## What the runtime actually needs
+
+The execution provider reaches the hardware entirely from userspace. It opens
+two families of device:
+
+- **`/dev/npuc0`, `/dev/npuc1`** — the NPU clusters. These are ordinary UIO
+  devices: the vendor's NPU device tree declares them `generic-uio` with a
+  `linux,uio-name`, and the userspace side picks their register windows with
+  `mmap` offsets that are multiples of the page size, which is the UIO map
+  convention. See [uio.md](uio.md).
+
+  **But those are not the names the kernel creates.** UIO names its device
+  nodes `/dev/uioN` by probe order and puts the declared name in
+  `/sys/class/uio/uioN/name`. Turning that name into `/dev/npuc0` takes a
+  one-line udev rule: match `SUBSYSTEM=="uio"` and symlink `$attr{name}`. The
+  same rule is also what makes the node openable by anything but root, since
+  UIO creates its devices `0600 root:root`. `config/51-x5h-uio.rules` supplies
+  it, verified on hardware 2026-08-11.
+- **`/dev/cmem_other*`** — contiguous memory, served by an out-of-tree driver
+  that has to be loaded once per boot. Its devices want a rule of their own,
+  for the same permission reason: `config/52-x5h-cmem.rules`.
+
+So there is no NPU kernel driver to find or write. What is missing is device
+tree, and possibly one firmware component. The module and both udev rules are
+done.
+
+The naming rules were the easiest of those to overlook, because nothing about a
+missing symlink points at udev. The device tree is right, the module is
+loaded, the UIO device is bound and named — and the runtime still fails at
+`open`, on a path that looks like it should exist.
+
+## What the board already has
+
+**The NPU firmwares are already flashed.** Both clusters' firmware is present
+at the offsets the vendor's flash-target definition names, and matches the
+package byte for byte across every S-record range — 139,230 chunks each, zero
+mismatches. This was the step that looked like it would need a bench visit
+and a serial flash writer. It does not: it is done.
+
+**The UIO mechanism works.** 177 of the board's `generic-uio` nodes bind and
+come up named, with mappings resolving to their declared addresses, once
+`uio_pdrv_genirq` is given its `of_id` — which `config/x5h-uio.conf` now
+supplies. Nodes that share one register window with separate interrupts bind
+correctly, which is the pattern the NPU uses.
+
+**One flash component differs.** The board carries the stock second-stage IPL
+for the realtime cluster; the AI package ships a variant of it. The package
+documents the change as switching DRAM ECC off *for improving performance*,
+and ships the stock binary alongside so it can be put back. The manual
+separately states that the SDK's IPL cannot run the package's samples, which
+is in tension with a change described as a performance tweak. Nothing in the
+documentation settles it, so Stage 1 below is written to find out cheaply
+rather than to assume either way.
+
+## Stage 0: capture what you would otherwise lose
+
+Do this before anything else, and keep the results off the board. **Executed
+2026-08-10**, so what follows is a record as much as an instruction.
+
+- Read both realtime firmware slots. Stage 2 writes into the same address
+  space, and one of these slots holds this branch's RPMsg responder — see the
+  trap below.
+- Read the flash region Stage 2 would rewrite, so a restore is a copy rather
+  than a rebuild.
+- Capture the U-Boot environment.
+
+**Take whole-device images, not slot-sized ones.** The logical units involved
+are small, so a full image costs little, and one image is then a superset of
+both realtime slots, the bootloader payloads and the NPU firmwares at once —
+with a single digest to check instead of one per extent, and no chance of
+having read the wrong window. Hash on the board, stream the image off
+compressed, and hash again after decompressing on the host: that checks the
+transfer end to end, rather than checking the board against itself.
+
+**The environment needs no serial.** `fw_printenv` is absent from this root
+filesystem, but the saved environment is a plain run of `key=value` strings
+behind a short header, living in one of the eMMC boot areas, so it can be read
+as bytes from Linux and decoded on the host. Find it by searching those areas
+for the name of a variable you know was set — the offset is a property of the
+U-Boot build, so search rather than hard-code it. Doing it this way is
+strictly better than a `printenv` transcript: it captures the stored form
+rather than a rendering of it, and it costs no reboot and no console. Self-boot
+can also be restored from `selfboot-env.txt` on the boot partition with no host
+at all ([selfboot.md](selfboot.md)), so that remains belt and braces.
+
+## Stage 1: bring the NPU up with no flash writes at all
+
+Everything here is remote-capable. None of it touches flash.
+
+1. **Merge the NPU device tree into the board's — this is where it stops.**
+   The shape of the merge was never in doubt: the NPU cluster and UIO nodes, a
+   root-level `/cmem` node carrying a `memory-region` phandle list, and the
+   reserved-memory regions it refers to. Where those regions can go is in
+   doubt, and badly enough that it is now a question for the vendor rather
+   than a step. Read [Where this stops](#where-this-stops) before starting.
+
+   Read the vendor's own NPU device tree first in any case. It is a complete,
+   ready-made dtb rather than a fragment, which settles what the nodes look
+   like without guesswork — and it also shows, by what it leaves out, that the
+   vendor's NPU configuration and this branch's realtime work are not
+   configured to run together.
+2. **Build the cmem driver.** It is public and needs no SDK access:
+   `github.com/renesas-rcar/cmem`, branch `rcar_gen5`, GPL-2.0. **Pin commit
+   `e67f473c`, not HEAD.** HEAD adapts the driver to kernel 6.12 —
+   `follow_pfnmap_start`, `vm_flags_set`, and the one-argument
+   `class_create` — and every one of those postdates the 6.1 this board runs.
+   `e67f473c` uses the older forms. Pin the SHA the way
+   `kernel/build-bsp-kernel.sh` pins the BSP tree: the branch is mutable, the
+   commit is the source of truth.
+
+   **Done, 2026-08-10.** It builds unpatched, and needs no kernel rebuild: an
+   out-of-tree module only wants a configured and built kernel tree at the
+   matching version, and the tree left behind by an earlier
+   `build-bsp-kernel.sh` run serves. Check the result by its `vermagic`
+   against the running kernel rather than by the build succeeding — a module
+   built against the wrong tree also compiles cleanly and then refuses to
+   load. It loads and unloads on the board, and with no `/cmem` node present
+   it creates only the default-CMA device, which is the expected shape of a
+   half-configured system rather than a failure.
+3. **Load it and confirm the devices appear.** Two mechanisms decide what
+   appears, and they are easy to conflate. The driver's size parameter is an
+   array, but it governs the devices carved out of the *default CMA* region;
+   the `cmem_other` devices are a separate family whose **count and size come
+   from the `/cmem` node's phandle list alone** — one device per phandle,
+   each inheriting its reserved region's address and extent, neither
+   overridable from the command line. So a `cmem_other` device of the wrong
+   size is a device-tree defect, not a module-argument one.
+
+   Confirm `/dev/npuc*` and `/dev/cmem_other*` both exist before going
+   further — `board/npu-probe`-style output, not inspection by eye — and
+   remember that their existence depends on the udev rules as much as on the
+   device tree.
+
+   **Done, 2026-08-11, as far as the device tree allows.** Both rules
+   (`config/51-x5h-uio.rules`, `config/52-x5h-cmem.rules`) are verified on the
+   board: 177 UIO name symlinks appear, and a fresh `cmemdrv` load with the
+   rule in place produces `/dev/cmem0` at `0666` rather than `0600`. Only
+   `cmem0` appears and no `npuc*` does, which is the expected shape while
+   `/cmem` and the NPU nodes are absent — so what remains untested here is the
+   device tree, not the plumbing around it. [uio.md](uio.md) records how the
+   `npuc*` mode branch was exercised without an `npuc*` device.
+4. **Run the critical experiment.** The ONNX Runtime release ships
+   precompiled artifacts for two sample models, so this needs no compiler
+   licence: deploy the runtime container, run the latency evaluation, and
+   assert positively that the Renesas EP executed subgraphs rather than
+   inferring it from a run that merely completed. The runtime is distributed
+   as a wheel built for one specific Python minor version, which this root
+   filesystem does not carry — hence a container rather than a `pip install`.
+
+   **Run 2026-08-11: everything above the device node worked, and the run
+   stopped at the device node** — `RenesasBackendLoad` reported
+   `Failed to open device /dev/npuc1`, `driver_open failed: -1`, and ORT raised
+   `Create state function failed`. That was the state until the device tree was
+   actually tried.
+
+   **Run 2026-08-21: the NPU executes.** Booting the vendor's own NPU device tree
+   one-shot from U-Boot — no flash writes, no `saveenv`, so a power cycle
+   restores the normal self-boot — brings up `/dev/npuc0`, `/dev/npuc1` and the
+   contiguous-memory devices, the backend reports
+   `NPUDriverRuntime initialized successfully`, and the shipped ResNet18 sample
+   runs **on the NPU**. Three consequences:
+
+   - **The stock bootloader reaches NPU execution, but it is not the configuration
+     the vendor documents.** A model runs, which answers the narrow question this
+     step was written around. It does not license the broader claim: the AI
+     package ships its **own** bootloader, and the manual's appendix describes
+     the change as turning DRAM ECC *off*. So Stage 2 is not the performance
+     afterthought this document previously called it — it is the documented
+     prerequisite, and everything below about model load failing was measured
+     without it.
+   - **The vendor's NPU device tree omits the realtime core's reserved-memory
+     nodes, and the BSP remoteproc driver does not tolerate that.** The service
+     that boots the realtime core calls into a prepare hook that uses
+     `of_reserved_mem_lookup()` without checking for NULL, so the kernel oopses
+     roughly nine seconds into *every* boot of that device tree, before any NPU
+     work. Disable that service (and the RPMsg bridge above it) before the
+     experiment — losing the realtime core for that boot is already implied by
+     the device tree you are booting. `systemd.mask=` on the kernel command
+     line did **not** take effect here; `systemctl disable` did.
+   - **Loading a model can oops the kernel, on the vendor's own artifacts, with
+     the documented prerequisite absent.** On a boot with no prior oops, the
+     precompiled yolov5s sample — Renesas-built, single fused subgraph, no
+     compiler licence involved — faults with
+     `Internal error: Oops - Undefined instruction` during model load; printk
+     dies immediately after `Modules linked in:`, RCU stalls follow, and the
+     board is unrecoverable without a power cycle. A locally compiled
+     7-subgraph model at a larger input size fails the same way. ResNet18, the
+     smallest, is the one that works.
+
+     **Do not report this as a vendor defect yet.** Every one of those runs used
+     the stock bootloader, i.e. with DRAM ECC on, and the vendor's own appendix
+     says the AI package's bootloader turns it off. The vendor's release notes
+     also already record timeout-class failures on particular models
+     (`OTLINT-22806`, naming HRNet, PointPillars and a YOLOv5 variant), which is
+     the same family as the `timeout:reg` lines these runs print. The honest
+     order of work is Stage 2 first, then re-measure, then report what survives.
+
+     What can be ruled out cheaply, and was: the runtime's ARC control-core
+     firmware is **present** in the board container — the wheel ships its own
+     `arc_prog_npu{s,n}` sets, `vpx0.bin` included — so "the control cores were
+     never programmed" is not the explanation. Check that before theorising, by
+     listing the runtime package inside the container; it needs no board reboot.
+
+   **Where the kernel is loaded matters, and U-Boot's default is wrong for
+   this.** The stock load address falls inside one of the NPU's own reserved
+   regions, so that region's whole-area contiguous allocation fails with
+   `-EBUSY` — visible as one contiguous-memory device missing while the others
+   appear, and confirmable in `/proc/iomem`, which shows `Kernel code` inside
+   the region. Load the kernel outside every NPU region; read the addresses
+   from the SDK's own device tree at the time you do it, and note that U-Boot
+   marks every bank above the first as `no-map`, so `ext4load` there fails
+   outright with `** Reading file would overwrite reserved memory **`.
+
+   `scripts/npu-probe.sh` is the check to run instead of reading output by eye.
+   Without the NPU device tree it stops at layer 2 with
+   `NPU_PROBE_FAIL reason=npuc_not_in_dtb sysfs_matches=0 uio_devices=177`,
+   which is the correct answer for that configuration.
+
+### Three traps in step 4, all measured
+
+- **The sample script exits 0 when it fails.** `run_inference()` catches every
+  exception, prints `Error occurred: ...`, and returns normally. A caller that
+  tests `$?` sees success on a board with no NPU at all. Assert on the output
+  text.
+- **A completed run is not an offloaded run.** The script lists
+  `CPUExecutionProvider` after the Renesas EP, so a working-looking latency
+  figure is exactly what a board without the NPU would produce if the EP
+  declined instead of failing. The provider list from `get_providers()` is the
+  minimum assertion; the ORT profiler's per-node assignment
+  (`--enable-rtt`) is the real one, and its schema should be read once on
+  working hardware before anything asserts against it.
+- **The artifacts have to be mounted under their own directory name.** The
+  manifest's `artifact_path` is `resnet18_artifacts/nnx/...`, resolved against
+  the artifacts directory's *parent*. Mount the directory as
+  `/work/artifacts` and the backend looks for `/work/resnet18_artifacts` and
+  misses — after printing a path that looks plausible.
+
+### Getting the runtime onto the board
+
+The board has no internet route, no `python3`, and no `tar`; it does have
+`podman`, `cpio` and `gzip`. So the image is built elsewhere and moved as a
+file, not pulled:
+
+```sh
+# on any x86_64 host with qemu binfmt registered
+podman build --platform linux/arm64 -t localhost/x5h-ort:1.1.0 .   # python:3.11-slim + the aarch64 wheel
+podman save localhost/x5h-ort:1.1.0 | gzip -1 > x5h-ort.tar.gz
+ssh root@192.168.0.20 'cat > /root/npu/x5h-ort.tar.gz' < x5h-ort.tar.gz
+ssh root@192.168.0.20 'gzip -dc /root/npu/x5h-ort.tar.gz | podman load'
+```
+
+Artifacts travel the same way through `cpio -o -H newc | gzip`, unpacked with
+`cpio -idm`. Verify both by `sha256sum` on each end rather than by size: a
+binary piped through `cat` on the sending side can be silently truncated
+(see the transfer note in [selfboot.md](selfboot.md)); stdin redirection as
+above is what avoids it. Measured throughput to the bench over the tailnet is
+about 1.5 MB/s, so the 164 MB image takes a little under two minutes and the
+228 MB artifact archive about two and a half.
+
+Verified on the board: `aarch64`, Python `3.11.15`, `onnxruntime 1.24.0`, and
+`get_available_providers()` returning `['RenesasExecutionProvider',
+'CPUExecutionProvider']`.
+
+If step 4 passes, the stock IPL is sufficient and Stage 2 is a performance
+question to schedule whenever someone is next at the bench. If it fails in a
+way that points at the IPL, Stage 2 becomes necessary and its cost is now
+known rather than assumed.
+
+## Where this stops
+
+**The appendix that would settle which regions may move is not in this SDK.** It belongs to the separate hardware user's manual. Every document that ships
+with the SDK was searched; none marks addresses as redefinable or fixed. Do
+not spend an afternoon looking for it here.
+
+**The overlap is not a placement problem.** Compared
+against the board's live reserved-memory, the NPU's own allocation map — which
+the AI tools carry in their host-application sources, so it can be read
+directly rather than inferred — overlaps the bootloader area, the FreeRTOS
+application area, the default CMA, and the realtime core's shared window with
+the application cores. The last of those is the one that matters: the NPU's
+model-binary area does not merely touch that window, it contains it outright,
+along with all three of the realtime core's small RAM regions. Carving the
+realtime regions back out is therefore not a fix. It would hand the NPU less
+memory than it was compiled to address, in the middle of the range it uses.
+
+**There is nowhere below 4 GiB to move to.** That bank is fully spoken for on
+this board — bootloader, FreeRTOS application, realtime regions, both CMA
+areas — with no gap of any size left over.
+
+**Moving the NPU's regions up is the obvious escape.** The board has ample
+free memory above 4 GiB, and the vendor already places half of the NPU's
+regions up there, so the hardware plainly reaches it. The compiled model
+artifacts do **not** pin the map: they carry no absolute physical addresses in
+the affected ranges. Counted against a uniform-noise expectation the NPU
+ranges score *below* noise, while a deliberately meaningless control range
+scores above it — the apparent matches are quantized weight bytes. A
+multi-megabyte weight file "contains" every 32-bit value, so test any pointer
+claim against noise before building on it.
+
+What verifiably carries absolute addresses, from reading the tools rather
+than pattern-matching binaries: a 44-byte load-map file the compiler frontend
+writes next to each compiled model — and the frontend is plain Python with
+those constants written into one function, so that file is trivially
+regenerable for a different map; the runtime's own region table; and the
+device tree. The model binaries show no evidence of baked-in placement. So
+relocation looks like a runtime-and-device-tree question, not a
+recompile-everything question — but whether the runtime takes its region
+table from itself or from the driver is exactly the open vendor question, so
+this stays a question rather than a plan.
+
+So the honest summary is that the vendor's NPU configuration and this branch's
+realtime work are not, as shipped, configured to coexist — and whether that is
+a fixed property of the platform or of this release is not answerable from the
+material on hand. That question, and the ones about relocatability and the IPL,
+have gone to the vendor. What would unblock the work: confirmation that the NPU
+regions may be relocated, and where the runtime takes its region table from.
+What would end it differently: confirmation that they may not, in which case
+NPU bring-up and the realtime responder become alternative configurations of
+this board rather than a single one, and this document needs a different shape.
+
+Separately, the model-compile pipeline itself is no longer a gap: with the
+compiler licence in hand, the runtime release's own generation script
+reproduces the shipped sample artifacts on the development host — the 44-byte
+load map comes out byte-identical — so if relocation does turn out to need
+recompilation, the machinery for it is already proven. Two environment potholes
+on a current distribution, recorded because both fail after the *frontend*
+succeeds: the compiler backend needs two superseded shared libraries the OS no
+longer ships, and the frontend *replaces* the library path environment for the
+backend subprocess rather than appending to it — so stage those libraries in
+the backend's own directory, where its launcher actually looks.
+
+None of this touches Stage 0, the driver build, the udev rules or the runtime
+container. All four are done and verified on hardware, and none of them left
+the board in a state it was not found in. That is worth stating precisely,
+because it narrows the open question to one thing: every layer between the
+ONNX model and the device node is now known to work on this board, and what
+remains is the device tree — which is exactly what the vendor question is
+about.
+
+## Stage 2: the IPL, only if Stage 1 shows it is needed
+
+Two traps, both of which cost real work if hit.
+
+**The vendor's flash procedure overwrites both realtime firmware slots.** Its
+write list includes the stock payloads for them, and one of those slots
+currently holds this branch's RPMsg responder — measured, not assumed: its
+contents differ from the vendor payload in every chunk compared. Running the
+procedure unedited breaks the CR52 round trip and therefore
+`selfboot-smoke.sh`. Edit the flash-target definition to disable every entry
+except the single component being changed.
+
+**Never enable the tool's Linux-files stage.** Alongside the bootloader
+entries, the same definition can repartition the storage and write a kernel,
+device tree and root filesystem. That is what would destroy the self-boot
+partitions. The vendor's own transcript skips it; keep it skipped.
+
+Beyond that, the write itself needs the serial flash writer, two USB-serial
+connections, and DIP switch changes, followed by a boot-mode command and a
+power cycle.
+
+**It is technically possible to do this from Linux instead.** The flash the
+component lives in is exposed as an MTD device, the target offset is
+erase-block aligned, and the writable node exists. Do not take that option
+for the first attempt: a failed IPL write is recoverable only through the
+serial flash writer with physical switch changes, so the one operation whose
+failure mode requires someone in the room is the wrong one to do while nobody
+is.
+
+## Recovery
+
+- **IPL** — the package ships the stock binary it replaces; write it back the
+  same way it was replaced.
+- **Realtime firmware slots** — restore from the Stage 0 copies.
+- **U-Boot environment** — re-import `selfboot-env.txt` from the boot
+  partition ([selfboot.md](selfboot.md)). This needs no host, which is the
+  point of it living on the board.
+- **A board that will not boot at all** — the serial flash writer, DIP
+  switches and a power cycle. This is the floor, and it is why Stage 2 is a
+  bench operation.
+
+## What the address space looks like
+
+Worth knowing before touching anything, because it is the reason Stage 1 and
+Stage 2 are separable at all:
+
+- The flash tool's storage address space is a small unpartitioned logical
+  unit — realtime firmware slots, the secure payloads, U-Boot and the NPU
+  firmwares all live there. **It is a different logical unit from the one
+  carrying the self-boot partitions**, so writes there cannot reach
+  `x5h-boot`, `x5h-root` or `autosd-store`. Address logical units by path and
+  by property, never by device letter: the letters move between boots
+  ([selfboot.md](selfboot.md)).
+- The bootloader components proper live in a separate flash, reachable from
+  Linux as an MTD device.
+
+## Related
+
+- [UIO](uio.md) — the mechanism `/dev/npuc*` arrives through, and the drop-in
+  that enables it.
+- [CR52 slot update](cr52-slot-update.md) — the established procedure for
+  writing that logical unit from Linux, and the slots Stage 2 must not touch.
+- [UFS self-boot](selfboot.md) — the partition layout Stage 2 must not
+  disturb, and the environment-restore path.

--- a/platforms/autosd/x5h/scripts/npu-probe.sh
+++ b/platforms/autosd/x5h/scripts/npu-probe.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+# npu-probe.sh — board-side proof that the NPU is actually reachable.
+#
+# Every layer between the device tree and the execution provider fails in a
+# way that looks like the layer below it, so this checks them in order and
+# names the one that broke rather than reporting "it did not work". Run it
+# before spending time in the runtime.
+#
+# Markers: NPU_PROBE_PASS / NPU_PROBE_FAIL reason=<...>
+#
+# Usage: npu-probe.sh [artifacts-dir] [image]
+set -u
+
+ARTIFACTS=${1:-/root/npu/ort/sample/resnet18/resnet18_artifacts}
+IMAGE=${2:-localhost/x5h-ort:1.1.0}
+SCRIPT=${NPU_EVAL_SCRIPT:-/root/npu/ort/renesas_ep_eval_latency.py}
+
+fail() { echo "NPU_PROBE_FAIL reason=$1"; exit 1; }
+
+# --- layer 1: UIO devices bound at all ---------------------------------
+# uio_pdrv_genirq binds nothing without of_id=generic-uio, and says nothing
+# when it does not; an empty class directory here means x5h-uio.conf did not
+# reach the image (see uio.md), not a device-tree fault.
+uio_count=$(ls -d /sys/class/uio/uio* 2>/dev/null | wc -l)
+[ "$uio_count" -gt 0 ] || fail uio_unbound
+
+# --- layer 2: the NPU nodes exist in the device tree --------------------
+# The names come from each node's linux,uio-name. No npuc* in sysfs means the
+# NPU is not described in the booted dtb -- the udev rule cannot invent it.
+npuc_sysfs=$(grep -l '^npuc' /sys/class/uio/uio*/name 2>/dev/null | wc -l)
+[ "$npuc_sysfs" -ge 2 ] || fail "npuc_not_in_dtb sysfs_matches=$npuc_sysfs uio_devices=$uio_count"
+
+# --- layer 3: udev turned those names into paths ------------------------
+for d in /dev/npuc0 /dev/npuc1; do
+  [ -e "$d" ] || fail "udev_symlink_missing dev=$d"
+  [ -r "$d" ] && [ -w "$d" ] || fail "npuc_mode dev=$d ($(ls -l "$d"))"
+done
+
+# --- layer 3.5: the kernel is still intact ------------------------------
+# Measured 2026-08-21: a run can print correct latencies on a kernel that has
+# already oopsed, so a plausible number is not evidence of a healthy board.
+# Two oops sources are known here, and both are worth naming rather than
+# reporting as "it crashed":
+#   * rcar_gen5_rproc_prepare -> of_reserved_mem_lookup, when the booted dtb
+#     describes the realtime cores but not their reserved memory (the vendor
+#     NPU dtb does exactly that). Stop whatever starts the realtime core.
+#   * an undefined-instruction fault during model load, which takes printk
+#     with it and leaves the board needing a power cycle.
+# Refuse to measure on a damaged kernel; the numbers would not mean anything.
+if dmesg 2>/dev/null | grep -q 'Internal error'; then
+  if dmesg | grep -q 'rcar_gen5_rproc_prepare'; then
+    fail "kernel_oopsed_remoteproc (dtb lacks the realtime reserved-memory nodes; disable the service that boots it)"
+  fi
+  fail "kernel_oopsed ($(dmesg | grep -m1 'Internal error'))"
+fi
+
+# --- layer 4: contiguous memory ----------------------------------------
+# cmem0 comes from the default CMA and proves only that the module loaded.
+# The runtime wants cmem_other*, which exist one per phandle in /cmem's
+# memory-region list -- so their absence is a device-tree gap, not a module
+# argument to tune (npu-bringup.md).
+lsmod | grep -q '^cmemdrv' || fail cmem_not_loaded
+ls /dev/cmem_other* >/dev/null 2>&1 || fail cmem_other_missing
+
+# A *short count* is the trap, not a zero count. /cmem's memory-region list is
+# one 4-byte phandle per region, so the expected number is knowable; and when
+# one region short-changes you, the runtime fails at "Failed to open device
+# /dev/cmem_otherN" -- which points at the driver, not at the real cause.
+#
+# The real cause, measured 2026-08-21: U-Boot's default kernel_addr_r places
+# the kernel INSIDE one of the npu_region ranges. Those regions are declared
+# reusable, so Linux boots and looks healthy, but cmem's whole-region
+# allocation then returns -EBUSY for that one region. Load the kernel outside
+# every npu_region and all of them allocate.
+phandles=/proc/device-tree/cmem/memory-region
+if [ -r "$phandles" ]; then
+  want=$(( $(wc -c < "$phandles") / 4 ))
+  have=$(ls -d /dev/cmem_other* 2>/dev/null | wc -l)
+  if [ "$have" -lt "$want" ]; then
+    node=$(dmesg | sed -n 's/.*assigned reserved memory node \(linux,npu_region[^ ]*\).*/\1/p' | tail -1)
+    kline=$(grep -i 'kernel code' /proc/iomem 2>/dev/null | head -1)
+    fail "cmem_other_short have=$have want=$want failed_node=${node:-unknown} kernel=${kline:-unknown} (is the kernel loaded inside an npu_region?)"
+  fi
+fi
+
+# --- layer 5: the runtime container -------------------------------------
+podman image exists "$IMAGE" || fail "image_missing image=$IMAGE"
+[ -f "$SCRIPT" ] || fail "eval_script_missing path=$SCRIPT"
+[ -d "$ARTIFACTS" ] || fail "artifacts_missing path=$ARTIFACTS"
+
+# --- layer 5.5: were these artifacts actually calibrated? ----------------
+# The compiling pass re-derives every internal tensor's quantization from the
+# calibration dump each time it runs. Given no dump it does not refuse: it
+# fabricates a histogram, quantizes everything at 1/255, and produces
+# artifacts that load, run, and report entirely normal latencies. Only the
+# numbers are wrong, and the sole trace is a dummy_histogram.pb left in the
+# subgraph directory.
+#
+# That is not hypothetical -- it cost this project two days in 2026-08, and
+# the wrong outputs were nearly reported to the vendor as a hardware defect.
+# So name the condition here rather than letting a latency number imply the
+# accuracy is meaningful.
+#
+# This warns and continues instead of failing: measuring latency on
+# deliberately uncalibrated artifacts is legitimate (latency is independent of
+# the scales, measured), and this probe's job is reachability. It is the
+# accuracy claim that the marker below must not be allowed to support.
+quant=real
+if ls "$ARTIFACTS"/nnx/*/dummy_histogram.pb >/dev/null 2>&1; then
+  quant=dummy
+  echo "NPU_PROBE_WARN dummy_calibration path=$ARTIFACTS" \
+       "(compiled without a calibration dump: internal scales are all 1/255," \
+       "so latency is valid and every accuracy figure from these is not)"
+fi
+
+# --- layer 6: the execution provider actually ran ------------------------
+# A run that merely completes proves nothing, in two separate ways. The sample
+# script lists CPUExecutionProvider as a fallback, so a board with no NPU still
+# produces correct results and a latency figure; and its run_inference()
+# swallows every exception into a printed "Error occurred:" line and returns
+# normally, so the exit status is 0 even when nothing ran. Hence three
+# assertions on the output text rather than one on $?.
+#
+# What this does not prove is which subgraphs the NPU executed -- the provider
+# list only says the EP registered. The ORT profiler (--enable-rtt) carries the
+# per-node assignment; check it by hand the first time the NPU comes up, and
+# turn it into an assertion here once its schema is known rather than guessed.
+devs=""
+for d in /dev/npuc0 /dev/npuc1 /dev/cmem_other*; do
+  devs="$devs --device $d"
+done
+# The manifest's artifact_path is relative to the artifacts directory's PARENT
+# and starts with that directory's own name ("resnet18_artifacts/nnx/..."), so
+# the mount point has to keep the directory name. Mounting it as /work/artifacts
+# makes the backend look for /work/resnet18_artifacts and miss.
+# The manifest records where the artifacts were compiled, and it is not always
+# relative. The shipped samples record a relative "resnet18_artifacts/nnx/..."
+# resolved against the artifacts directory's PARENT, so the mount point must
+# keep the directory name -- mounting it as /work/artifacts makes the backend
+# look for /work/resnet18_artifacts and miss. Locally compiled artifacts record
+# the ABSOLUTE compile-host path instead, and the backend fopen()s it verbatim,
+# so there the mount point must BE that path. Read it rather than assuming.
+art_name=$(basename "$ARTIFACTS")
+recorded=$(sed -n 's/.*"artifact_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+             "$ARTIFACTS/nnx/manifest.json" 2>/dev/null | head -1)
+case "$recorded" in
+  /*) # absolute: strip the trailing /nnx/<subgraph> to get the recorded dir
+      art_target=$(dirname "$(dirname "$recorded")") ;;
+  "") fail "manifest_unreadable path=$ARTIFACTS/nnx/manifest.json" ;;
+  *)  art_target="/work/$art_name" ;;
+esac
+
+# Device passthrough is the least-privilege form and is what this asserts. If
+# the backend fails to mmap despite the nodes being present, retry by hand with
+# "--privileged -v /dev:/dev", which is what the 2026-08-21 board session used;
+# treat needing it as a finding worth writing down rather than a fix.
+out=$(podman run --rm $devs \
+        -v "$ARTIFACTS":"$art_target":ro \
+        -v "$SCRIPT":/work/eval.py:ro \
+        "$IMAGE" python /work/eval.py --artifacts "$art_target" 2>&1)
+echo "$out"
+echo "$out" | grep -q 'Error occurred:' && fail "runtime_error ($(echo "$out" | grep -m1 'Error occurred:'))"
+echo "$out" | grep -q 'providers:.*RenesasExecutionProvider' || fail ep_not_selected
+echo "$out" | grep -q 'avg Latency' || fail no_latency_result
+
+# The run can complete and still have killed the kernel, so check again after.
+dmesg 2>/dev/null | grep -q 'Internal error' \
+  && fail "kernel_oopsed_during_run ($(dmesg | grep -m1 'Internal error'))"
+
+echo "NPU_PROBE_PASS uio=$uio_count npuc=$npuc_sysfs cmem_other=$(ls -d /dev/cmem_other* | wc -l) quant=$quant artifacts=$art_target"

--- a/platforms/autosd/x5h/uio.md
+++ b/platforms/autosd/x5h/uio.md
@@ -1,0 +1,168 @@
+# X5H UIO: reaching the SoC's accelerator blocks from userspace
+
+The X5H describes a large set of accelerator and capture blocks — image
+processing, ISP, video capture, CSI receivers, the DSP subsystem, the RPMsg
+shared-memory and IPI windows — as `generic-uio` device-tree nodes. Nothing
+in the kernel drives them; they are handed to userspace through
+`uio_pdrv_genirq`, which maps each node's register window and delivers its
+interrupt to whatever opens `/dev/uioN`.
+
+This is how the Renesas ONNX Runtime execution provider is expected to reach
+the NPU, so it is a prerequisite for that work rather than an unrelated
+platform detail. It is not sufficient on its own — see
+[What this does not cover](#what-this-does-not-cover).
+
+## The trap: loaded, but bound to nothing
+
+`uio_pdrv_genirq` ships wildcard OF aliases (`of:N*T*C*`), so udev autoloads
+it during boot on the first unmatched device-tree node. But the module's
+`of_match_table` starts empty and is filled from the `of_id` module
+parameter, so a load with no parameter binds nothing at all.
+
+The failure is silent and reads as a device-tree problem. `lsmod` shows the
+module present, the device-tree nodes are there and carry no `status`
+property (so they are enabled), and yet `/dev/uio*` does not exist,
+`/sys/class/uio` is empty, and `dmesg` prints nothing — there is no probe to
+fail. Every symptom points at the dtb, and the dtb is fine.
+
+`config/x5h-uio.conf` supplies the parameter:
+
+```
+options uio_pdrv_genirq of_id=generic-uio
+```
+
+A `modprobe.d` drop-in is the right place for it precisely because the
+module is modprobe-loaded. The alternative — `uio_pdrv_genirq.of_id=` on the
+kernel command line — would mean editing `bootargs_autosd_ufs`, which is
+coupled to the self-boot PARTUUIDs in three places that must agree (see
+[selfboot.md](selfboot.md)); this needs none of that.
+
+## Verified on hardware, 2026-08-10
+
+On the self-booted `6.1.102-autosd` board:
+
+| measure | value |
+|---|---|
+| `generic-uio` nodes in the live device tree | 201 |
+| UIO devices bound | 177 (`/dev/uio0` … `/dev/uio176`) |
+| probe errors in `dmesg` | none |
+
+The devices come up named from each node's `linux,uio-name`, which is what
+makes them addressable by something other than a probe-order index. The name
+lands in `/sys/class/uio/uioN/name`; the device node itself is still
+`/dev/uioN`, and still `0600 root:root`. Turning the name into a path takes a
+udev rule — see [From a sysfs name to a `/dev`
+path](#from-a-sysfs-name-to-a-dev-path).
+
+| name prefix | count | block |
+|---|---|---|
+| `vin_*` | 80 | video capture |
+| `rsip_e_*` | 20 | RSIP engine |
+| `rfso_*` | 20 | RFSO |
+| `ims_*` | 8 | IMR-LX7 scaler |
+| `ostm_*` | 6 | OS timer |
+| `vspx_*`, `vcp5_*`, `tisp_*`, `imr_*`, `fcpvx_*`, `fcpc_*`, `csi_*`, `cisp_*` | 4 each | VSPX / DSP subsystem / ISP / CSI |
+| `rpmsg_shm0`, `rpmsg_ipi0` | 1 each | CR52 shared memory and IPI |
+
+Mappings resolve to the addresses the device tree declares — `rpmsg_shm0`
+becomes `uio0`, and its `map0` base and size match the `cr52_ram0`
+reserved-memory region exactly. Read the values from the booted device tree
+rather than from here; see the note on where numbers live in
+[npu-bringup.md](npu-bringup.md).
+
+**Sibling nodes that share a register window do bind.** Several blocks are
+described as one node for the window plus additional nodes carrying the same
+`reg` and a different interrupt each; the `irq_vcp5_*` nodes come up at the
+same base as `vcp5_0`. This pattern was in doubt and is now settled, which
+matters because the NPU is described the same way.
+
+24 of the 201 nodes did not bind, with nothing logged. Not investigated —
+none of them are in a subsystem this branch depends on.
+
+### Checking it
+
+```sh
+ls -d /sys/class/uio/uio* | wc -l
+for d in /sys/class/uio/uio*; do echo "$(basename "$d") $(cat "$d/name")"; done
+```
+
+An empty result on a board whose device tree has `generic-uio` nodes means
+the drop-in did not reach the image, or the module was loaded before it was
+read. `modprobe -r uio_pdrv_genirq && modprobe uio_pdrv_genirq` re-reads it
+without a reboot; the module binds nothing beforehand, so unloading it is a
+no-op.
+
+## From a sysfs name to a `/dev` path
+
+Binding the devices and naming them is not the same as making them openable.
+UIO creates `/dev/uioN` numbered by probe order and `0600 root:root`; the
+`linux,uio-name` reaches `/sys/class/uio/uioN/name` and stops there. A runtime
+that opens `/dev/npuc0` therefore gets `ENOENT` on a board where the device
+tree, the module binding and the sysfs name are all correct — the same shape of
+failure as the `of_id` trap above, and misleading in the same direction.
+
+`config/51-x5h-uio.rules` closes it, and `config/52-x5h-cmem.rules` does the
+same for the contiguous-memory devices:
+
+```
+SUBSYSTEM=="uio", SYMLINK+="$attr{name}"
+SUBSYSTEM=="uio", ATTR{name}=="npuc*", MODE="0666"
+```
+
+One symlink rule covers all 177 devices at once. The mode line is deliberately
+narrower than the vendor's reference rootfs, which relaxes every UIO device on
+the board: only the NPU cluster is opened to a non-root process. Widen that
+match if the runtime turns out to need another block — a blanket `0666` here
+would hand every capture, ISP and RSIP block on the SoC to any local process.
+
+**Verified on hardware, 2026-08-11.** All 177 devices gained a name symlink
+(`/dev/rpmsg_shm0` → `uio0`, `/dev/rpmsg_ipi0` → `uio1`); nodes outside the
+`npuc*` match stayed `0600`. The `ATTR{name}` branch was exercised separately
+against `rpmsg_shm*` — `/dev/uio0` became `0666` and `/dev/uio1` did not — since
+no `npuc*` device exists until the NPU nodes are in the device tree. With the
+cmem rule in place, a fresh `cmemdrv` load produced `/dev/cmem0` at `0666`
+directly.
+
+**Removing a rule does not undo it.** udev applies modes when it processes a
+device; a `udevadm trigger` after deleting the rule leaves the node at whatever
+it was last set to. The mode returns only when the node is re-created — a
+reboot, or unbinding and rebinding the driver. Testing from
+`/run/udev/rules.d` keeps the *rule* out of the image, but the permission
+change it made outlives it, so put the node back by hand.
+
+## What this does not cover
+
+Enabling UIO does not by itself make the NPU reachable. Three things are still
+missing, and none of them is fixed by this drop-in:
+
+- **The NPU's device-tree nodes are absent from the board's dtb.** The board
+  boots `r8a78000-ironhide-uio-autosd.dtb`, built from the public
+  `renesas-rcar/linux-bsp` tree pinned by `kernel/build-bsp-kernel.sh`. That
+  tree's UIO dtsi describes the ISP, IMR, VSPX, DSP, capture and RSIP blocks
+  but has no NPU node — only the NPU's SMMUs, disabled. The vendor SDK's own
+  UIO device-tree source does describe the NPU blocks as `generic-uio`; those
+  values are SDK material and stay out of this repository.
+- **`/dev/cmem_other*`** — the contiguous-memory devices the runtime opens
+  are served by an out-of-tree Renesas module, loaded once per boot. It is
+  absent from the pinned kernel source and from this image's module tree, and
+  the vendor's build is against their own kernel release, so it cannot simply
+  be copied across; it is built from public source against this board's kernel
+  tree instead ([npu-bringup.md](npu-bringup.md) pins the commit and explains
+  why not HEAD). The module itself is no longer the gap — the `cmem_other`
+  devices are, because their count and size come from a `/cmem` device-tree
+  node this board does not have.
+- **`/dev/npuc*`** — these are UIO devices, named the same way as every
+  device in the table above: the vendor's NPU device tree declares them
+  `generic-uio` with a `linux,uio-name`, and the userspace side selects their
+  register windows by `mmap` offsets that are multiples of the page size,
+  which is the UIO map-selection convention. So the drop-in here, and the udev
+  rule above, are the mechanism the NPU will use; what is missing is only the
+  nodes.
+
+## Related
+
+- [UFS self-boot](selfboot.md) — the boot path and why `bootargs` is
+  expensive to change.
+- [CR52 dual boot + RPMsg](rpmsg-dualboot.md) — the kernel-space RPMsg path,
+  which is what the board uses today; `rpmsg_shm0`/`rpmsg_ipi0` are the
+  userspace alternative the same hardware also exposes.


### PR DESCRIPTION
Brings the R-Car X5H NPU within reach of the ONNX Runtime Renesas execution provider from AutoSD: the UIO/cmem device enablement the runtime needs, a layered board-side probe, the host-side inputs for the model compiler, and the bring-up runbook. Assembled fresh off `main` and ported file by file, so it carries no fork-only commits and none of the branch's intermediate revisions.

### What is here

- **UIO enablement.** `uio_pdrv_genirq` comes up loaded and bound to nothing without an `of_id`, and logs nothing about it. Binding it names the blocks in sysfs only, so two udev rules turn those names into the `/dev` paths a runtime actually opens — the kernel names them `uioN`, and only each node's own `linux,uio-name` says which block a given `uioN` is. The UIO rule narrows its mode change to the NPU nodes rather than widening it across all 201 bound devices. Wired into the image manifest and documented in `uio.md`.
- **`scripts/npu-probe.sh`.** Every layer between the device tree and the execution provider fails in a way that looks like the layer below it, so this checks them in order and names the one that broke rather than reporting "it did not work". It grades by markers rather than by exit status, for three measured reasons: the vendor evaluation script swallows exceptions and returns 0, a completed run may have silently used the CPU fallback, and a run can print correct numbers on a kernel that has already oopsed. It also reports whether the artifacts were calibrated at all, because artifacts compiled without a calibration dump load, run and report entirely normal latencies with only the numbers wrong.
- **`ai/`.** Host side: export the pinned VisionPilot models, pin their batch dimension, and dump calibration that mirrors the VisionPilot C++ preprocessing rather than a reasonable-looking reconstruction of it — the three models are not preprocessed alike, and feeding one the other's tensors sets every quantization range wrong at once. Plus a consistency check that compares NPU against CPU over replay feeds.
- **`npu-bringup.md`.** Staged so that everything reachable without a flash write happens first, with the two writes that would break the CR52 round trip or the self-boot partitions called out rather than buried.

### Two constraints worth reading before board time

The kernel load address is not free: at the wrong one the NPU runtime writes over the kernel, and it takes an undefined-instruction oops during model load with no diagnostic anywhere near the cause. And the vendor NPU device tree omits the realtime core's reserved memory, so the NPU and the realtime cores cannot run in one configuration; the NULL dereference that omission triggers in the BSP remoteproc driver is a vendor defect in its own right.

### Boundary

Device-tree addresses, flash offsets and interrupt numbers stay out of this repository — the same boundary `cr52-slot-update.md` draws — and the scripts read them from the SDK at the time you run them. `tolerance.json` is deliberately not committed: an accuracy envelope is only meaningful frozen against the model and board configuration it will be asserted on, so generate it for the model you are shipping rather than inheriting one.

Verified locally: `shellcheck -S error` clean on both shell scripts, all three Python files parse, and the image manifest still loads as YAML.
